### PR TITLE
Switch Docker base image to Alpine from Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM alpine:3.6
 
-RUN apt-get update -y && apt-get install -y ca-certificates
+RUN apk add --no-cache ca-certificates
 
 ADD digitalocean-cloud-controller-manager /bin/
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -f digitalocean-cloud-controller-manager
 
 compile:
-	GOOS=linux go build .
+	CGO_ENABLED=0 GOOS=linux go build .
 
 build:
 	docker build -t $(REGISTRY)/digitalocean-cloud-controller-manager:$(VERSION) .


### PR DESCRIPTION
This reduce the image size by 75%.
Before this change the image size was 214MB, now it is only 50.2MB.

---

Note: Not tested..