### PR TITLE
README: add versioning process and support level

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,25 @@
 
 `digitalocean-cloud-controller-manager` is the Kubernetes cloud controller manager implementation for DigitalOcean. Read more about cloud controller managers [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/). Running `digitalocean-cloud-controller-manager` allows you to leverage many of the cloud provider features offered by DigitalOcean on your kubernetes clusters.
 
-**WARNING**: this project is a work in progress and may not be production ready.
+
+## Releases
+
+Cloud Controller Manager follows [semantic versioning](https://semver.org/).
+The current version is: **`v0.1.7`**. This means that the project is still
+under active development and may not be production ready. The plugin will be
+bumped to **`v1.0.0`** once the [DigitalOcean Kubernetes
+product](https://www.digitalocean.com/products/kubernetes/) is released and
+will continue following the rules below:
+
+* Bug fixes will be released as a `PATCH` update.
+* New features (such as CSI spec bumps) will be released as a `MINOR` update.
+* Significant breaking changes makes a `MAJOR` update.
+
+Because of the fast Kubernetes release cycles, CCM (Cloud Controller Manager)
+will **only** support the version that is _also_ supported on [DigitalOcean Kubernetes
+product](https://www.digitalocean.com/products/kubernetes/). Any other releases
+will be not officially supported by us.
+
 
 ## Getting Started!
 


### PR DESCRIPTION
Going forward we should have a known and strict policy about versioning
and set the expectations accordingly. This PR adds the related
information.

Note that I also changed which supports are officially supported by us.
This means replying to issues and handling bug fixes. We should not
maintain older versions or very new versions unless we also support it
on DigitalOcean Kubernetes. Currently we don't have the time and
manpower to support fully all Kubernetes versions.