### PR TITLE
[load_balancer] add annotation for redirect_http_to_https option

### DIFF
--- a/do/loadbalancers.go
+++ b/do/loadbalancers.go
@@ -72,9 +72,9 @@ const (
 	// annDOStickySessionType is set to cookies.
 	annDOStickySessionsCookieTTL = "service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl"
 
-        // annDORedirectHttpToHttps is the annotation specifying whether or not Http traffic
-        // should be redirected to Https. Defaults to false
-        annDORedirectHttpToHttps = "service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https"
+	// annDORedirectHttpToHttps is the annotation specifying whether or not Http traffic
+	// should be redirected to Https. Defaults to false
+	annDORedirectHttpToHttps = "service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https"
 
 	// defaultActiveTimeout is the number of seconds to wait for a load balancer to
 	// reach the active state.
@@ -308,17 +308,17 @@ func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 
 	algorithm := getAlgorithm(service)
 
-        redirectHttpToHttps := getRedirectHttpToHttps(service)
+	redirectHttpToHttps := getRedirectHttpToHttps(service)
 
 	return &godo.LoadBalancerRequest{
-		Name:                   lbName,
-		DropletIDs:             dropletIDs,
-		Region:                 l.region,
-		ForwardingRules:        forwardingRules,
-		HealthCheck:            healthCheck,
-		StickySessions:         stickySessions,
-		Algorithm:              algorithm,
-                RedirectHttpToHttps:    redirectHttpToHttps,
+		Name:                lbName,
+		DropletIDs:          dropletIDs,
+		Region:              l.region,
+		ForwardingRules:     forwardingRules,
+		HealthCheck:         healthCheck,
+		StickySessions:      stickySessions,
+		Algorithm:           algorithm,
+		RedirectHttpToHttps: redirectHttpToHttps,
 	}, nil
 }
 

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -1080,6 +1080,74 @@ func Test_buildStickySessions(t *testing.T) {
 	}
 }
 
+func Test_getRedirectHttpToHttps(t *testing.T) {
+	testcases := []struct {
+		name                string
+		service             *v1.Service
+		redirectHttpToHttps bool
+	}{
+		{
+			"Redirect Http to Https true",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDORedirectHttpToHttps: "true",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"Redirect Http to Https false",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDORedirectHttpToHttps: "false",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"Redirect Http to Https not defined",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test",
+					UID:         "abc123",
+					Annotations: map[string]string{},
+				},
+			},
+			false,
+		},
+		{
+			"Service annotations nil",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+				},
+			},
+			false,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			redirectHttpToHttps := getRedirectHttpToHttps(test.service)
+			if redirectHttpToHttps != test.redirectHttpToHttps {
+				t.Error("unexpected redirect Http to Https")
+				t.Logf("expected: %t", test.redirectHttpToHttps)
+				t.Logf("actual: %t", redirectHttpToHttps)
+			}
+		})
+	}
+
+}
+
 func Test_buildLoadBalancerRequest(t *testing.T) {
 	testcases := []struct {
 		name          string

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -1418,6 +1418,107 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"successful load balancer request with redirect_http_to_https",
+			func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+				return []godo.Droplet{
+					{
+						ID:   100,
+						Name: "node-1",
+					},
+					{
+						ID:   101,
+						Name: "node-2",
+					},
+					{
+						ID:   102,
+						Name: "node-3",
+					},
+				}, newFakeOKResponse(), nil
+			},
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "foobar123",
+					Annotations: map[string]string{
+						annDOProtocol:            "http",
+						annDOAlgorithm:           "round_robin",
+						annDORedirectHttpToHttps: "true",
+						annDOTLSPorts:            "443",
+						annDOCertificateID:       "test-certificate",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(443),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			[]*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-3",
+					},
+				},
+			},
+			&godo.LoadBalancerRequest{
+				// cloudprovider.GetLoadBalancer name uses 'a' + service.UID
+				// as loadbalancer name
+				Name:       "afoobar123",
+				DropletIDs: []int{100, 101, 102},
+				Region:     "nyc3",
+				ForwardingRules: []godo.ForwardingRule{
+					{
+						EntryProtocol:  "http",
+						EntryPort:      80,
+						TargetProtocol: "http",
+						TargetPort:     30000,
+					},
+					{
+						EntryProtocol:  "https",
+						EntryPort:      443,
+						TargetProtocol: "http",
+						TargetPort:     30000,
+						CertificateID:  "test-certificate",
+					},
+				},
+				HealthCheck: &godo.HealthCheck{
+					Protocol:               "http",
+					Port:                   30000,
+					CheckIntervalSeconds:   3,
+					ResponseTimeoutSeconds: 5,
+					HealthyThreshold:       5,
+					UnhealthyThreshold:     3,
+				},
+				Algorithm:           "round_robin",
+				RedirectHttpToHttps: true,
+				StickySessions: &godo.StickySessions{
+					Type: "none",
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, test := range testcases {

--- a/do/loadbalancers_test.go
+++ b/do/loadbalancers_test.go
@@ -200,7 +200,7 @@ func Test_getTLSPassThrough(t *testing.T) {
 			false,
 		},
 		{
-			"Service annotatiosn nil",
+			"Service annotations nil",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",


### PR DESCRIPTION
Add the option to specify redirect_http_to_https on the DO load balancer resource using the annotation

```
service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https
```

As per the specification at https://developers.digitalocean.com/documentation/v2/#load-balancers this defaults to false.