### PR TITLE
Handle firewall rule creation for load balancers

### DIFF
--- a/do/firewalls.go
+++ b/do/firewalls.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"fmt"
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/godo/context"
+	"strconv"
+	"strings"
+)
+
+type firewallRequest struct {
+	firewallID string
+	rules      *godo.FirewallRulesRequest
+}
+
+func checkIfPortInRange(port int, fwPortRange string) bool {
+
+	fwPortList := strings.Split(fwPortRange, "-")
+	if fwPortList[0] == "all" {
+		return true
+	}
+	if len(fwPortList) == 1 {
+		fwPort, _ := strconv.Atoi(fwPortList[0])
+		if port == fwPort {
+			return true
+		}
+	} else {
+		fwLowerVal, _ := strconv.Atoi(fwPortList[0])
+		fwUpperVal, _ := strconv.Atoi(fwPortList[1])
+		if port >= fwLowerVal && port <= fwUpperVal {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+func checkIfPortRequiresDeletion(port int, fwPortRange string) bool {
+
+	fwPortList := strings.Split(fwPortRange, "-")
+	if fwPortList[0] == "all" {
+		return false
+	}
+	if len(fwPortList) == 1 {
+		fwPort, _ := strconv.Atoi(fwPortList[0])
+		if port == fwPort {
+			return true
+		}
+	}
+
+	return false
+
+}
+
+func createRuleRequest(sourcelb string, targetPort int) *godo.FirewallRulesRequest {
+	rr := &godo.FirewallRulesRequest{
+		InboundRules: []godo.InboundRule{
+			{
+				Protocol:  "tcp",
+				PortRange: strconv.Itoa(targetPort),
+				Sources: &godo.Sources{
+					LoadBalancerUIDs: []string{sourcelb},
+				},
+			},
+		},
+	}
+	return rr
+}
+
+// Check if a firewall rule already exists for a load balancer
+// forwarding rule ( returns true if covered by ALL, a port range or a single port)
+func lbfwRuleExists(lbID string, lbRule godo.ForwardingRule, firewalls []godo.Firewall) bool {
+	ruleExists := false
+	//check each firewall to see if rule already exists
+	for _, firewall := range firewalls {
+		for _, fwInboundRule := range firewall.InboundRules {
+			for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
+				if fwSourcelbs == lbID {
+					res := checkIfPortInRange(lbRule.TargetPort, fwInboundRule.PortRange)
+					if res && fwInboundRule.Protocol == "tcp" {
+						ruleExists = true
+					}
+				}
+			}
+		}
+	}
+
+	return ruleExists
+
+}
+
+func requestExists(requests []firewallRequest, firewallID string, lbID string, targetPort int) bool {
+
+	for _, request := range requests {
+		if firewallID == request.firewallID &&
+			lbID == request.rules.InboundRules[0].Sources.LoadBalancerUIDs[0] &&
+			strconv.Itoa(targetPort) == request.rules.InboundRules[0].PortRange {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Check if a single port rule exists for a load balancer
+// forwarding rule ( will not remove ranges defined by ports or ALL )
+func lbfwRuleRequiresDeletion(lbID string, lbRule godo.ForwardingRule, firewalls []godo.Firewall) bool {
+	requiresDeletion := false
+	//check each firewall to see if rule need deleting
+	for _, firewall := range firewalls {
+		for _, fwInboundRule := range firewall.InboundRules {
+			for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
+				if fwSourcelbs == lbID {
+					res := checkIfPortRequiresDeletion(lbRule.TargetPort, fwInboundRule.PortRange)
+					if res && fwInboundRule.Protocol == "tcp" {
+						requiresDeletion = true
+					}
+				}
+			}
+		}
+	}
+
+	return requiresDeletion
+
+}
+
+func addRules(client *godo.Client, rulesToAdd []firewallRequest) error {
+	for _, ruleToAdd := range rulesToAdd {
+		_, err := client.Firewalls.AddRules(context.TODO(), ruleToAdd.firewallID, ruleToAdd.rules)
+		if err != nil {
+			return fmt.Errorf("Error adding rule to firewall %s", ruleToAdd.firewallID)
+		}
+	}
+
+	return nil
+}
+
+func deleteRules(client *godo.Client, rulesToDelete []firewallRequest) error {
+	for _, ruleToDelete := range rulesToDelete {
+		_, err := client.Firewalls.RemoveRules(context.TODO(), ruleToDelete.firewallID, ruleToDelete.rules)
+		if err != nil {
+			return fmt.Errorf("Error removing rule from firewall %s", ruleToDelete.firewallID)
+		}
+	}
+
+	return nil
+}
+
+// EnsureFWRuleExists ensures that the node firewalls have the correct rules for
+// the load balancer.
+//
+// EnsureFWRuleExists will not modify service or nodes.
+func (l *loadbalancers) EnsureFWRuleExists(lb *godo.LoadBalancer) ([]firewallRequest, error) {
+	var rulesToAdd []firewallRequest
+
+	for _, dropletID := range lb.DropletIDs {
+		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("Error listing firewalls for droplet %d", dropletID)
+		}
+
+		if len(firewalls) == 0 {
+			continue
+		}
+
+		for _, lbRule := range lb.ForwardingRules {
+			if lbfwRuleExists(lb.ID, lbRule, firewalls) == false &&
+				requestExists(rulesToAdd, firewalls[0].ID, lb.ID, lbRule.TargetPort) == false {
+
+				rulesToAdd = append(rulesToAdd, firewallRequest{firewalls[0].ID, createRuleRequest(lb.ID, lbRule.TargetPort)})
+
+			}
+		}
+
+	}
+
+	err := addRules(l.client, rulesToAdd)
+	if err != nil {
+		return rulesToAdd, fmt.Errorf("Error adding firewall rules")
+	}
+
+	return rulesToAdd, nil
+}
+
+func (l *loadbalancers) EnsureFWRuleDeleted(lb *godo.LoadBalancer) ([]firewallRequest, error) {
+	var rulesToDelete []firewallRequest
+
+	for _, dropletID := range lb.DropletIDs {
+
+		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletID, nil)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error listing firewalls for droplet %d", dropletID)
+		}
+
+		if len(firewalls) == 0 {
+			continue
+		}
+
+		for _, lbRule := range lb.ForwardingRules {
+
+			if lbfwRuleRequiresDeletion(lb.ID, lbRule, firewalls) == true &&
+				requestExists(rulesToDelete, firewalls[0].ID, lb.ID, lbRule.TargetPort) == false {
+
+				rulesToDelete = append(rulesToDelete, firewallRequest{firewalls[0].ID, createRuleRequest(lb.ID, lbRule.TargetPort)})
+
+			}
+		}
+
+	}
+
+	err := deleteRules(l.client, rulesToDelete)
+	if err != nil {
+		return rulesToDelete, fmt.Errorf("Error deleting firewall rules")
+	}
+
+	return rulesToDelete, nil
+}

--- a/do/firewalls_test.go
+++ b/do/firewalls_test.go
@@ -1,0 +1,334 @@
+/*
+Copyright 2017 DigitalOcean
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"github.com/digitalocean/godo"
+	"testing"
+)
+
+func Test_checkIfPortInRange(t *testing.T) {
+	testcases := []struct {
+		name      string
+		portRange string
+		port      int
+		result    bool
+	}{
+		{
+			"Port in range",
+			"100-200",
+			150,
+			true,
+		},
+		{
+			"Port not in range",
+			"100-200",
+			250,
+			false,
+		},
+		{
+			"Return true if all specified",
+			"all",
+			250,
+			true,
+		},
+		{
+			"Return true if single port match",
+			"250",
+			250,
+			true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := checkIfPortInRange(testcase.port, testcase.portRange)
+			if result != testcase.result {
+				t.Errorf("actual result of check port %d in range %s is: %t", testcase.port, testcase.portRange, result)
+				t.Errorf("expected result: %t", testcase.result)
+				t.Error("unexpected check if port is in range result")
+			}
+		})
+	}
+
+}
+
+func Test_checkIfPortRequiresDeletion(t *testing.T) {
+	testcases := []struct {
+		name      string
+		portRange string
+		port      int
+		result    bool
+	}{
+		{
+			"Port is in a range",
+			"100-200",
+			150,
+			false,
+		},
+		{
+			"Port not in range",
+			"100-200",
+			250,
+			false,
+		},
+		{
+			"Return false if all specified",
+			"all",
+			250,
+			false,
+		},
+		{
+			"Single port match",
+			"250",
+			250,
+			true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := checkIfPortRequiresDeletion(testcase.port, testcase.portRange)
+			if result != testcase.result {
+				t.Errorf("actual result of check port %d requires deletion %s is: %t", testcase.port, testcase.portRange, result)
+				t.Errorf("expected result: %t", testcase.result)
+				t.Error("unexpected check if port requires deletion result")
+			}
+		})
+	}
+
+}
+
+func Test_lbfwRuleExists(t *testing.T) {
+	testcases := []struct {
+		name           string
+		lbID           string
+		forwardingRule godo.ForwardingRule
+		firewall       []godo.Firewall
+		checkFunc      func(port int, fwPortRange string) bool
+		result         bool
+	}{
+		{
+			"Firewall rule does not exist for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An existing rule exists allowing port 123 through
+							PortRange: "123",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortInRange,
+			//A rule does not exist for port 30000 so we expect a result of false
+			false,
+		},
+		{
+			"Firewall rule exists for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An existing rule exists allowing port 30000 through
+							PortRange: "30000",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortInRange,
+			//A rule does exist for port 30000 so we expect a result of true
+			true,
+		},
+		{
+			"Firewall rule is covered by a port range for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An existing rule exists allowing a range of ports through
+							PortRange: "30000-30050",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortInRange,
+			//A rule exists within a range allowing the port through
+			true,
+		},
+		{
+			"Firewall rule does not require deletion for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An existing rule exists allowing port 123 through
+							PortRange: "123",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortRequiresDeletion,
+			//A rule does not exist for port 30000 and so no rule requires deletion
+			false,
+		},
+		{
+			"Firewall rule requires deletion for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An  rule exists allowing port 30000 through
+							PortRange: "30000",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortRequiresDeletion,
+			//A rule does exist for port 30000 which requires deletion so we expect a result of true
+			true,
+		},
+		{
+			"Firewall rule exists for range no deletion required for load balancer forward port",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			godo.ForwardingRule{
+				EntryProtocol:  "tcp",
+				EntryPort:      80,
+				TargetProtocol: "tcp",
+				//A forwarding rule exists for port 30000
+				TargetPort:     30000,
+				CertificateID:  "",
+				TlsPassthrough: false,
+			},
+			[]godo.Firewall{
+				{
+					ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+					InboundRules: []godo.InboundRule{
+						{
+							Protocol: "tcp",
+							//An  rule exists allowing port 30000 through
+							PortRange: "30000-30050",
+							Sources: &godo.Sources{
+								LoadBalancerUIDs: []string{
+									"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+								},
+							},
+						},
+					},
+				},
+			},
+			checkIfPortRequiresDeletion,
+			//A rule does exist for port 30000 but it lies within a range
+			//therefore no rule requres deletion
+			false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := lbfwRuleExists(testcase.lbID, testcase.forwardingRule, testcase.firewall, testcase.checkFunc)
+			if result != testcase.result {
+				t.Errorf("actual result of check firewall rule required is: %t", result)
+				t.Errorf("expected result: %t", testcase.result)
+				t.Error("unexpected check if rule is required for forwarding rule result")
+			}
+		})
+	}
+
+}

--- a/do/firewalls_test.go
+++ b/do/firewalls_test.go
@@ -315,7 +315,7 @@ func Test_lbfwRuleExists(t *testing.T) {
 			},
 			checkIfPortRequiresDeletion,
 			//A rule does exist for port 30000 but it lies within a range
-			//therefore no rule requres deletion
+			//therefore no rule requires deletion
 			false,
 		},
 	}
@@ -327,6 +327,116 @@ func Test_lbfwRuleExists(t *testing.T) {
 				t.Errorf("actual result of check firewall rule required is: %t", result)
 				t.Errorf("expected result: %t", testcase.result)
 				t.Error("unexpected check if rule is required for forwarding rule result")
+			}
+		})
+	}
+
+}
+
+func Test_requestExists(t *testing.T) {
+	testcases := []struct {
+		name       string
+		requests   []firewallRequest
+		firewallID string
+		lbID       string
+		targetPort int
+		result     bool
+	}{
+		{
+			"Firewall request already exists",
+			[]firewallRequest{
+				{
+					firewallID: "bb4b2611-3d72-467b-8602-280330ecd65c",
+					rules: &godo.FirewallRulesRequest{
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "123",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+						OutboundRules: []godo.OutboundRule{},
+					},
+				},
+				{
+					firewallID: "bb4b2611-aaaa-467b-8602-280330ecd65c",
+					rules: &godo.FirewallRulesRequest{
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "30000",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-aaaa-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+						OutboundRules: []godo.OutboundRule{},
+					},
+				},
+			},
+			"bb4b2611-3d72-467b-8602-280330ecd65c",
+			"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+			123,
+			true,
+		},
+		{
+			"Firewall request does not exist",
+			[]firewallRequest{
+				{
+					firewallID: "bb4b2611-3d72-467b-8602-280330ecd65c",
+					rules: &godo.FirewallRulesRequest{
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "123",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+						OutboundRules: []godo.OutboundRule{},
+					},
+				},
+				{
+					firewallID: "bb4b2611-aaaa-467b-8602-280330ecd65c",
+					rules: &godo.FirewallRulesRequest{
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "30000",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-aaaa-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+						OutboundRules: []godo.OutboundRule{},
+					},
+				},
+			},
+			"bb4b2611-bbbb-467b-8602-280330ecd65c",
+			"4de7ac8b-cccc-4884-9a69-1050c6793cd6",
+			30000,
+			false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			result := requestExists(testcase.requests, testcase.firewallID, testcase.lbID, testcase.targetPort)
+			if result != testcase.result {
+				t.Errorf("actual result if firewall request exists is: %t", result)
+				t.Errorf("expected result: %t", testcase.result)
+				t.Error("unexpected check if firewall request exists result")
 			}
 		})
 	}

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -20,7 +20,6 @@ import (
 	goctx "context"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -258,7 +257,7 @@ func (l *loadbalancers) EnsureFirewall(lb *godo.LoadBalancer) error {
 	for _, dropletid := range lb.DropletIDs {
 		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletid, nil)
 		if err != nil {
-			log.Print("Something bad happened: %s\n\n", err)
+			return fmt.Errorf("Error listing firewalls for droplet %d", dropletid)
 		}
 
 		if len(firewalls) > 0 {
@@ -298,10 +297,8 @@ func (l *loadbalancers) EnsureFirewall(lb *godo.LoadBalancer) error {
 	for _, ruleToAdd := range rulesToAdd {
 		_, err := l.client.Firewalls.AddRules(context.TODO(), ruleToAdd.firewallId, ruleToAdd.rules)
 		if err != nil {
-			log.Print("error creating firewall rule")
-			log.Print(err)
+			return fmt.Errorf("Error adding rule to firewall %s", ruleToAdd.firewallId)
 		}
-
 	}
 
 	return nil
@@ -370,7 +367,7 @@ func (l *loadbalancers) EnsureFirewallDeleted(lb *godo.LoadBalancer) error {
 		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletid, nil)
 
 		if err != nil {
-			log.Print("Something bad happened: %s\n\n", err)
+			return fmt.Errorf("Error listing firewalls for droplet %d", dropletid)
 		}
 
 		if len(firewalls) > 0 {
@@ -410,10 +407,8 @@ func (l *loadbalancers) EnsureFirewallDeleted(lb *godo.LoadBalancer) error {
 	for _, ruleToDelete := range rulesToDelete {
 		_, err := l.client.Firewalls.RemoveRules(context.TODO(), ruleToDelete.firewallId, ruleToDelete.rules)
 		if err != nil {
-			log.Print("error removing firewall rule")
-			log.Print(err)
+			return fmt.Errorf("Error removing rule from firewall %s", ruleToDelete.firewallId)
 		}
-
 	}
 
 	return nil

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -20,6 +20,7 @@ import (
 	goctx "context"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -156,6 +157,11 @@ func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Servi
 			return nil, err
 		}
 
+		err = l.EnsureFirewall(lb)
+		if err != nil {
+			return nil, err
+		}
+
 		return &v1.LoadBalancerStatus{
 			Ingress: []v1.LoadBalancerIngress{
 				{
@@ -177,6 +183,128 @@ func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Servi
 
 	return lbStatus, nil
 
+}
+
+func checkIfPortInRange(port int, fwPortRange string) (bool){
+
+    fwPortList := strings.Split(fwPortRange, "-")
+    if(fwPortList[0] == "all"){
+        return true
+    }
+    if(len(fwPortList)==1){
+        fwPort,_ := strconv.Atoi(fwPortList[0])
+        if(port == fwPort){
+            return true
+        }
+    }else{
+        fwLowerVal, _ := strconv.Atoi(fwPortList[0])
+        fwUpperVal, _ := strconv.Atoi(fwPortList[1])
+        if(port >= fwLowerVal && port <= fwUpperVal){
+            return true
+        }
+    }
+
+    return false
+
+}
+
+func checkIfPortRequiresDeletion(port int, fwPortRange string) (bool){
+
+    fwPortList := strings.Split(fwPortRange, "-")
+    if(fwPortList[0] == "all"){
+        return false
+    }
+    if(len(fwPortList)==1){
+        fwPort,_ := strconv.Atoi(fwPortList[0])
+        if(port == fwPort){
+            return true
+        }
+    }
+
+    return false
+
+}
+
+func CreateFirewallsRuleRequest(sourcelb string, targetPort int)(*godo.FirewallRulesRequest) {
+    rr := &godo.FirewallRulesRequest{
+            InboundRules: []godo.InboundRule{
+                {
+                    Protocol:  "tcp",
+                    PortRange: strconv.Itoa(targetPort),
+                    Sources: &godo.Sources{
+                        LoadBalancerUIDs: []string{sourcelb},
+                    },
+                },
+            },
+        }
+    return rr
+}
+
+type firewallRequest struct {
+    firewallId string
+    rules *godo.FirewallRulesRequest
+}
+
+// EnsureFirewall ensures that the node firewalls have the correct rules for
+// the load balancer.
+//
+// EnsureFirewall will not modify service or nodes.
+func (l *loadbalancers) EnsureFirewall(lb *godo.LoadBalancer) (error) {
+    var ruleExists bool
+    var rulesToAdd []firewallRequest
+    var alreadyAdded bool
+    //var completedFirewalls []string
+
+    for _, dropletid := range lb.DropletIDs {
+        firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(),dropletid,nil)
+        if err != nil {
+            log.Print("Something bad happened: %s\n\n", err)
+        }
+
+        if(len(firewalls)>0){
+            for _, lbRule := range lb.ForwardingRules {
+                ruleExists = false
+                //check each firewall to see if rule already exists
+                for _, firewall := range firewalls {
+                    for _, fwInboundRule := range firewall.InboundRules {
+                        for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
+                            if(fwSourcelbs == lb.ID){
+                                    res := checkIfPortInRange(lbRule.TargetPort,fwInboundRule.PortRange)
+                                    if(res && fwInboundRule.Protocol=="tcp"){
+                                        ruleExists = true
+                                    }
+                            }
+                        }
+                    }
+                }
+
+                if ( ruleExists == false){
+                    alreadyAdded = false
+                    for _, ruleToAdd := range rulesToAdd {
+                        if(firewalls[0].ID == ruleToAdd.firewallId && lb.ID == ruleToAdd.rules.InboundRules[0].Sources.LoadBalancerUIDs[0] && strconv.Itoa(lbRule.TargetPort) == ruleToAdd.rules.InboundRules[0].PortRange){
+                            alreadyAdded = true
+                        }
+                    }
+                    if(alreadyAdded==false){
+                        rulesToAdd = append(rulesToAdd,firewallRequest{firewalls[0].ID,CreateFirewallsRuleRequest(lb.ID,lbRule.TargetPort)})
+                    }
+                }
+            }
+
+        }
+
+    }
+
+    for _, ruleToAdd := range rulesToAdd {
+        _, err := l.client.Firewalls.AddRules(context.TODO(), ruleToAdd.firewallId, ruleToAdd.rules)
+        if(err!=nil){
+            log.Print("error creating firewall rule")
+            log.Print(err)
+        }
+
+    }
+
+    return nil
 }
 
 // UpdateLoadBalancer updates the load balancer for service to balance across
@@ -223,8 +351,75 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(clusterName string, service *v
 	}
 
 	_, err = l.client.LoadBalancers.Delete(ctx, lb.ID)
-	return err
+
+	if err != nil {
+		return err
+	}
+
+    err = l.EnsureFirewallDeleted(lb)
+    return err
 }
+
+func (l *loadbalancers) EnsureFirewallDeleted(lb *godo.LoadBalancer) (error) {
+    var ruleRequiresDeletion bool
+    var rulesToDelete []firewallRequest
+    var alreadyDeleted bool
+    //var completedFirewalls []string
+
+    for _, dropletid := range lb.DropletIDs {
+
+        firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(),dropletid,nil)
+
+        if err != nil {
+            log.Print("Something bad happened: %s\n\n", err)
+        }
+
+        if(len(firewalls)>0){
+            for _, lbRule := range lb.ForwardingRules {
+                ruleRequiresDeletion = false
+                //check each firewall to see if rule need deleting
+                for _, firewall := range firewalls {
+                    for _, fwInboundRule := range firewall.InboundRules {
+                        for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
+                            if(fwSourcelbs == lb.ID){
+                                    res := checkIfPortRequiresDeletion(lbRule.TargetPort,fwInboundRule.PortRange)
+                                    if(res && fwInboundRule.Protocol=="tcp"){
+                                        ruleRequiresDeletion = true
+                                    }
+                            }
+                        }
+                    }
+                }
+
+                if ( ruleRequiresDeletion == true){
+                    alreadyDeleted = false
+                    for _, ruleToDelete := range rulesToDelete {
+                        if(firewalls[0].ID == ruleToDelete.firewallId && lb.ID == ruleToDelete.rules.InboundRules[0].Sources.LoadBalancerUIDs[0] && strconv.Itoa(lbRule.TargetPort) == ruleToDelete.rules.InboundRules[0].PortRange){
+                            alreadyDeleted = true
+                        }
+                    }
+                    if(alreadyDeleted==false){
+                        rulesToDelete = append(rulesToDelete,firewallRequest{firewalls[0].ID,CreateFirewallsRuleRequest(lb.ID,lbRule.TargetPort)})
+                    }
+                }
+            }
+
+        }
+
+    }
+
+    for _, ruleToDelete := range rulesToDelete {
+        _, err := l.client.Firewalls.RemoveRules(context.TODO(), ruleToDelete.firewallId, ruleToDelete.rules)
+        if(err!=nil){
+            log.Print("error removing firewall rule")
+            log.Print(err)
+        }
+
+    }
+
+    return nil
+}
+
 
 // lbByName gets a DigitalOcean Load Balancer by name. The returned error will
 // be lbNotFound if the load balancer does not exist.

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -350,13 +350,12 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(clusterName string, service *v
 		return err
 	}
 
-	_, err = l.client.LoadBalancers.Delete(ctx, lb.ID)
-
+    err = l.EnsureFirewallDeleted(lb)
 	if err != nil {
 		return err
 	}
 
-    err = l.EnsureFirewallDeleted(lb)
+	_, err = l.client.LoadBalancers.Delete(ctx, lb.ID)
     return err
 }
 

--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -156,7 +156,7 @@ func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Servi
 			return nil, err
 		}
 
-		err = l.EnsureFirewall(lb)
+		_, err = l.EnsureFWRuleExists(lb)
 		if err != nil {
 			return nil, err
 		}
@@ -182,126 +182,6 @@ func (l *loadbalancers) EnsureLoadBalancer(clusterName string, service *v1.Servi
 
 	return lbStatus, nil
 
-}
-
-func checkIfPortInRange(port int, fwPortRange string) bool {
-
-	fwPortList := strings.Split(fwPortRange, "-")
-	if fwPortList[0] == "all" {
-		return true
-	}
-	if len(fwPortList) == 1 {
-		fwPort, _ := strconv.Atoi(fwPortList[0])
-		if port == fwPort {
-			return true
-		}
-	} else {
-		fwLowerVal, _ := strconv.Atoi(fwPortList[0])
-		fwUpperVal, _ := strconv.Atoi(fwPortList[1])
-		if port >= fwLowerVal && port <= fwUpperVal {
-			return true
-		}
-	}
-
-	return false
-
-}
-
-func checkIfPortRequiresDeletion(port int, fwPortRange string) bool {
-
-	fwPortList := strings.Split(fwPortRange, "-")
-	if fwPortList[0] == "all" {
-		return false
-	}
-	if len(fwPortList) == 1 {
-		fwPort, _ := strconv.Atoi(fwPortList[0])
-		if port == fwPort {
-			return true
-		}
-	}
-
-	return false
-
-}
-
-func CreateFirewallsRuleRequest(sourcelb string, targetPort int) *godo.FirewallRulesRequest {
-	rr := &godo.FirewallRulesRequest{
-		InboundRules: []godo.InboundRule{
-			{
-				Protocol:  "tcp",
-				PortRange: strconv.Itoa(targetPort),
-				Sources: &godo.Sources{
-					LoadBalancerUIDs: []string{sourcelb},
-				},
-			},
-		},
-	}
-	return rr
-}
-
-type firewallRequest struct {
-	firewallId string
-	rules      *godo.FirewallRulesRequest
-}
-
-// EnsureFirewall ensures that the node firewalls have the correct rules for
-// the load balancer.
-//
-// EnsureFirewall will not modify service or nodes.
-func (l *loadbalancers) EnsureFirewall(lb *godo.LoadBalancer) error {
-	var ruleExists bool
-	var rulesToAdd []firewallRequest
-	var alreadyAdded bool
-	//var completedFirewalls []string
-
-	for _, dropletid := range lb.DropletIDs {
-		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletid, nil)
-		if err != nil {
-			return fmt.Errorf("Error listing firewalls for droplet %d", dropletid)
-		}
-
-		if len(firewalls) > 0 {
-			for _, lbRule := range lb.ForwardingRules {
-				ruleExists = false
-				//check each firewall to see if rule already exists
-				for _, firewall := range firewalls {
-					for _, fwInboundRule := range firewall.InboundRules {
-						for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
-							if fwSourcelbs == lb.ID {
-								res := checkIfPortInRange(lbRule.TargetPort, fwInboundRule.PortRange)
-								if res && fwInboundRule.Protocol == "tcp" {
-									ruleExists = true
-								}
-							}
-						}
-					}
-				}
-
-				if ruleExists == false {
-					alreadyAdded = false
-					for _, ruleToAdd := range rulesToAdd {
-						if firewalls[0].ID == ruleToAdd.firewallId && lb.ID == ruleToAdd.rules.InboundRules[0].Sources.LoadBalancerUIDs[0] && strconv.Itoa(lbRule.TargetPort) == ruleToAdd.rules.InboundRules[0].PortRange {
-							alreadyAdded = true
-						}
-					}
-					if alreadyAdded == false {
-						rulesToAdd = append(rulesToAdd, firewallRequest{firewalls[0].ID, CreateFirewallsRuleRequest(lb.ID, lbRule.TargetPort)})
-					}
-				}
-			}
-
-		}
-
-	}
-
-	for _, ruleToAdd := range rulesToAdd {
-		_, err := l.client.Firewalls.AddRules(context.TODO(), ruleToAdd.firewallId, ruleToAdd.rules)
-		if err != nil {
-			return fmt.Errorf("Error adding rule to firewall %s", ruleToAdd.firewallId)
-		}
-	}
-
-	return nil
 }
 
 // UpdateLoadBalancer updates the load balancer for service to balance across
@@ -347,71 +227,13 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(clusterName string, service *v
 		return err
 	}
 
-	err = l.EnsureFirewallDeleted(lb)
+	_, err = l.EnsureFWRuleDeleted(lb)
 	if err != nil {
 		return err
 	}
 
 	_, err = l.client.LoadBalancers.Delete(ctx, lb.ID)
 	return err
-}
-
-func (l *loadbalancers) EnsureFirewallDeleted(lb *godo.LoadBalancer) error {
-	var ruleRequiresDeletion bool
-	var rulesToDelete []firewallRequest
-	var alreadyDeleted bool
-	//var completedFirewalls []string
-
-	for _, dropletid := range lb.DropletIDs {
-
-		firewalls, _, err := l.client.Firewalls.ListByDroplet(context.TODO(), dropletid, nil)
-
-		if err != nil {
-			return fmt.Errorf("Error listing firewalls for droplet %d", dropletid)
-		}
-
-		if len(firewalls) > 0 {
-			for _, lbRule := range lb.ForwardingRules {
-				ruleRequiresDeletion = false
-				//check each firewall to see if rule need deleting
-				for _, firewall := range firewalls {
-					for _, fwInboundRule := range firewall.InboundRules {
-						for _, fwSourcelbs := range fwInboundRule.Sources.LoadBalancerUIDs {
-							if fwSourcelbs == lb.ID {
-								res := checkIfPortRequiresDeletion(lbRule.TargetPort, fwInboundRule.PortRange)
-								if res && fwInboundRule.Protocol == "tcp" {
-									ruleRequiresDeletion = true
-								}
-							}
-						}
-					}
-				}
-
-				if ruleRequiresDeletion == true {
-					alreadyDeleted = false
-					for _, ruleToDelete := range rulesToDelete {
-						if firewalls[0].ID == ruleToDelete.firewallId && lb.ID == ruleToDelete.rules.InboundRules[0].Sources.LoadBalancerUIDs[0] && strconv.Itoa(lbRule.TargetPort) == ruleToDelete.rules.InboundRules[0].PortRange {
-							alreadyDeleted = true
-						}
-					}
-					if alreadyDeleted == false {
-						rulesToDelete = append(rulesToDelete, firewallRequest{firewalls[0].ID, CreateFirewallsRuleRequest(lb.ID, lbRule.TargetPort)})
-					}
-				}
-			}
-
-		}
-
-	}
-
-	for _, ruleToDelete := range rulesToDelete {
-		_, err := l.client.Firewalls.RemoveRules(context.TODO(), ruleToDelete.firewallId, ruleToDelete.rules)
-		if err != nil {
-			return fmt.Errorf("Error removing rule from firewall %s", ruleToDelete.firewallId)
-		}
-	}
-
-	return nil
 }
 
 // lbByName gets a DigitalOcean Load Balancer by name. The returned error will

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -1828,6 +1828,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 		dropletListFn   func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
 		listFn          func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
 		listByDropletFn func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+		addRulesFn      func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error)
 		createFn        func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
 		updateFn        func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
 		service         *v1.Service
@@ -1874,7 +1875,26 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				}, newFakeOKResponse(), nil
 			},
 			func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
-				return []godo.Firewall{}, newFakeOKResponse(), nil
+				return []godo.Firewall{
+					{
+						ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "80",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+					},
+				}, newFakeOKResponse(), nil
+			},
+			func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
+				// shouldn't be run in this test case
+				return newFakeOKResponse(), nil
 			},
 			func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 				// shouldn't be run in this test case
@@ -1975,7 +1995,26 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				return []godo.LoadBalancer{}, nil, nil
 			},
 			func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
-				return []godo.Firewall{}, newFakeOKResponse(), nil
+				return []godo.Firewall{
+					{
+						ID: "fb6045f1-cf1d-4ca3-bfac-18832663025b",
+						InboundRules: []godo.InboundRule{
+							{
+								Protocol:  "tcp",
+								PortRange: "80",
+								Sources: &godo.Sources{
+									LoadBalancerUIDs: []string{
+										"4de7ac8b-495b-4884-9a69-1050c6793cd6",
+									},
+								},
+							},
+						},
+					},
+				}, newFakeOKResponse(), nil
+			},
+			func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
+				//Simulate rules being added
+				return newFakeOKResponse(), nil
 			},
 			func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 				return &godo.LoadBalancer{
@@ -2048,6 +2087,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 			}
 			fakeFW := &fakeFWService{
 				listByDropletFn: test.listByDropletFn,
+				addRulesFn:      test.addRulesFn,
 			}
 
 			fakeClient := newFakeLBClient(fakeLB, fakeDroplet, fakeFW)

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -52,7 +52,6 @@ func (f *fakeLBService) List(ctx context.Context, listOpts *godo.ListOptions) ([
 	return f.listFn(ctx, listOpts)
 }
 
-
 func (f *fakeLBService) Create(ctx context.Context, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 	return f.createFn(ctx, lbr)
 }
@@ -81,48 +80,47 @@ func (f *fakeLBService) RemoveForwardingRules(ctx context.Context, lbID string, 
 }
 
 type fakeFWService struct {
-    addRulesFn              func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error)
-    createAndDoReqFn        func(ctx context.Context, method, path string, v interface{}) (*godo.Response, error)
-    getFn                   func(ctx context.Context, fID string) (*godo.Firewall, *godo.Response, error)
-    createFn                func(ctx context.Context, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
-    updateFn                func(ctx context.Context, fID string, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
-    deleteFn                func(ctx context.Context, fID string) (*godo.Response, error)
-    listFn                  func(ctx context.Context, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
-    listByDropletFn         func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
-    addDropletsFn           func(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error)
-    removeDropletsFn        func(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error)
-    addTagsFn               func(ctx context.Context, fID string, tags ...string) (*godo.Response, error)
-    removeTagsFn            func(ctx context.Context, fID string, tags ...string) (*godo.Response, error)
-    removeRulesFn           func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error)
+	addRulesFn       func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error)
+	createAndDoReqFn func(ctx context.Context, method, path string, v interface{}) (*godo.Response, error)
+	getFn            func(ctx context.Context, fID string) (*godo.Firewall, *godo.Response, error)
+	createFn         func(ctx context.Context, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+	updateFn         func(ctx context.Context, fID string, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+	deleteFn         func(ctx context.Context, fID string) (*godo.Response, error)
+	listFn           func(ctx context.Context, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+	listByDropletFn  func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+	addDropletsFn    func(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error)
+	removeDropletsFn func(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error)
+	addTagsFn        func(ctx context.Context, fID string, tags ...string) (*godo.Response, error)
+	removeTagsFn     func(ctx context.Context, fID string, tags ...string) (*godo.Response, error)
+	removeRulesFn    func(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error)
 }
 
-
 func (fw *fakeFWService) AddRules(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
-    return fw.addRulesFn(ctx, fID, rr)
+	return fw.addRulesFn(ctx, fID, rr)
 }
 
 func (fw *fakeFWService) createAndDoReq(ctx context.Context, method, path string, v interface{}) (*godo.Response, error) {
-    return fw.createAndDoReqFn(ctx, method, path, nil)
+	return fw.createAndDoReqFn(ctx, method, path, nil)
 }
 
 func (fw *fakeFWService) Get(ctx context.Context, fID string) (*godo.Firewall, *godo.Response, error) {
-    return fw.getFn(ctx, fID)
+	return fw.getFn(ctx, fID)
 }
 
 func (fw *fakeFWService) Create(ctx context.Context, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
-    return fw.createFn(ctx, fr)
+	return fw.createFn(ctx, fr)
 }
 
 func (fw *fakeFWService) Update(ctx context.Context, fID string, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
-    return fw.updateFn(ctx, fID, fr)
+	return fw.updateFn(ctx, fID, fr)
 }
 
 func (fw *fakeFWService) Delete(ctx context.Context, fID string) (*godo.Response, error) {
-    return fw.deleteFn(ctx, fID)
+	return fw.deleteFn(ctx, fID)
 }
 
 func (fw *fakeFWService) List(ctx context.Context, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
-    return fw.listFn(ctx, opt)
+	return fw.listFn(ctx, opt)
 }
 
 func (fw *fakeFWService) ListByDroplet(ctx context.Context, dID int, listOpts *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
@@ -130,23 +128,23 @@ func (fw *fakeFWService) ListByDroplet(ctx context.Context, dID int, listOpts *g
 }
 
 func (fw *fakeFWService) AddDroplets(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error) {
-    return fw.addDropletsFn(ctx, fID, dropletIDs...)
+	return fw.addDropletsFn(ctx, fID, dropletIDs...)
 }
 
 func (fw *fakeFWService) RemoveDroplets(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error) {
-    return fw.removeDropletsFn(ctx, fID, dropletIDs...)
+	return fw.removeDropletsFn(ctx, fID, dropletIDs...)
 }
 
 func (fw *fakeFWService) AddTags(ctx context.Context, fID string, tags ...string) (*godo.Response, error) {
-    return fw.addTagsFn(ctx, fID, tags...)
+	return fw.addTagsFn(ctx, fID, tags...)
 }
 
 func (fw *fakeFWService) RemoveTags(ctx context.Context, fID string, tags ...string) (*godo.Response, error) {
-    return fw.removeTagsFn(ctx, fID, tags...)
+	return fw.removeTagsFn(ctx, fID, tags...)
 }
 
 func (fw *fakeFWService) RemoveRules(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
-    return fw.removeRulesFn(ctx, fID, rr)
+	return fw.removeRulesFn(ctx, fID, rr)
 }
 
 func newFakeLBClient(fakeLB *fakeLBService, fakeDroplet *fakeDropletService, fakeFW *fakeFWService) *godo.Client {
@@ -1825,17 +1823,17 @@ func Test_GetLoadBalancer(t *testing.T) {
 
 func Test_EnsureLoadBalancer(t *testing.T) {
 	testcases := []struct {
-		name          string
-		getFn         func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error)
-		dropletListFn func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
-		listFn        func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
-        listByDropletFn func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
-		createFn      func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
-		updateFn      func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
-		service       *v1.Service
-		nodes         []*v1.Node
-		lbStatus      *v1.LoadBalancerStatus
-		err           error
+		name            string
+		getFn           func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error)
+		dropletListFn   func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
+		listFn          func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
+		listByDropletFn func(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+		createFn        func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
+		updateFn        func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
+		service         *v1.Service
+		nodes           []*v1.Node
+		lbStatus        *v1.LoadBalancerStatus
+		err             error
 	}{
 		{
 			"successfully ensured loadbalancer, already exists",
@@ -1940,21 +1938,21 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 			"successfully ensured loadbalancer that didn't exist",
 			func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error) {
 				return &godo.LoadBalancer{
-                    ID:     "4de7ac8b-495b-4884-9a69-1050c6793cd6",
-					Name:   "afoobar123",
-					IP:     "10.0.0.1",
-                    ForwardingRules: []godo.ForwardingRule{
-                        {
-                            EntryProtocol:  "http",
-                            EntryPort:      80,
-                            TargetProtocol: "http",
-                            TargetPort:     30000,
-                            CertificateID:  "",
-                            TlsPassthrough: false,
-                        },
-                    },
-                    DropletIDs: []int{100, 101, 102},
-					Status: lbStatusActive,
+					ID:   "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+					Name: "afoobar123",
+					IP:   "10.0.0.1",
+					ForwardingRules: []godo.ForwardingRule{
+						{
+							EntryProtocol:  "http",
+							EntryPort:      80,
+							TargetProtocol: "http",
+							TargetPort:     30000,
+							CertificateID:  "",
+							TlsPassthrough: false,
+						},
+					},
+					DropletIDs: []int{100, 101, 102},
+					Status:     lbStatusActive,
 				}, newFakeOKResponse(), nil
 			},
 			func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
@@ -2049,8 +2047,8 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				listFunc: test.dropletListFn,
 			}
 			fakeFW := &fakeFWService{
-                listByDropletFn: test.listByDropletFn,
-            }
+				listByDropletFn: test.listByDropletFn,
+			}
 
 			fakeClient := newFakeLBClient(fakeLB, fakeDroplet, fakeFW)
 

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -19,11 +19,10 @@ package do
 import (
 	"errors"
 	"fmt"
-	"reflect"
-	"testing"
-
 	"github.com/digitalocean/godo"
 	"github.com/digitalocean/godo/context"
+	"reflect"
+	"testing"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
This adds the ability for digitalocean-cloud-controller-manager to inspect the droplets which are part of a newly created load balancer and check whether they have an attached firewall. 

If a firewall is present, it then checks to see if a firewall rule is required to allow the load balancer to communicate with the droplet on the target port. 

Upon deletion of the load balancer, the reverse happens and the firewall rules are removed. 

I've tested this and it does appear to work. I think perhaps the firewall function mocks need pulling out into their own file and more tests need adding. 

There also needs to be some cleanup of the error handling/logging messages. Would be good to see if this works for anyone else. 