### PR TITLE
Fix LoadBlancer And Instances, when do droplet count exceeds one page

### DIFF
--- a/do/common.go
+++ b/do/common.go
@@ -1,6 +1,9 @@
 package do
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/godo/context"
 )
@@ -17,6 +20,14 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 		droplets, resp, err := client.Droplets.List(ctx, opt)
 		if err != nil {
 			return nil, err
+		}
+
+		if resp == nil {
+			return nil, fmt.Errorf("DO API returned no response ")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("DO API returned non-200 status code: %d", resp.StatusCode)
 		}
 
 		// append the current page's droplets to our list

--- a/do/common.go
+++ b/do/common.go
@@ -39,9 +39,7 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 			return nil, fmt.Errorf("droplets list request returned no response ")
 		}
 
-		for _, d := range droplets {
-			list = append(list, d)
-		}
+		list = append(list, droplets...)
 
 		// if we are at the last page, break out the for loop
 		if resp.Links == nil || resp.Links.IsLastPage() {

--- a/do/common.go
+++ b/do/common.go
@@ -1,8 +1,23 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package do
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/godo/context"
@@ -11,10 +26,8 @@ import (
 const apiPerPage = 100
 
 func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
-	// create a list to hold our droplets
 	list := []godo.Droplet{}
 
-	// create options. initially, these will be blank
 	opt := &godo.ListOptions{PerPage: apiPerPage}
 	for {
 		droplets, resp, err := client.Droplets.List(ctx, opt)
@@ -23,14 +36,9 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 		}
 
 		if resp == nil {
-			return nil, fmt.Errorf("DO API returned no response ")
+			return nil, fmt.Errorf("droplets list request returned no response ")
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("DO API returned non-200 status code: %d", resp.StatusCode)
-		}
-
-		// append the current page's droplets to our list
 		for _, d := range droplets {
 			list = append(list, d)
 		}
@@ -45,7 +53,6 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 			return nil, err
 		}
 
-		// set the page we want for the next request
 		opt.Page = page + 1
 	}
 

