### PR TITLE
CCM should be critical pod and have resource requests

### DIFF
--- a/releases/v0.1.0.yml
+++ b/releases/v0.1.0.yml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: digitalocean-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
       tolerations:
@@ -19,6 +21,11 @@ spec:
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
           effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        # cloud controller manager should be able to run on masters
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
       containers:
       - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.0
         name: digitalocean-cloud-controller-manager
@@ -26,6 +33,10 @@ spec:
           - "/bin/digitalocean-cloud-controller-manager"
           - "--cloud-provider=digitalocean"
           - "--leader-elect=false"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
         env:
           - name: DO_ACCESS_TOKEN
             valueFrom:

--- a/releases/v0.1.1.yml
+++ b/releases/v0.1.1.yml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: digitalocean-cloud-controller-manager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
       tolerations:
@@ -19,6 +21,11 @@ spec:
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
           effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+        # cloud controller manages should be able to run on masters
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
       containers:
       - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.1
         name: digitalocean-cloud-controller-manager
@@ -26,6 +33,10 @@ spec:
           - "/bin/digitalocean-cloud-controller-manager"
           - "--cloud-provider=digitalocean"
           - "--leader-elect=false"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
         env:
           - name: DO_ACCESS_TOKEN
             valueFrom:


### PR DESCRIPTION
Fixes https://github.com/digitalocean/digitalocean-cloud-controller-manager/issues/32. Also adds toleration for master node taint.

@odacremolbap as you mentioned, 100m CPU and 50Mi memory seems pretty reasonable for now. It's also a resource request and not a limit for now so it can still burst if needed. 

In general, I think we should avoid making changes to the files in releases as they should be locked down once a release goes in. But this change seems pretty harmless since we're not changing any of the CCM flags that might change its behavior.