### PR TITLE
Implement zones

### DIFF
--- a/do/cloud.go
+++ b/do/cloud.go
@@ -48,7 +48,7 @@ func newCloud(config io.Reader) (cloudprovider.Interface, error) {
 	doClient := godo.NewClient(oauthClient)
 
 	instances := newInstances(doClient)
-	zones := newZones(client)
+	zones := newZones()
 
 	return &cloud{
 		client:    doClient,

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -3,7 +3,6 @@ package do
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -26,14 +25,13 @@ func newInstances(client *godo.Client) cloudprovider.Instances {
 
 // NodeAddresses returns all the valid addresses of the specified node
 // For DO, this is the public/private ipv4 addresses only for now
-// This method only fetches the addresses of the calling instances,
-func (i *instances) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
-	selfDropletID, err := dropletID()
+func (i *instances) NodeAddresses(nodeName types.NodeName) ([]v1.NodeAddress, error) {
+	droplet, err := i.dropletByName(context.TODO(), nodeName)
 	if err != nil {
 		return nil, err
 	}
 
-	return i.NodeAddressesByProviderID(selfDropletID)
+	return nodeAddresses(droplet)
 }
 
 // NodeAddressesByProviderID returns all the valid addresses of the specified
@@ -45,6 +43,11 @@ func (i *instances) NodeAddressesByProviderID(providerId string) ([]v1.NodeAddre
 		return nil, err
 	}
 
+	return nodeAddresses(droplet)
+}
+
+// nodeAddresses extracts droplet data into []v1.NodeAddress
+func nodeAddresses(droplet *godo.Droplet) ([]v1.NodeAddress, error) {
 	var addresses []v1.NodeAddress
 	addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: droplet.Name})
 

--- a/do/droplets_test.go
+++ b/do/droplets_test.go
@@ -121,6 +121,45 @@ func newFakeNotOKResponse() *godo.Response {
 	}
 }
 
+func TestNodeAddreesses(t *testing.T) {
+	fake := &fakeDropletService{}
+	fake.listFunc = func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+		droplet := newFakeDroplet()
+		droplets := []godo.Droplet{*droplet}
+
+		resp := newFakeOKResponse()
+		return droplets, resp, nil
+	}
+
+	client := newFakeClient(fake)
+	instances := newInstances(client)
+
+	expectedAddresses := []v1.NodeAddress{
+		v1.NodeAddress{
+			Type:    v1.NodeHostName,
+			Address: "test-droplet",
+		},
+		v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: "10.0.0.0",
+		},
+		v1.NodeAddress{
+			Type:    v1.NodeExternalIP,
+			Address: "99.99.99.99",
+		},
+	}
+
+	addresses, err := instances.NodeAddresses("test-droplet")
+
+	if !reflect.DeepEqual(addresses, expectedAddresses) {
+		t.Errorf("unexpected node addresses. got: %v want: %v", addresses, expectedAddresses)
+	}
+
+	if err != nil {
+		t.Errorf("unexpected err, expected nil. got: %v", err)
+	}
+}
+
 func TestNodeAddreessesByProviderID(t *testing.T) {
 	fake := &fakeDropletService{}
 	fake.getFunc = func(ctx context.Context, dropletID int) (*godo.Droplet, *godo.Response, error) {

--- a/do/metadata.go
+++ b/do/metadata.go
@@ -1,18 +1,12 @@
 package do
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
 
-const dropletIDMetadataURL = "http://169.254.169.254/metadata/v1/id"
 const dropletRegionMetadataURL = "http://169.254.169.254/metadata/v1/region"
-
-// dropletID returns the currently running droplet id
-// using the metadata service available on all running droplets
-func dropletID() (string, error) {
-	return httpGet(dropletIDMetadataURL)
-}
 
 // dropletRegion returns the currently the region of the currently
 // running program

--- a/do/zones.go
+++ b/do/zones.go
@@ -1,6 +1,8 @@
 package do
 
 import (
+	"fmt"
+
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
@@ -17,7 +19,7 @@ func newZones() cloudprovider.Zones {
 func (r region) GetZone() (cloudprovider.Zone, error) {
 	region, err := dropletRegion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get droplet region: %v", err)
+		return cloudprovider.Zone{}, fmt.Errorf("failed to get droplet region: %v", err)
 	}
 
 	return cloudprovider.Zone{Region: region}, nil


### PR DESCRIPTION
Implements the [Zones](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/cloud.go#L182-L186) interface for cloud controller manager.

Also fixes a bug that was created due to misleading doc strings. The comment [here](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/cloud.go#L115-L118) seems to no longer apply 