### PR TITLE
edit godoc

### DIFF
--- a/do/droplets.go
+++ b/do/droplets.go
@@ -31,7 +31,6 @@ import (
 	"github.com/digitalocean/godo/context"
 )
 
-// instances Implements cloudprovider.Instances
 type instances struct {
 	client *godo.Client
 	region string
@@ -41,8 +40,11 @@ func newInstances(client *godo.Client, region string) cloudprovider.Instances {
 	return &instances{client, region}
 }
 
-// NodeAddresses returns all the valid addresses of the specified node
-// For DO, this is the public/private ipv4 addresses only for now
+// NodeAddresses returns all the valid addresses of the droplet identified by
+// nodeName. Only the public/private IPv4 addresses are considered for now.
+//
+// When nodeName identifies more than one droplet, only the first will be
+// considered.
 func (i *instances) NodeAddresses(nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	droplet, err := dropletByName(context.TODO(), i.client, nodeName)
 	if err != nil {
@@ -52,10 +54,11 @@ func (i *instances) NodeAddresses(nodeName types.NodeName) ([]v1.NodeAddress, er
 	return nodeAddresses(droplet)
 }
 
-// NodeAddressesByProviderID returns all the valid addresses of the specified
-// node by providerId. For DO this is the public/private ipv4 addresses for now.
-func (i *instances) NodeAddressesByProviderID(providerId string) ([]v1.NodeAddress, error) {
-	id, err := dropletIDFromProviderID(providerId)
+// NodeAddressesByProviderID returns all the valid addresses of the droplet
+// identified by providerID. Only the public/private IPv4 addresses will be
+// considered for now.
+func (i *instances) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error) {
+	id, err := dropletIDFromProviderID(providerID)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +71,7 @@ func (i *instances) NodeAddressesByProviderID(providerId string) ([]v1.NodeAddre
 	return nodeAddresses(droplet)
 }
 
-// nodeAddresses extracts droplet data into []v1.NodeAddress
+// nodeAddresses returns a []v1.NodeAddress from droplet.
 func nodeAddresses(droplet *godo.Droplet) ([]v1.NodeAddress, error) {
 	var addresses []v1.NodeAddress
 	addresses = append(addresses, v1.NodeAddress{Type: v1.NodeHostName, Address: droplet.Name})
@@ -88,13 +91,17 @@ func nodeAddresses(droplet *godo.Droplet) ([]v1.NodeAddress, error) {
 	return addresses, nil
 }
 
-// ExternalID returns the cloud provider ID of the node with the specified NodeName.
-// Note that if the instance does not exist or is no longer running, we must return ("", cloudprovider.InstanceNotFound)
+// ExternalID returns the cloud provider ID of the droplet identified by
+// nodeName. If the droplet does not exist or is no longer running, the
+// returned error will be cloudprovider.InstanceNotFound.
+//
+// When nodeName identifies more than one droplet, only the first will be
+// considered.
 func (i *instances) ExternalID(nodeName types.NodeName) (string, error) {
 	return i.InstanceID(nodeName)
 }
 
-// InstanceID returns the cloud provider ID of the node with the specified NodeName.
+// InstanceID returns the cloud provider ID of the droplet identified by nodeName.
 func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
 	droplet, err := dropletByName(context.TODO(), i.client, nodeName)
 	if err != nil {
@@ -103,8 +110,7 @@ func (i *instances) InstanceID(nodeName types.NodeName) (string, error) {
 	return strconv.Itoa(droplet.ID), nil
 }
 
-// InstanceType returns the type of the specified instance.
-// Droplet types are defined by amount of memory available
+// InstanceType returns the type of the droplet identified by name.
 func (i *instances) InstanceType(name types.NodeName) (string, error) {
 	droplet, err := dropletByName(context.TODO(), i.client, name)
 	if err != nil {
@@ -114,9 +120,9 @@ func (i *instances) InstanceType(name types.NodeName) (string, error) {
 	return droplet.SizeSlug, nil
 }
 
-// InstanceTypeByProviderID returns the type of the specified instance.
-func (i *instances) InstanceTypeByProviderID(providerId string) (string, error) {
-	id, err := dropletIDFromProviderID(providerId)
+// InstanceTypeByProviderID returns the type of the droplet identified by providerID.
+func (i *instances) InstanceTypeByProviderID(providerID string) (string, error) {
+	id, err := dropletIDFromProviderID(providerID)
 	if err != nil {
 		return "", err
 	}
@@ -129,21 +135,25 @@ func (i *instances) InstanceTypeByProviderID(providerId string) (string, error) 
 	return droplet.SizeSlug, err
 }
 
-// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
-// expected format for the key is standard ssh-keygen format: <protocol> <blob>
+// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all
+// droplets.
+//
+// The expected key format is the standard ssh-keygen format: <protocol> <blob>.
 func (i *instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("not implemented yet")
 }
 
-// CurrentNodeName returns the name of the node we are currently running on
-// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
+// CurrentNodeName returns hostname as a NodeName value.
 func (i *instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 	return types.NodeName(hostname), nil
 }
 
-// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
-// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
+// InstanceExistsByProviderID returns true if the droplet identified by
+// providerID is running.
 func (i *instances) InstanceExistsByProviderID(providerID string) (bool, error) {
+	// NOTE: when false is returned with no error, the instance will be
+	// immediately deleted by the cloud controller manager.
+
 	id, err := dropletIDFromProviderID(providerID)
 	if err != nil {
 		return false, err
@@ -166,7 +176,7 @@ func (i *instances) InstanceExistsByProviderID(providerID string) (bool, error) 
 	return false, nil
 }
 
-// dropletByID returns the godo Droplet type corresponding to the provided id
+// dropletByID returns a *godo.Droplet value for the droplet identified by id.
 func dropletByID(ctx context.Context, client *godo.Client, id string) (*godo.Droplet, error) {
 	intId, err := strconv.Atoi(id)
 	if err != nil {
@@ -181,9 +191,10 @@ func dropletByID(ctx context.Context, client *godo.Client, id string) (*godo.Dro
 	return droplet, nil
 }
 
-// dropletByName returns the godo Droplet type corresponding to the node name
-// since we can only get droplets by id, we do a list of all droplets and return
-// the first one that matches the provided name
+// dropletByName returns a *godo.Droplet for the droplet identified by nodeName.
+//
+// When nodeName identifies more than one droplet, only the first will be
+// considered.
 func dropletByName(ctx context.Context, client *godo.Client, nodeName types.NodeName) (*godo.Droplet, error) {
 	// TODO (andrewsykim): list by tag once a tagging format is determined
 	droplets, err := allDropletList(ctx, client)
@@ -200,8 +211,9 @@ func dropletByName(ctx context.Context, client *godo.Client, nodeName types.Node
 	return nil, cloudprovider.InstanceNotFound
 }
 
-// dropletIDFromProviderID returns a droplet's ID extracted from the node's
-// providerID spec. The providerID spec should be retrievable from the Kubernetes
+// dropletIDFromProviderID returns a droplet's ID from providerID.
+//
+// The providerID spec should be retrievable from the Kubernetes
 // node object. The expected format is: digitalocean://droplet-id
 func dropletIDFromProviderID(providerID string) (string, error) {
 	if providerID == "" {

--- a/do/droplets.go
+++ b/do/droplets.go
@@ -135,12 +135,9 @@ func (i *instances) InstanceTypeByProviderID(providerID string) (string, error) 
 	return droplet.SizeSlug, err
 }
 
-// AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all
-// droplets.
-//
-// The expected key format is the standard ssh-keygen format: <protocol> <blob>.
+// AddSSHKeyToAllInstances is not implemented; it always returns an error.
 func (i *instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
-	return errors.New("not implemented yet")
+	return errors.New("not implemented")
 }
 
 // CurrentNodeName returns hostname as a NodeName value.

--- a/do/droplets_test.go
+++ b/do/droplets_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/godo/context"
@@ -141,6 +142,8 @@ func newFakeNotOKResponse() *godo.Response {
 		},
 	}
 }
+
+var _ cloudprovider.Instances = new(instances)
 
 func TestNodeAddresses(t *testing.T) {
 	fake := &fakeDropletService{}

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -80,12 +80,12 @@ type loadbalancers struct {
 	lbActiveCheckTick int
 }
 
-// newLoadbalancers returns a LoadBalancer whose concrete type is a *loadbalancer.
+// newLoadbalancers returns a cloudprovider.LoadBalancer whose concrete type is a *loadbalancer.
 func newLoadbalancers(client *godo.Client, region string) cloudprovider.LoadBalancer {
 	return &loadbalancers{client, region, defaultActiveTimeout, defaultActiveCheckTick}
 }
 
-// GetLoadBalancer returns the LoadBalancerStatus of service.
+// GetLoadBalancer returns the *v1.LoadBalancerStatus of service.
 //
 // GetLoadBalancer will not modify service.
 func (l *loadbalancers) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -34,35 +34,35 @@ import (
 const (
 	// annDOProtocol is the annotation used to specify the default protocol
 	// for DO load balancers. For ports specifed in annDOTLSPorts, this protocol
-	// is overwritten to https. Options are tcp, http and https. Defaults to tcp
+	// is overwritten to https. Options are tcp, http and https. Defaults to tcp.
 	annDOProtocol = "service.beta.kubernetes.io/do-loadbalancer-protocol"
 
 	// annDOTLSPorts is the annotation used to specify which ports of the loadbalancer
 	// should use the https protocol. This is a comma separated list of ports
-	// e.g. 443,6443,7443
+	// (e.g. 443,6443,7443).
 	annDOTLSPorts = "service.beta.kubernetes.io/do-loadbalancer-tls-ports"
 
 	// annDOTLSPassThrough is the annotation used to specify whether the
 	// DO loadbalancer should pass encrypted data to backend droplets.
-	// This is optional and defaults to false
+	// This is optional and defaults to false.
 	annDOTLSPassThrough = "service.beta.kubernetes.io/do-loadbalancer-tls-passthrough"
 
 	// annDOCertificateID is the annotation specifying the certificate ID
 	// used for https protocol. This annoataion is required if annDOTLSPorts
-	// is passed
+	// is passed.
 	annDOCertificateID = "service.beta.kubernetes.io/do-loadbalancer-certificate-id"
 
 	// annDOAlgorithm is the annotation specifying which algorithm DO loadbalancer
 	// should use. Options are round_robin and least_connections. Defaults
-	// to round_robin
+	// to round_robin.
 	annDOAlgorithm = "service.beta.kubernetes.io/do-loadbalancer-algorithm"
 
 	// defaultActiveTimeout is the number of seconds to wait for a load balancer to
-	// reach the active state
+	// reach the active state.
 	defaultActiveTimeout = 90
 
 	// defaultActiveCheckTick is the number of seconds between load balancer
-	// status checks when waiting for activation
+	// status checks when waiting for activation.
 	defaultActiveCheckTick = 5
 
 	// statuses for Digital Ocean load balancer
@@ -73,7 +73,6 @@ const (
 
 var lbNotFound = errors.New("loadbalancer not found")
 
-// loadbalancers implements cloudprovider.Loadbalancer
 type loadbalancers struct {
 	client            *godo.Client
 	region            string
@@ -81,14 +80,14 @@ type loadbalancers struct {
 	lbActiveCheckTick int
 }
 
-// newLoadbalancers returns a type loadbalancer, implementing cloudprovider.Loadbalancer
+// newLoadbalancers returns a LoadBalancer whose concrete type is a *loadbalancer.
 func newLoadbalancers(client *godo.Client, region string) cloudprovider.LoadBalancer {
 	return &loadbalancers{client, region, defaultActiveTimeout, defaultActiveCheckTick}
 }
 
-// GetLoadBalancer specifies whether the loadbalancer exists based on the provided service
-// if exists, will return loadbalancer status. v1.Service provdied must be treated
-// as read only. clusterName is what's specified in the kube-controller-manager
+// GetLoadBalancer returns the LoadBalancerStatus of service.
+//
+// GetLoadBalancer will not modify service.
 func (l *loadbalancers) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	lbName := cloudprovider.GetLoadBalancerName(service)
 	lb, err := l.lbByName(context.TODO(), lbName)
@@ -116,9 +115,10 @@ func (l *loadbalancers) GetLoadBalancer(clusterName string, service *v1.Service)
 	}, true, nil
 }
 
-// EnsureLoadBalancer will create a new load balancer or updating existing ones
-// Service and Nodes passed in must be treated as read only.
-// clusterName is what's specified in the kube-controller-manager
+// EnsureLoadBalancer ensures that the cluster is running a load balancer for
+// service.
+//
+// EnsureLoadBalancer will not modify service or nodes.
 func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	lbStatus, exists, err := l.GetLoadBalancer(clusterName, service)
 	if err != nil {
@@ -164,9 +164,10 @@ func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Servi
 
 }
 
-// UpdateLoadBalancer updates any droplets under the specified loadbalancer
-// services and nodes passed in are to be treated as read only
-// clusterName is what's specified in the kube-controller-manager
+// UpdateLoadBalancer updates the load balancer for service to balance across
+// the droplets in nodes.
+//
+// UpdateLoadBalancer will not modify service or nodes.
 func (l *loadbalancers) UpdateLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) error {
 	lbRequest, err := l.buildLoadBalancerRequest(service, nodes)
 	if err != nil {
@@ -183,10 +184,11 @@ func (l *loadbalancers) UpdateLoadBalancer(clusterName string, service *v1.Servi
 	return err
 }
 
-// EnsureLoadBalancerDeleted deletes the specified loadbalancer if it exists
-// returning nil if the loadbalancer specifed either didn't exist or
-// was successfully deleted. Services and nodes passed in are to be treated
-// as read only. clusterName is what's specified in kube-controller-manager
+// EnsureLoadBalancerDeleted deletes the specified loadbalancer if it exists.
+// nil is returned if the load balancer for service does not exist or is
+// successfully deleted.
+//
+// EnsureLoadBalancerDeleted will not modify service.
 func (l *loadbalancers) EnsureLoadBalancerDeleted(clusterName string, service *v1.Service) error {
 	_, exists, err := l.GetLoadBalancer(clusterName, service)
 	if err != nil {
@@ -209,8 +211,8 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(clusterName string, service *v
 	return err
 }
 
-// lbByName gets a DigitalOcean loadbalancer provided it's name.
-// returns lbNotFound error if it doesn't exist
+// lbByName gets a DigitalOcean Load Balancer by name. The returned error will
+// be lbNotFound if the load balancer does not exist.
 func (l *loadbalancers) lbByName(ctx context.Context, name string) (*godo.LoadBalancer, error) {
 	lbs, _, err := l.client.LoadBalancers.List(ctx, &godo.ListOptions{})
 	if err != nil {
@@ -226,8 +228,9 @@ func (l *loadbalancers) lbByName(ctx context.Context, name string) (*godo.LoadBa
 	return nil, lbNotFound
 }
 
-// nodesToDropletID receives a list of Kubernetes nodes and get's all the corresponding droplet IDs.
-// This function assumes nodes names match that of the droplet name
+// nodesToDropletID returns a []int containing ids of all droplets identified by name in nodes.
+//
+// Node names are assumed to match droplet names.
 func (l *loadbalancers) nodesToDropletIDs(nodes []*v1.Node) ([]int, error) {
 	droplets, err := allDropletList(context.TODO(), l.client)
 
@@ -248,10 +251,9 @@ func (l *loadbalancers) nodesToDropletIDs(nodes []*v1.Node) ([]int, error) {
 	return dropletIDs, nil
 }
 
-// buildLoadBalancerRequest builds godo.LoadBalancerRequest provided
-// kubernetes service and list of kubernetes nodes.
-func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v1.Node) (
-	*godo.LoadBalancerRequest, error) {
+// buildLoadBalancerRequest returns a *godo.LoadBalancerRequest to balance
+// requests for service across nodes.
+func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v1.Node) (*godo.LoadBalancerRequest, error) {
 	lbName := cloudprovider.GetLoadBalancerName(service)
 
 	dropletIDs, err := l.nodesToDropletIDs(nodes)
@@ -307,10 +309,11 @@ func (l *loadbalancers) waitActive(lbID string) (*godo.LoadBalancer, error) {
 	}
 }
 
-// buildHealthChecks receives a kubernetes service and builds health checks
-// used for DO loadbalancers. Although a Kubernetes Service can have many node ports,
-// DO Loadbalancers can only take 1 node port so we choose the first node port
-// for health checking.
+// buildHealthChecks returns a godo.HealthCheck for service.
+//
+// Although a Kubernetes Service can have many node ports, DigitalOcean Load
+// Balancers can only take one node port so we choose the first node port for
+// health checking.
 func buildHealthCheck(service *v1.Service) (*godo.HealthCheck, error) {
 	protocol, err := getProtocol(service)
 	if err != nil {
@@ -329,8 +332,8 @@ func buildHealthCheck(service *v1.Service) (*godo.HealthCheck, error) {
 	}, nil
 }
 
-// buildForwardingRules will build forwarding rules for DigitalOcean loadbalancers
-// based on the given Kubernetes service
+// buildForwardingRules returns the forwarding rules of the Load Balancer of
+// service.
 func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 	protocol, err := getProtocol(service)
 	if err != nil {
@@ -394,7 +397,7 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 	return forwardingRules, nil
 }
 
-// getProtocol returns the desired protocol reading annotiation annDOProtocol
+// getProtocol returns the desired protocol of service.
 func getProtocol(service *v1.Service) (string, error) {
 	protocol, ok := service.Annotations[annDOProtocol]
 	if !ok {
@@ -408,8 +411,7 @@ func getProtocol(service *v1.Service) (string, error) {
 	return protocol, nil
 }
 
-// getTLSPorts reads the set of ports that are set to use TLS
-// by reading annotiation annDOTLSPorts
+// getTLSPorts returns the ports of service that are set to use TLS.
 func getTLSPorts(service *v1.Service) ([]int, error) {
 	tlsPorts, ok := service.Annotations[annDOTLSPorts]
 	if !ok {
@@ -431,33 +433,30 @@ func getTLSPorts(service *v1.Service) ([]int, error) {
 	return tlsPortsInt, nil
 }
 
-// getCertificateID gets the certificate ID to use for forwarding rule
-// passed in through annotations annDOCertificateID
+// getCertificateID returns the certificate ID of service to use for fowarding
+// rules.
 func getCertificateID(service *v1.Service) string {
 	return service.Annotations[annDOCertificateID]
 }
 
-// getTlsPassThrough determines if there should be TLS pass through
-// to backend nodes. This is specificed with annotation annDOTlsPassThrough
+// getTLSPassThrough returns true if there should be TLS pass through to
+// backend nodes.
 func getTLSPassThrough(service *v1.Service) bool {
 	passThrough, ok := service.Annotations[annDOTLSPassThrough]
 	if !ok {
-		// this is the DO default
 		return false
 	}
 
 	passThroughBool, err := strconv.ParseBool(passThrough)
 	if err != nil {
-		// this is the DO default
 		return false
 	}
 
 	return passThroughBool
 }
 
-// getAlgorithm will get the desired algorithm by reading
-// an annotation from a service. Defaults to round_robin if
-// annotation doesn't exist
+// getAlgorithm returns the load balancing algorithm to use for service.
+// round_robin is returned when service does not specify an algorithm.
 func getAlgorithm(service *v1.Service) string {
 	algo := service.Annotations[annDOAlgorithm]
 

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -27,7 +27,10 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 )
+
+var _ cloudprovider.LoadBalancer = new(loadbalancers)
 
 type fakeLBService struct {
 	getFn                   func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error)

--- a/do/metadata.go
+++ b/do/metadata.go
@@ -24,8 +24,7 @@ import (
 
 const dropletRegionMetadataURL = "http://169.254.169.254/metadata/v1/region"
 
-// dropletRegion returns the currently the region of the currently
-// running program
+// dropletRegion returns the region of the currently running program.
 func dropletRegion() (string, error) {
 	return httpGet(dropletRegionMetadataURL)
 }

--- a/do/zones.go
+++ b/do/zones.go
@@ -58,8 +58,7 @@ func (z zones) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error
 // GetZoneByNodeName returns a cloudprovider.Zone from the droplet identified
 // by nodeName. GetZoneByNodeName only sets the Region field of the returned
 // cloudprovider.Zone.
-func (z zones) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone,
-	error) {
+func (z zones) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone, error) {
 	d, err := dropletByName(context.Background(), z.client, nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, err

--- a/do/zones.go
+++ b/do/zones.go
@@ -32,15 +32,15 @@ func newZones(client *godo.Client, region string) cloudprovider.Zones {
 	return zones{client, region}
 }
 
-// GetZone returns a cloudprovider.Zone for the currently running node.
-// GetZone will only fill the Region field of cloudprovider.Zone for DO.
+// GetZone returns a cloudprovider.Zone from the region of z. GetZone only sets
+// the Region field of the returned cloudprovider.Zone.
 func (z zones) GetZone() (cloudprovider.Zone, error) {
 	return cloudprovider.Zone{Region: z.region}, nil
 }
 
-// GetZoneByProviderID returns the Zone containing the current zone and
-// locality region of the node specified by providerId. GetZoneByProviderID
-// will only fill the Region field of cloudprovider.Zone for DO.
+// GetZoneByProviderID returns a cloudprovider.Zone from the droplet identified
+// by providerID. GetZoneByProviderID only sets the Region field of the
+// returned cloudprovider.Zone.
 func (z zones) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error) {
 	id, err := dropletIDFromProviderID(providerID)
 	if err != nil {
@@ -55,10 +55,11 @@ func (z zones) GetZoneByProviderID(providerID string) (cloudprovider.Zone, error
 	return cloudprovider.Zone{Region: d.Region.Slug}, nil
 }
 
-// GetZoneByNodeName returns the Zone containing the current zone and locality
-// region of the node specified by node name. GetZoneByNodeName will only fill
-// the Region field of cloudprovider.Zone for DO.
-func (z zones) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone, error) {
+// GetZoneByNodeName returns a cloudprovider.Zone from the droplet identified
+// by nodeName. GetZoneByNodeName only sets the Region field of the returned
+// cloudprovider.Zone.
+func (z zones) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zone,
+	error) {
 	d, err := dropletByName(context.Background(), z.client, nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, err

--- a/do/zones.go
+++ b/do/zones.go
@@ -34,6 +34,8 @@ func newZones(client *godo.Client, region string) cloudprovider.Zones {
 
 // GetZone returns a cloudprovider.Zone from the region of z. GetZone only sets
 // the Region field of the returned cloudprovider.Zone.
+//
+// Kuberenetes uses this method to get the region that the program is running in.
 func (z zones) GetZone() (cloudprovider.Zone, error) {
 	return cloudprovider.Zone{Region: z.region}, nil
 }


### PR DESCRIPTION
Edit godoc comments that were merely copies of Kubernetes' cloudprovider
interface definitions' godoc comments so that they describe the
behavior, expected inputs, and return values of the DigitalOcean
interface implementations of those interfaces.

Add punctuation to godoc comments where it was missing.

Replace comments documenting that do/instances and do/loadbalancers
implement cloudprovider.Instances and cloudprovider.LoadBalancers,
respectively, with variable declarations in test files that verify the
same.

Rename a couple of method parameters to be cased in the standard fashion
(e.g. providerId -> providerID).