--- a/do/common.go
+++ b/do/common.go
@@ -1,0 +1,42 @@
+package do
+
+import (
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/godo/context"
+)
+
+const apiPerPage = 100
+
+func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
+	// create a list to hold our droplets
+	list := []godo.Droplet{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{PerPage: apiPerPage}
+	for {
+		droplets, resp, err := client.Droplets.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		// append the current page's droplets to our list
+		for _, d := range droplets {
+			list = append(list, d)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -92,7 +92,6 @@ func (i *instances) ExternalID(nodeName types.NodeName) (string, error) {
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
 func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
 	droplet, err := i.dropletByName(context.TODO(), nodeName)
-
 	if err != nil {
 		return "", err
 	}

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -91,7 +91,6 @@ func (i *instances) ExternalID(nodeName types.NodeName) (string, error) {
 
 // InstanceID returns the cloud provider ID of the node with the specified NodeName.
 func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
-
 	droplet, err := i.dropletByName(context.TODO(), nodeName)
 
 	if err != nil {

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/godo/context"
+
+	"github.com/golang/glog"
 )
 
 // instances Implements cloudprovider.Instances
@@ -93,6 +95,7 @@ func (i *instances) ExternalID(nodeName types.NodeName) (string, error) {
 func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
 	droplet, err := i.dropletByName(context.TODO(), nodeName)
 	if err != nil {
+		glog.Infof("InstanceID %v : %v", nodeName, droplet.ID)
 		return "", err
 	}
 	return strconv.Itoa(droplet.ID), nil
@@ -133,9 +136,12 @@ func (i *instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 
 // dropletById returns the godo Droplet type corresponding to the provided id
 func (i *instances) dropletById(ctx context.Context, id string) (*godo.Droplet, error) {
+
+	glog.Infof("dropletById %v", id)
+
 	intId, err := strconv.Atoi(id)
 	if err != nil {
-		return nil, fmt.Errorf("error converting droplet id to string: %v", err)
+		return nil, fmt.Errorf("error converting droplet id to string: %v %s", err, id)
 	}
 
 	droplet, resp, err := i.client.Droplets.Get(ctx, intId)
@@ -150,25 +156,60 @@ func (i *instances) dropletById(ctx context.Context, id string) (*godo.Droplet, 
 	return droplet, nil
 }
 
+func (i *instances) dropletList(ctx context.Context) ([]godo.Droplet, error) {
+	// create a list to hold our droplets
+	list := []godo.Droplet{}
+
+	// create options. initially, these will be blank
+	opt := &godo.ListOptions{PerPage: 100}
+	for {
+		droplets, resp, err := i.client.Droplets.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		// append the current page's droplets to our list
+		for _, d := range droplets {
+			list = append(list, d)
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		// set the page we want for the next request
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}
+
 // dropletByName returns the godo Droplet type corresponding to the node name
 // since we can only get droplets by id, we do a list of all droplets and return
 // the first one that matches the provided name
 func (i *instances) dropletByName(ctx context.Context, nodeName types.NodeName) (*godo.Droplet, error) {
 	// TODO (andrewsykim): list by tag once a tagging format is determined
-	droplets, resp, err := i.client.Droplets.List(ctx, &godo.ListOptions{})
+	glog.Infof("dropletByName %v for region %v", nodeName, i.region)
+
+	droplets, err := i.dropletList(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("DO API returned non-200 status code: %d", resp.StatusCode)
-	}
-
 	for _, droplet := range droplets {
 		if droplet.Name == string(nodeName) {
+			glog.Infof("dropletByName %v FOUND", nodeName)
 			return &droplet, nil
 		}
 	}
+
+	glog.Infof("dropletByName %v NOT FOUND", nodeName)
 
 	return nil, cloudprovider.InstanceNotFound
 }

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -229,7 +229,6 @@ func (l *loadbalancers) lbByName(ctx context.Context, name string) (*godo.LoadBa
 // nodesToDropletID receives a list of Kubernetes nodes and get's all the corresponding droplet IDs.
 // This function assumes nodes names match that of the droplet name
 func (l *loadbalancers) nodesToDropletIDs(nodes []*v1.Node) ([]int, error) {
-
 	droplets, err := allDropletList(context.TODO(), l.client)
 
 	if err != nil {

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -226,45 +226,11 @@ func (l *loadbalancers) lbByName(ctx context.Context, name string) (*godo.LoadBa
 	return nil, lbNotFound
 }
 
-func (l *loadbalancers) dropletList(ctx context.Context) ([]godo.Droplet, error) {
-	// create a list to hold our droplets
-	list := []godo.Droplet{}
-
-	// create options. initially, these will be blank
-	opt := &godo.ListOptions{PerPage: 100}
-	for {
-		droplets, resp, err := l.client.Droplets.List(ctx, opt)
-		if err != nil {
-			return nil, err
-		}
-
-		// append the current page's droplets to our list
-		for _, d := range droplets {
-			list = append(list, d)
-		}
-
-		// if we are at the last page, break out the for loop
-		if resp.Links == nil || resp.Links.IsLastPage() {
-			break
-		}
-
-		page, err := resp.Links.CurrentPage()
-		if err != nil {
-			return nil, err
-		}
-
-		// set the page we want for the next request
-		opt.Page = page + 1
-	}
-
-	return list, nil
-}
-
 // nodesToDropletID receives a list of Kubernetes nodes and get's all the corresponding droplet IDs.
 // This function assumes nodes names match that of the droplet name
 func (l *loadbalancers) nodesToDropletIDs(nodes []*v1.Node) ([]int, error) {
 
-	droplets, err := l.dropletList(context.TODO())
+	droplets, err := allDropletList(context.TODO(), l.client)
 
 	if err != nil {
 		return nil, err

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -780,7 +780,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						ID:   102,
 						Name: "node-3",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -862,7 +862,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						ID:   102,
 						Name: "node-3",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -998,7 +998,7 @@ func Test_nodeToDropletIDs(t *testing.T) {
 						ID:   102,
 						Name: "node-3",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			[]int{100, 101, 102},
 			nil,
@@ -1069,7 +1069,7 @@ func Test_nodeToDropletIDs(t *testing.T) {
 						ID:   202,
 						Name: "node-11",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			[]int{100, 101, 102},
 			nil,
@@ -1353,7 +1353,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					Name:   "afoobar123",
 					IP:     "10.0.0.1",
 					Status: lbStatusActive,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{
@@ -1369,7 +1369,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 						ID:   102,
 						Name: "node-3",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 				return []godo.LoadBalancer{
@@ -1380,7 +1380,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 						IP:     "10.0.0.1",
 						Status: lbStatusActive,
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 				// shouldn't be run in this test case
@@ -1393,7 +1393,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					Name:   "afoobar123",
 					IP:     "10.0.0.1",
 					Status: lbStatusActive,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1447,7 +1447,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					Name:   "afoobar123",
 					IP:     "10.0.0.1",
 					Status: lbStatusActive,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{
@@ -1463,7 +1463,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 						ID:   102,
 						Name: "node-3",
 					},
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 				return []godo.LoadBalancer{}, nil, nil
@@ -1473,7 +1473,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					Name:   "afoobar123",
 					IP:     "10.0.0.1",
 					Status: lbStatusActive,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 				// should not be run in this test case
@@ -1583,7 +1583,7 @@ func Test_waitActive(t *testing.T) {
 				return &godo.LoadBalancer{
 					ID:     "lb1",
 					Status: lbStatusErrored,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			nil,
 			errors.New("error creating DigitalOcean balancer: \"lb1\""),
@@ -1602,7 +1602,7 @@ func Test_waitActive(t *testing.T) {
 				return &godo.LoadBalancer{
 					ID:     "lb1",
 					Status: lbStatusNew,
-				}, nil, nil
+				}, newFakeOKResponse(), nil
 			},
 			nil,
 			errors.New("load balancer creation for \"lb1\" timed out"),


### PR DESCRIPTION
When the droplet count in the digital ocean account exceeds the size of one api result page, dropletByName, and nodesToDropletIDs were not able to match the droplet to the node.