### PR TITLE
docs: account for new lines in base64 encoded secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cp releases/secret.yml.tmpl releases/secret.yml
 
 If your token is `abc123abc123abc123`, then you want to base64 encode your token like so:
 ```bash
-echo -n "abc123abc123abc123" | base64
+echo -n "abc123abc123abc123" | base64 | tr -d '\r\n'
 ```
 
 Replace the placeholder in the copy with your base64 encoded token. When you're done, the releases/secret.yml should look something like this:

--- a/releases/secret.yml.tmpl
+++ b/releases/secret.yml.tmpl
@@ -6,5 +6,5 @@ metadata:
 data:
   # insert your base64 encoded DO access token here, ensure there's no trailing newline:
   # to base64 encode your token run:
-  #      echo -n "abc123abc123doaccesstoken" | base64
+  #      echo -n "abc123abc123doaccesstoken" | base64 | tr -d '\r\n'
   access-token: "REPLACE WITH BASE64 ENCODED DO ACCESS TOKEN"

--- a/scripts/generate-secret.sh
+++ b/scripts/generate-secret.sh
@@ -19,7 +19,7 @@ if [[ -z $DIGITALOCEAN_ACCESS_TOKEN ]]; then
   exit 1
 fi
 
-ENCODED_ACCESS_TOKEN=$(echo -n "$DIGITALOCEAN_ACCESS_TOKEN" | base64)
+ENCODED_ACCESS_TOKEN=$(echo -n "$DIGITALOCEAN_ACCESS_TOKEN" | base64 | tr -d '\r\n')
 
 GENERATED_SECRET=./generated-secret.yml
 trap "{ rm $GENERATED_SECRET; }" EXIT


### PR DESCRIPTION
This PR adds `-w 0` flag to the all base64 to prevent confusion as `base64` automatically adds new line after 72 characters.

This also fix the secret generation script, as it returns the following error if new line is present:
```
...
Create the following secret to your default kubectl context? [y/N]: y
Creating Kubernetes Secret for DigitalOcean
error: error converting YAML to JSON: yaml: line 9: could not find expected ':'
```

/cc @andrewsykim 