### PR TITLE
move apiextensions-apiserver and client-go to overrides

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -402,10 +402,10 @@
   revision = "4df58c811fe2e65feb879227b2b245e4dc26e7ad"
 
 [[projects]]
-  branch = "master"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
-  revision = "51a1910459f074162eb4e25233e461fe91e99405"
+  revision = "e509bb64fe1116e12a32273a2032426aa1a5fd26"
+  version = "kubernetes-1.8.2"
 
 [[projects]]
   branch = "release-1.8"
@@ -586,8 +586,8 @@
     "util/retry",
     "util/workqueue"
   ]
-  revision = "2ae454230481a7cb5544325e12ad7658ecccd19b"
-  version = "v5.0.1"
+  revision = "35ccd4336052e7d73018b1382413534936f34eee"
+  version = "kubernetes-1.8.2"
 
 [[projects]]
   branch = "master"
@@ -654,6 +654,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5531f38fc70ea52058e4c812486d1526bb1255c81f1b9b820a5199ab789713b4"
+  inputs-digest = "81985ebad47dd34c62a716cc7df8d4a5316f133a595f09c9d30e8d2ddbdde084"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,4 +1,3 @@
-
 # Gopkg.toml example
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
@@ -26,6 +25,14 @@
   #revision = "master"
   revision = "edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c"
 
+[[override]]
+  name = "k8s.io/apiextensions-apiserver"
+  version = "kubernetes-1.8.2"
+
+[[override]]
+  name = "k8s.io/client-go"
+  version = "kubernetes-1.8.2"
+
 [[constraint]]
   branch = "master"
   name = "github.com/digitalocean/godo"
@@ -52,14 +59,6 @@
 
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.8.2"
-
-[[constraint]]
-  name = "k8s.io/apiextensions-apiserver"
-  version = "kubernetes-1.8.2"
-
-[[constraint]]
-  name = "k8s.io/client-go"
   version = "kubernetes-1.8.2"
 
 [[constraint]]

--- a/vendor/k8s.io/apiextensions-apiserver/BUILD
+++ b/vendor/k8s.io/apiextensions-apiserver/BUILD
@@ -8,14 +8,12 @@ load(
 
 go_binary(
     name = "apiextensions-apiserver",
-    importpath = "k8s.io/apiextensions-apiserver",
     library = ":go_default_library",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "k8s.io/apiextensions-apiserver",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/cmd/server:go_default_library",

--- a/vendor/k8s.io/apiextensions-apiserver/README.md
+++ b/vendor/k8s.io/apiextensions-apiserver/README.md
@@ -1,6 +1,6 @@
 # apiextensions-apiserver
 
-Implements: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/thirdpartyresources.md
+Implements https://github.com/kubernetes/community/blob/master/contributors/design-proposals/thirdpartyresources.md
 
 It provides an API for registering `CustomResourceDefinitions`.
 
@@ -12,7 +12,7 @@ delegate server inside of `kube-apiserver`.
 
 ## Compatibility
 
-HEAD of this repo will match HEAD of k8s.io/apiserver, k8s.io/apimachinery, and k8s.io/client-go.
+HEAD of this repo will match HEAD of k8s.io/apiserver, k8s.io/apimachinvery, and k8s.io/client-go.
 
 ## Where does it come from?
 

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/features/BUILD
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/features/BUILD
@@ -8,7 +8,6 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["kube_features.go"],
-    importpath = "k8s.io/apiextensions-apiserver/pkg/features",
     deps = ["//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library"],
 )
 

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.8.1+$Format:%h$"
+	gitVersion   string = "v1.8.2+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
k8s.io/apiextensions-apiserver and k8s.io/client-go are transitive
dependencies, not direct dependencies, so need to be in the overrides
instead of the constraints.

After moving them and running dep ensure,the apiextensions-apiserver was
properly updated (it must have previously been vendored from the
kubernetes-1.8.1 tag that last time I upgraded k8s.io packages).