### PR TITLE
Handle correct providerID format

### DIFF
--- a/do/zones.go
+++ b/do/zones.go
@@ -42,7 +42,12 @@ func (z zones) GetZone() (cloudprovider.Zone, error) {
 // locality region of the node specified by providerId. GetZoneByProviderID
 // will only fill the Region field of cloudprovider.Zone for DO.
 func (z zones) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error) {
-	d, err := dropletByID(context.Background(), z.client, providerID)
+	id, err := dropletIDFromProviderID(providerID)
+	if err != nil {
+		return cloudprovider.Zone{}, err
+	}
+
+	d, err := dropletByID(context.Background(), z.client, id)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}

--- a/do/zones_test.go
+++ b/do/zones_test.go
@@ -50,7 +50,7 @@ func TestZones_GetZoneByProviderID(t *testing.T) {
 
 	expected := cloudprovider.Zone{Region: "test1"}
 
-	actual, err := zones.GetZoneByProviderID("123")
+	actual, err := zones.GetZoneByProviderID("digitalocean://123")
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("unexpected region. got: %+v want: %+v", actual, expected)


### PR DESCRIPTION
Addresses https://github.com/digitalocean/digitalocean-cloud-controller-manager/issues/15. 

In v1.7.x this wasn't important since CCM never set providerID in the first place. In v1.8, it will so we should handle the expected format. The expected format for node's providerID is `digitalocean://droplet-id`, example:

```yaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    node.alpha.kubernetes.io/ttl: "0"
    volumes.kubernetes.io/controller-managed-attach-detach: "true"
  creationTimestamp: 2017-09-27T14:30:44Z
  labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/instance-type: 512mb
    beta.kubernetes.io/os: linux
    kubernetes.io/hostname: k8s-worker-01
    kubernetes.io/role: node
  name: k8s-worker-01
  resourceVersion: "7123"
  selfLink: /api/v1/nodes/k8s-worker-01
  uid: 720492a5-a390-11e7-8009-6ea0aaddb09e
spec:
  externalID: k8s-worker-01
  providerID: digitalocean://64011171
```