### PR TITLE
Add script to generate Kubernetes Secret for DigitalOcean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# binaries
 digitalocean-cloud-controller-manager
+
+# generated kubernetes manifests
+generated-secret.yml

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run digitalocean-cloud-controller-manager, you need a digitalocean access tok
 #### Script
 You can use the script [scripts/generate-secret.sh](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/scripts/generate-secret.sh) in this repo to create the Kubernetes Secret. Note that this will apply changes using your default `kubectl` context. For example, if your token is `abc123abc123abc123`, run the following to create the Kubernetes Secret.
 ```bash
-export DO_ACCESS_TOKEN=abc123abc123abc123
+export DIGITALOCEAN_ACCESS_TOKEN=abc123abc123abc123
 scripts/generate-secret.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,23 @@ In the future, it may implement:
 ## Deployment
 
 ### Token
-To run digitalocean-cloud-controller-manager, you need a digitalocean access token. If you are already logged in, you can create one [here](https://cloud.digitalocean.com/settings/api/tokens). Ensure the token you create has both read and write access. Once you have an access token, you want to create a Kubernetes Secret.
+To run digitalocean-cloud-controller-manager, you need a digitalocean access token. If you are already logged in, you can create one [here](https://cloud.digitalocean.com/settings/api/tokens). Ensure the token you create has both read and write access. Once you have an access token, you want to create a Kubernetes Secret as a way for the cloud controller manager to access your token. You can do this with one of the following methods:
 
+#### Script
+You can use the script [scripts/generate-secret.sh](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/scripts/generate-secret.sh) in this repo to create the Kubernetes Secret. Note that this will apply changes using your default `kubectl` context. For example, if your token is `abc123abc123abc123`, run the following to create the Kubernetes Secret.
+```bash
+export DO_ACCESS_TOKEN=abc123abc123abc123
+scripts/generate-secret.sh
+```
+
+#### Manually
 If your token is `abc123abc123abc123`, then you want to base64 encode your token like so:
 ```bash
 echo -n "abc123abc123abc123" | base64
 ```
 
 and then insert the base64 encoded token into the secret file [here](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/token.yml#L10), replacing the placeholder. The secret should look something like this:
-```
+```yaml
 apiVersion: v1
 kind: Secret
 metadata:

--- a/scripts/generate-secret.sh
+++ b/scripts/generate-secret.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+if [[ -z $DO_ACCESS_TOKEN ]]; then
+  echo "DO_ACCESS_TOKEN is empty, this must be set to your DigitalOcean access token..."
+  exit 1
+fi
+
+ENCODED_ACCESS_TOKEN=$(echo -n "$DO_ACCESS_TOKEN" | base64)
+
+GENERATED_SECRET=./generated-secret.yml
+trap "{ rm $GENERATED_SECRET; }" EXIT
+
+cat > $GENERATED_SECRET <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: digitalocean
+  namespace: kube-system
+data:
+  access-token: $ENCODED_ACCESS_TOKEN
+EOF
+
+echo "Generated secret:"
+cat $GENERATED_SECRET
+
+read -p "Create the following secret to your default kubectl context? [y/N]: " -r
+
+if [[ ! $REPLY =~ ^[y]$ ]]
+then
+	exit 0
+fi
+
+echo "Creating Kubernetes Secret for DigitalOcean"
+kubectl apply -f $GENERATED_SECRET

--- a/scripts/generate-secret.sh
+++ b/scripts/generate-secret.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 
-if [[ -z $DO_ACCESS_TOKEN ]]; then
-  echo "DO_ACCESS_TOKEN is empty, this must be set to your DigitalOcean access token..."
+# Copyright 2017 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ -z $DIGITALOCEAN_ACCESS_TOKEN ]]; then
+  echo "DIGITALOCEAN_ACCESS_TOKEN is empty, this must be set to your DigitalOcean access token..."
   exit 1
 fi
 
-ENCODED_ACCESS_TOKEN=$(echo -n "$DO_ACCESS_TOKEN" | base64)
+ENCODED_ACCESS_TOKEN=$(echo -n "$DIGITALOCEAN_ACCESS_TOKEN" | base64)
 
 GENERATED_SECRET=./generated-secret.yml
 trap "{ rm $GENERATED_SECRET; }" EXIT


### PR DESCRIPTION
We create a secret containing a DO access token for cloud-controller-manager to consume. Though it's documented how to create the secret, figured it would also help to create a script to make this easier. 

@xmudrii @bhcleek  r? 