### PR TITLE
Rename http/s variable fragments to HTTP/S.

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -76,9 +76,9 @@ const (
 	// annDOStickySessionType is set to cookies.
 	annDOStickySessionsCookieTTL = "service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl"
 
-	// annDORedirectHttpToHttps is the annotation specifying whether or not Http traffic
+	// annDORedirectHTTPToHTTPS is the annotation specifying whether or not Http traffic
 	// should be redirected to Https. Defaults to false
-	annDORedirectHttpToHttps = "service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https"
+	annDORedirectHTTPToHTTPS = "service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https"
 
 	// defaultActiveTimeout is the number of seconds to wait for a load balancer to
 	// reach the active state.
@@ -312,7 +312,7 @@ func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 
 	algorithm := getAlgorithm(service)
 
-	redirectHttpToHttps := getRedirectHttpToHttps(service)
+	redirectHTTPToHTTPS := getRedirectHTTPToHTTPS(service)
 
 	return &godo.LoadBalancerRequest{
 		Name:                lbName,
@@ -322,7 +322,7 @@ func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 		HealthCheck:         healthCheck,
 		StickySessions:      stickySessions,
 		Algorithm:           algorithm,
-		RedirectHttpToHttps: redirectHttpToHttps,
+		RedirectHttpToHttps: redirectHTTPToHTTPS,
 	}, nil
 }
 
@@ -585,18 +585,18 @@ func getStickySessionsCookieTTL(service *v1.Service) (int, error) {
 	return strconv.Atoi(ttl)
 }
 
-// getRedirectHttpToHttps returns whether or not Http traffic should be redirected
+// getRedirectHTTPToHTTPS returns whether or not Http traffic should be redirected
 // to Https traffic for the loadbalancer. false is returned if not specified.
-func getRedirectHttpToHttps(service *v1.Service) bool {
-	redirectHttpToHttps, ok := service.Annotations[annDORedirectHttpToHttps]
+func getRedirectHTTPToHTTPS(service *v1.Service) bool {
+	redirectHTTPToHTTPS, ok := service.Annotations[annDORedirectHTTPToHTTPS]
 	if !ok {
 		return false
 	}
 
-	redirectHttpToHttpsBool, err := strconv.ParseBool(redirectHttpToHttps)
+	redirectHTTPToHTTPSBool, err := strconv.ParseBool(redirectHTTPToHTTPS)
 	if err != nil {
 		return false
 	}
 
-	return redirectHttpToHttpsBool
+	return redirectHTTPToHTTPSBool
 }

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1113,11 +1113,11 @@ func Test_buildStickySessions(t *testing.T) {
 	}
 }
 
-func Test_getRedirectHttpToHttps(t *testing.T) {
+func Test_getRedirectHTTPToHTTPS(t *testing.T) {
 	testcases := []struct {
 		name                string
 		service             *v1.Service
-		redirectHttpToHttps bool
+		redirectHTTPToHTTPS bool
 	}{
 		{
 			"Redirect Http to Https true",
@@ -1126,7 +1126,7 @@ func Test_getRedirectHttpToHttps(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORedirectHttpToHttps: "true",
+						annDORedirectHTTPToHTTPS: "true",
 					},
 				},
 			},
@@ -1139,7 +1139,7 @@ func Test_getRedirectHttpToHttps(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORedirectHttpToHttps: "false",
+						annDORedirectHTTPToHTTPS: "false",
 					},
 				},
 			},
@@ -1170,11 +1170,11 @@ func Test_getRedirectHttpToHttps(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			redirectHttpToHttps := getRedirectHttpToHttps(test.service)
-			if redirectHttpToHttps != test.redirectHttpToHttps {
+			redirectHTTPToHTTPS := getRedirectHTTPToHTTPS(test.service)
+			if redirectHTTPToHTTPS != test.redirectHTTPToHTTPS {
 				t.Error("unexpected redirect Http to Https")
-				t.Logf("expected: %t", test.redirectHttpToHttps)
-				t.Logf("actual: %t", redirectHttpToHttps)
+				t.Logf("expected: %t", test.redirectHTTPToHTTPS)
+				t.Logf("actual: %t", redirectHTTPToHTTPS)
 			}
 		})
 	}
@@ -1478,7 +1478,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Annotations: map[string]string{
 						annDOProtocol:            "http",
 						annDOAlgorithm:           "round_robin",
-						annDORedirectHttpToHttps: "true",
+						annDORedirectHTTPToHTTPS: "true",
 						annDOTLSPorts:            "443",
 						annDOCertificateID:       "test-certificate",
 					},


### PR DESCRIPTION
Addresses the following golint complaints:

```
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers.go:81:2: const annDORedirectHttpToHttps should be annDORedirectHTTPToHTTPS
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers.go:315:2: var redirectHttpToHttps should be redirectHTTPToHTTPS
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers.go:590:6: func getRedirectHttpToHttps should be getRedirectHTTPToHTTPS
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers.go:591:2: var redirectHttpToHttps should be redirectHTTPToHTTPS
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers.go:596:2: var redirectHttpToHttpsBool should be redirectHTTPToHTTPSBool
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers_test.go:1120:3: struct field redirectHttpToHttps should be redirectHTTPToHTTPS
/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do/loadbalancers_test.go:1173:4: var redirectHttpToHttps should be redirectHTTPToHTTPS
```