### PR TITLE
reduce risk of a contributor commiting their token

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ scripts/generate-secret.sh
 ```
 
 #### Manually
-Copy [releases/secret.yml.tmpl](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/secret.yml#L10) to releases/secret.yml and replace the placeholder in the copy with your base64 encoded token.
-
-Copy releases/secret.yml.tmpl to releases/secret.yml:
+Copy [releases/secret.yml.tmpl](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/secret.yml.tmpl) to releases/secret.yml:
 ```bash
 cp releases/secret.yml.tmpl releases/secret.yml
 ```
@@ -73,7 +71,7 @@ If your token is `abc123abc123abc123`, then you want to base64 encode your token
 echo -n "abc123abc123abc123" | base64
 ```
 
-Replace the placeholder in releases/secret.yml with the base64 encoded token. When you're done, the releases/secret.yml should look something like this:
+Replace the placeholder in the copy with your base64 encoded token. When you're done, the releases/secret.yml should look something like this:
 ```yaml
 apiVersion: v1
 kind: Secret

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In the future, it may implement:
 ## Deployment
 
 ### Token
-To run digitalocean-cloud-controller-manager, you need a digitalocean access token. If you are already logged in, you can create one [here](https://cloud.digitalocean.com/settings/api/tokens). Ensure the token you create has both read and write access. Once you have an access token, you want to create a Kubernetes Secret as a way for the cloud controller manager to access your token. You can do this with one of the following methods:
+To run digitalocean-cloud-controller-manager, you need a DigitalOcean personal access token. If you are already logged in, you can create one [here](https://cloud.digitalocean.com/settings/api/tokens). Ensure the token you create has both read and write access. Once you have a personal access token, create a Kubernetes Secret as a way for the cloud controller manager to access your token. You can do this with one of the following methods:
 
 #### Script
 You can use the script [scripts/generate-secret.sh](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/scripts/generate-secret.sh) in this repo to create the Kubernetes Secret. Note that this will apply changes using your default `kubectl` context. For example, if your token is `abc123abc123abc123`, run the following to create the Kubernetes Secret.
@@ -61,12 +61,19 @@ scripts/generate-secret.sh
 ```
 
 #### Manually
+Copy [releases/secret.yml.tmpl](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/secret.yml#L10) to releases/secret.yml and replace the placeholder in the copy with your base64 encoded token.
+
+Copy releases/secret.yml.tmpl to releases/secret.yml:
+```bash
+cp releases/secret.yml.tmpl releases/secret.yml
+```
+
 If your token is `abc123abc123abc123`, then you want to base64 encode your token like so:
 ```bash
 echo -n "abc123abc123abc123" | base64
 ```
 
-and then insert the base64 encoded token into the secret file [here](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/token.yml#L10), replacing the placeholder. The secret should look something like this:
+Replace the placeholder in releases/secret.yml with the base64 encoded token. When you're done, the releases/secret.yml should look something like this:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -77,9 +84,9 @@ data:
   access-token: "YWJjMTIzYWJjMTIzYWJjMTIz"
 ```
 
-then simply run this command from the root of this repo:
+Finally, run this command from the root of this repo:
 ```bash
-kubectl apply -f releases/token.yml
+kubectl apply -f releases/secret.yml
 ```
 
 You should now see the digitalocean secret in the `kube-system` namespace along with other secrets

--- a/releases/.gitignore
+++ b/releases/.gitignore
@@ -1,0 +1,1 @@
+/secret.yml

--- a/releases/secret.yml.tmpl
+++ b/releases/secret.yml.tmpl
@@ -7,4 +7,4 @@ data:
   # insert your base64 encoded DO access token here, ensure there's no trailing newline:
   # to base64 encode your token run:
   #      echo -n "abc123abc123doaccesstoken" | base64
-  access-token: "<INSERT BASE64 ENCODED DO ACCESS TOKEN>"
+  access-token: "REPLACE WITH BASE64 ENCODED DO ACCESS TOKEN"


### PR DESCRIPTION
* Rename releases/token.yml to releases/secret.yml.tmpl
* Add a .gitignore entry for releases/secret.yml
* Edit README.md instructions to direct users to copy
  releases/secret.yml.tmpl to releases/secret.yml before replacing the
  placeholder.

Edit references to DigitalOcean in README.md to be capitalized
correctly.

Edit the placeholder value; remove the the wrapping angle brackets so
that users don't mistakenly think the angle brackets are necessary.