### PR TITLE
use the region slug instead of region name

### DIFF
--- a/do/droplets_test.go
+++ b/do/droplets_test.go
@@ -118,6 +118,7 @@ func newFakeDroplet() *godo.Droplet {
 		},
 		Region: &godo.Region{
 			Name: "test-region",
+			Slug: "test1",
 		},
 	}
 }

--- a/do/zones.go
+++ b/do/zones.go
@@ -47,7 +47,7 @@ func (z zones) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error
 		return cloudprovider.Zone{}, err
 	}
 
-	return cloudprovider.Zone{Region: d.Region.Name}, nil
+	return cloudprovider.Zone{Region: d.Region.Slug}, nil
 }
 
 // GetZoneByNodeName returns the Zone containing the current zone and locality
@@ -59,5 +59,5 @@ func (z zones) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone, e
 		return cloudprovider.Zone{}, err
 	}
 
-	return cloudprovider.Zone{Region: d.Region.Name}, nil
+	return cloudprovider.Zone{Region: d.Region.Slug}, nil
 }

--- a/do/zones_test.go
+++ b/do/zones_test.go
@@ -24,12 +24,12 @@ func TestZones_GetZoneByNodeName(t *testing.T) {
 	client := newFakeClient(fake)
 	zones := newZones(client, "nyc1")
 
-	expected := cloudprovider.Zone{Region: "test-region"}
+	expected := cloudprovider.Zone{Region: "test1"}
 
 	actual, err := zones.GetZoneByNodeName("test-droplet")
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("unexpected region. got: %v want: %v", actual, expected)
+		t.Errorf("unexpected region. got: %+v want: %+v", actual, expected)
 	}
 
 	if err != nil {
@@ -48,12 +48,12 @@ func TestZones_GetZoneByProviderID(t *testing.T) {
 	client := newFakeClient(fake)
 	zones := newZones(client, "nyc1")
 
-	expected := cloudprovider.Zone{Region: "test-region"}
+	expected := cloudprovider.Zone{Region: "test1"}
 
 	actual, err := zones.GetZoneByProviderID("123")
 
 	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("unexpected region. got: %v want: %v", actual, expected)
+		t.Errorf("unexpected region. got: %+v want: %+v", actual, expected)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Use the region slug instead of the region name to communicate the region
of a given node.