### PR TITLE
Update golint import path to please the import path checker.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 dist: trusty
 
 script:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - make ci
 
 branches:


### PR DESCRIPTION
golint [introduced an import path check](https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58) recently.

Updating to the new path re-enables golint.