### PR TITLE
Tag created load balancers with existing cluster ID.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -87,12 +87,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:2681dc88c16e1c1391db61bd22063891fac3c59445c3ee64aa0ddd03ee17b217"
+  digest = "1:ea3b7e0433c21fd9d3db5ab2a3c55359835aecd5f83e3d514bc3f47e84933113"
   name = "github.com/digitalocean/godo"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "51f18c0e42941703dc13d15bc0ad69aef6a49830"
-  version = "v1.3.0"
+  revision = "360ee5cab86ffe07b3d5009a3bbb658862c55cf8"
+  version = "v1.7.3"
 
 [[projects]]
   digest = "1:4189ee6a3844f555124d9d2656fe7af02fca961c2a9bad9074789df13a0c62e0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,7 +43,7 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[constraint]]
-  version = "v1.2.0"
+  version = "v1.7.3"
   name = "github.com/digitalocean/godo"
 
 [[constraint]]

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -32,6 +32,7 @@ import (
 const (
 	doAccessTokenEnv    string = "DO_ACCESS_TOKEN"
 	doOverrideAPIURLEnv string = "DO_OVERRIDE_URL"
+	doClusterIDEnv      string = "DO_CLUSTER_ID"
 	providerName        string = "digitalocean"
 )
 
@@ -81,11 +82,13 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("failed to get region from droplet metadata: %s", err)
 	}
 
+	clusterID := os.Getenv(doClusterIDEnv)
+
 	return &cloud{
 		client:        doClient,
 		instances:     newInstances(doClient, region),
 		zones:         newZones(doClient, region),
-		loadbalancers: newLoadBalancers(doClient, region),
+		loadbalancers: newLoadBalancers(doClient, region, clusterID),
 	}, nil
 }
 

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 
 	"github.com/digitalocean/godo"

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 
 	"github.com/digitalocean/godo"
@@ -104,13 +104,20 @@ var errLBNotFound = errors.New("loadbalancer not found")
 type loadBalancers struct {
 	client            *godo.Client
 	region            string
+	clusterID         string
 	lbActiveTimeout   int
 	lbActiveCheckTick int
 }
 
-// newLoadBalancers returns a cloudprovider.LoadBalancer whose concrete type is a *loadbalancer.
-func newLoadBalancers(client *godo.Client, region string) cloudprovider.LoadBalancer {
-	return &loadBalancers{client, region, defaultActiveTimeout, defaultActiveCheckTick}
+// newLoadbalancers returns a cloudprovider.LoadBalancer whose concrete type is a *loadbalancer.
+func newLoadBalancers(client *godo.Client, region, clusterID string) cloudprovider.LoadBalancer {
+	return &loadBalancers{
+		client:            client,
+		region:            region,
+		clusterID:         clusterID,
+		lbActiveTimeout:   defaultActiveTimeout,
+		lbActiveCheckTick: defaultActiveCheckTick,
+	}
 }
 
 // GetLoadBalancer returns the *v1.LoadBalancerStatus of service.
@@ -319,6 +326,11 @@ func (l *loadBalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 
 	redirectHTTPToHTTPS := getRedirectHTTPToHTTPS(service)
 
+	var tags []string
+	if l.clusterID != "" {
+		tags = []string{l.clusterID}
+	}
+
 	return &godo.LoadBalancerRequest{
 		Name:                lbName,
 		DropletIDs:          dropletIDs,
@@ -326,6 +338,7 @@ func (l *loadBalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 		ForwardingRules:     forwardingRules,
 		HealthCheck:         healthCheck,
 		StickySessions:      stickySessions,
+		Tags:                tags,
 		Algorithm:           algorithm,
 		RedirectHttpToHttps: redirectHTTPToHTTPS,
 	}, nil

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/digitalocean/godo"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/digitalocean/godo"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
@@ -1706,7 +1706,12 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 			fakeDroplet.listFunc = test.dropletListFn
 			fakeClient := newFakeLBClient(&fakeLBService{}, fakeDroplet)
 
-			lb := &loadBalancers{fakeClient, "nyc3", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc3",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 
 			lbr, err := lb.buildLoadBalancerRequest(test.service, test.nodes)
 
@@ -1723,6 +1728,58 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func Test_buildLoadBalancerRequestWithClusterID(t *testing.T) {
+	fakeDropletSvc := &fakeDropletService{
+		listFunc: func(context.Context, *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+			return []godo.Droplet{
+				{
+					ID:   100,
+					Name: "node-1",
+				},
+			}, newFakeOKResponse(), nil
+		},
+	}
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test",
+					Protocol: "TCP",
+					Port:     int32(80),
+					NodePort: int32(30000),
+				},
+			},
+		},
+	}
+	nodes := []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node-1",
+			},
+		},
+	}
+	fakeClient := newFakeLBClient(&fakeLBService{}, fakeDropletSvc)
+
+	wantTags := []string{"fdda2d9d-0856-4ca4-b8ee-27ca8bfecc77"}
+	lb := &loadBalancers{
+		client:    fakeClient,
+		region:    "nyc3",
+		clusterID: wantTags[0],
+	}
+
+	lbr, err := lb.buildLoadBalancerRequest(service, nodes)
+	if err != nil {
+		t.Errorf("got error: %s", err)
+	}
+
+	if !reflect.DeepEqual(lbr.Tags, wantTags) {
+		t.Errorf("got tags %q, want %q", lbr.Tags, wantTags)
 	}
 }
 
@@ -1851,7 +1908,12 @@ func Test_nodeToDropletIDs(t *testing.T) {
 			fakeDroplet.listFunc = test.dropletListFn
 			fakeClient := newFakeLBClient(&fakeLBService{}, fakeDroplet)
 
-			lb := &loadBalancers{fakeClient, "nyc1", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc1",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 			dropletIDs, err := lb.nodesToDropletIDs(test.nodes)
 			if !reflect.DeepEqual(dropletIDs, test.dropletIDs) {
 				t.Error("unexpected droplet IDs")
@@ -1923,7 +1985,12 @@ func Test_lbByName(t *testing.T) {
 			fakeLB.listFn = test.listFn
 			fakeClient := newFakeLBClient(fakeLB, &fakeDropletService{})
 
-			lb := &loadBalancers{fakeClient, "nyc1", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc1",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 			loadbalancer, err := lb.lbByName(context.TODO(), test.lbName)
 
 			if !reflect.DeepEqual(loadbalancer, test.loadbalancer) {
@@ -2074,7 +2141,12 @@ func Test_GetLoadBalancer(t *testing.T) {
 			fakeLB.listFn = test.listFn
 			fakeClient := newFakeLBClient(fakeLB, &fakeDropletService{})
 
-			lb := &loadBalancers{fakeClient, "nyc1", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc1",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 
 			// we don't actually use clusterName param in GetLoadBalancer
 			lbStatus, exists, err := lb.GetLoadBalancer(context.TODO(), "test", test.service)
@@ -2308,7 +2380,12 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 			}
 			fakeClient := newFakeLBClient(fakeLB, fakeDroplet)
 
-			lb := &loadBalancers{fakeClient, "nyc1", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc1",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 
 			// clusterName param in EnsureLoadBalancer currently not used
 			lbStatus, err := lb.EnsureLoadBalancer(context.TODO(), "test", test.service, test.nodes)
@@ -2386,7 +2463,12 @@ func Test_waitActive(t *testing.T) {
 
 			fakeClient := newFakeLBClient(fakeLB, nil)
 
-			lb := &loadBalancers{fakeClient, "nyc1", 2, 1}
+			lb := &loadBalancers{
+				client:            fakeClient,
+				region:            "nyc1",
+				lbActiveTimeout:   2,
+				lbActiveCheckTick: 1,
+			}
 
 			lbStatus, err := lb.waitActive("lb1")
 			if !reflect.DeepEqual(lbStatus, test.lbStatus) {

--- a/vendor/github.com/digitalocean/godo/account.go
+++ b/vendor/github.com/digitalocean/godo/account.go
@@ -24,6 +24,7 @@ var _ AccountService = &AccountServiceOp{}
 type Account struct {
 	DropletLimit    int    `json:"droplet_limit,omitempty"`
 	FloatingIPLimit int    `json:"floating_ip_limit,omitempty"`
+	VolumeLimit     int    `json:"volume_limit,omitempty"`
 	Email           string `json:"email,omitempty"`
 	UUID            string `json:"uuid,omitempty"`
 	EmailVerified   bool   `json:"email_verified,omitempty"`

--- a/vendor/github.com/digitalocean/godo/cdn.go
+++ b/vendor/github.com/digitalocean/godo/cdn.go
@@ -1,0 +1,195 @@
+package godo
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const cdnBasePath = "v2/cdn/endpoints"
+
+// CDNService is an interface for managing Spaces CDN with the DigitalOcean API.
+type CDNService interface {
+	List(context.Context, *ListOptions) ([]CDN, *Response, error)
+	Get(context.Context, string) (*CDN, *Response, error)
+	Create(context.Context, *CDNCreateRequest) (*CDN, *Response, error)
+	UpdateTTL(context.Context, string, *CDNUpdateRequest) (*CDN, *Response, error)
+	FlushCache(context.Context, string, *CDNFlushCacheRequest) (*Response, error)
+	Delete(context.Context, string) (*Response, error)
+}
+
+// CDNServiceOp handles communication with the CDN related methods of the
+// DigitalOcean API.
+type CDNServiceOp struct {
+	client *Client
+}
+
+var _ CDNService = &CDNServiceOp{}
+
+// CDN represents a DigitalOcean CDN
+type CDN struct {
+	ID        string    `json:"id"`
+	Origin    string    `json:"origin"`
+	Endpoint  string    `json:"endpoint"`
+	CreatedAt time.Time `json:"created_at"`
+	TTL       uint32    `json:"ttl"`
+}
+
+// CDNRoot represents a response from the DigitalOcean API
+type cdnRoot struct {
+	Endpoint *CDN `json:"endpoint"`
+}
+
+type cdnsRoot struct {
+	Endpoints []CDN  `json:"endpoints"`
+	Links     *Links `json:"links"`
+}
+
+// CDNCreateRequest represents a request to create a CDN.
+type CDNCreateRequest struct {
+	Origin string `json:"origin"`
+	TTL    uint32 `json:"ttl"`
+}
+
+// CDNUpdateRequest represents a request to update the ttl of a CDN.
+type CDNUpdateRequest struct {
+	TTL uint32 `json:"ttl"`
+}
+
+// CDNFlushCacheRequest represents a request to flush cache of a CDN.
+type CDNFlushCacheRequest struct {
+	Files []string `json:"files"`
+}
+
+// List all CDN endpoints
+func (c CDNServiceOp) List(ctx context.Context, opt *ListOptions) ([]CDN, *Response, error) {
+	path, err := addOptions(cdnBasePath, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := c.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(cdnsRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Endpoints, resp, err
+}
+
+// Get individual CDN. It requires a non-empty cdn id.
+func (c CDNServiceOp) Get(ctx context.Context, id string) (*CDN, *Response, error) {
+	if len(id) == 0 {
+		return nil, nil, NewArgError("id", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s", cdnBasePath, id)
+
+	req, err := c.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(cdnRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Endpoint, resp, err
+}
+
+// Create a new CDN
+func (c CDNServiceOp) Create(ctx context.Context, createRequest *CDNCreateRequest) (*CDN, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := c.client.NewRequest(ctx, http.MethodPost, cdnBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(cdnRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Endpoint, resp, err
+}
+
+// UpdateTTL updates the ttl of individual CDN
+func (c CDNServiceOp) UpdateTTL(ctx context.Context, id string, updateRequest *CDNUpdateRequest) (*CDN, *Response, error) {
+	if updateRequest == nil {
+		return nil, nil, NewArgError("updateRequest", "cannot be nil")
+	}
+
+	if len(id) == 0 {
+		return nil, nil, NewArgError("id", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s", cdnBasePath, id)
+
+	req, err := c.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(cdnRoot)
+	resp, err := c.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Endpoint, resp, err
+}
+
+// FlushCache flushes the cache of an individual CDN. Requires a non-empty slice of file paths and/or wildcards
+func (c CDNServiceOp) FlushCache(ctx context.Context, id string, flushCacheRequest *CDNFlushCacheRequest) (*Response, error) {
+	if flushCacheRequest == nil {
+		return nil, NewArgError("flushCacheRequest", "cannot be nil")
+	}
+
+	if len(id) == 0 {
+		return nil, NewArgError("id", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s/cache", cdnBasePath, id)
+
+	req, err := c.client.NewRequest(ctx, http.MethodDelete, path, flushCacheRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(ctx, req, nil)
+
+	return resp, err
+}
+
+// Delete an individual CDN
+func (c CDNServiceOp) Delete(ctx context.Context, id string) (*Response, error) {
+	if len(id) == 0 {
+		return nil, NewArgError("id", "cannot be an empty string")
+	}
+
+	path := fmt.Sprintf("%s/%s", cdnBasePath, id)
+
+	req, err := c.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/vendor/github.com/digitalocean/godo/domains.go
+++ b/vendor/github.com/digitalocean/godo/domains.go
@@ -52,7 +52,7 @@ type domainsRoot struct {
 // DomainCreateRequest respresents a request to create a domain.
 type DomainCreateRequest struct {
 	Name      string `json:"name"`
-	IPAddress string `json:"ip_address"`
+	IPAddress string `json:"ip_address,omitempty"`
 }
 
 // DomainRecordRoot is the root of an individual Domain Record response
@@ -72,10 +72,10 @@ type DomainRecord struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority,omitempty"`
+	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
@@ -85,16 +85,20 @@ type DomainRecordEditRequest struct {
 	Type     string `json:"type,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Data     string `json:"data,omitempty"`
-	Priority int    `json:"priority,omitempty"`
+	Priority int    `json:"priority"`
 	Port     int    `json:"port,omitempty"`
 	TTL      int    `json:"ttl,omitempty"`
-	Weight   int    `json:"weight,omitempty"`
+	Weight   int    `json:"weight"`
 	Flags    int    `json:"flags"`
 	Tag      string `json:"tag,omitempty"`
 }
 
 func (d Domain) String() string {
 	return Stringify(d)
+}
+
+func (d Domain) URN() string {
+	return ToURN("Domain", d.Name)
 }
 
 // List all domains.

--- a/vendor/github.com/digitalocean/godo/droplets.go
+++ b/vendor/github.com/digitalocean/godo/droplets.go
@@ -125,6 +125,10 @@ func (d Droplet) String() string {
 	return Stringify(d)
 }
 
+func (d Droplet) URN() string {
+	return ToURN("Droplet", d.ID)
+}
+
 // DropletRoot represents a Droplet root
 type dropletRoot struct {
 	Droplet *Droplet `json:"droplet"`

--- a/vendor/github.com/digitalocean/godo/firewalls.go
+++ b/vendor/github.com/digitalocean/godo/firewalls.go
@@ -49,6 +49,10 @@ func (fw Firewall) String() string {
 	return Stringify(fw)
 }
 
+func (fw Firewall) URN() string {
+	return ToURN("Firewall", fw.ID)
+}
+
 // FirewallRequest represents the configuration to be applied to an existing or a new Firewall.
 type FirewallRequest struct {
 	Name          string         `json:"name"`

--- a/vendor/github.com/digitalocean/godo/floating_ips.go
+++ b/vendor/github.com/digitalocean/godo/floating_ips.go
@@ -37,6 +37,10 @@ func (f FloatingIP) String() string {
 	return Stringify(f)
 }
 
+func (f FloatingIP) URN() string {
+	return ToURN("FloatingIP", f.IP)
+}
+
 type floatingIPsRoot struct {
 	FloatingIPs []FloatingIP `json:"floating_ips"`
 	Links       *Links       `json:"links"`

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.3.0"
+	libraryVersion = "1.6.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"
@@ -46,6 +46,7 @@ type Client struct {
 	// Services used for communicating with the API
 	Account           AccountService
 	Actions           ActionsService
+	CDNs              CDNService
 	Domains           DomainsService
 	Droplets          DropletsService
 	DropletActions    DropletActionsService
@@ -63,6 +64,8 @@ type Client struct {
 	LoadBalancers     LoadBalancersService
 	Certificates      CertificatesService
 	Firewalls         FirewallsService
+	Projects          ProjectsService
+	Kubernetes        KubernetesService
 
 	// Optional function called after every successful request made to the DO APIs
 	onRequestCompleted RequestCompletionCallback
@@ -157,23 +160,26 @@ func NewClient(httpClient *http.Client) *Client {
 	c := &Client{client: httpClient, BaseURL: baseURL, UserAgent: userAgent}
 	c.Account = &AccountServiceOp{client: c}
 	c.Actions = &ActionsServiceOp{client: c}
+	c.CDNs = &CDNServiceOp{client: c}
+	c.Certificates = &CertificatesServiceOp{client: c}
 	c.Domains = &DomainsServiceOp{client: c}
 	c.Droplets = &DropletsServiceOp{client: c}
 	c.DropletActions = &DropletActionsServiceOp{client: c}
+	c.Firewalls = &FirewallsServiceOp{client: c}
 	c.FloatingIPs = &FloatingIPsServiceOp{client: c}
 	c.FloatingIPActions = &FloatingIPActionsServiceOp{client: c}
 	c.Images = &ImagesServiceOp{client: c}
 	c.ImageActions = &ImageActionsServiceOp{client: c}
 	c.Keys = &KeysServiceOp{client: c}
+	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
+	c.Projects = &ProjectsServiceOp{client: c}
 	c.Regions = &RegionsServiceOp{client: c}
-	c.Snapshots = &SnapshotsServiceOp{client: c}
 	c.Sizes = &SizesServiceOp{client: c}
+	c.Snapshots = &SnapshotsServiceOp{client: c}
 	c.Storage = &StorageServiceOp{client: c}
 	c.StorageActions = &StorageActionsServiceOp{client: c}
 	c.Tags = &TagsServiceOp{client: c}
-	c.LoadBalancers = &LoadBalancersServiceOp{client: c}
-	c.Certificates = &CertificatesServiceOp{client: c}
-	c.Firewalls = &FirewallsServiceOp{client: c}
+	c.Kubernetes = &KubernetesServiceOp{client: c}
 
 	return c
 }

--- a/vendor/github.com/digitalocean/godo/images.go
+++ b/vendor/github.com/digitalocean/godo/images.go
@@ -16,8 +16,10 @@ type ImagesService interface {
 	ListDistribution(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
 	ListApplication(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
 	ListUser(ctx context.Context, opt *ListOptions) ([]Image, *Response, error)
+	ListByTag(ctx context.Context, tag string, opt *ListOptions) ([]Image, *Response, error)
 	GetByID(context.Context, int) (*Image, *Response, error)
 	GetBySlug(context.Context, string) (*Image, *Response, error)
+	Create(context.Context, *CustomImageCreateRequest) (*Image, *Response, error)
 	Update(context.Context, int, *ImageUpdateRequest) (*Image, *Response, error)
 	Delete(context.Context, int) (*Response, error)
 }
@@ -32,20 +34,35 @@ var _ ImagesService = &ImagesServiceOp{}
 
 // Image represents a DigitalOcean Image
 type Image struct {
-	ID           int      `json:"id,float64,omitempty"`
-	Name         string   `json:"name,omitempty"`
-	Type         string   `json:"type,omitempty"`
-	Distribution string   `json:"distribution,omitempty"`
-	Slug         string   `json:"slug,omitempty"`
-	Public       bool     `json:"public,omitempty"`
-	Regions      []string `json:"regions,omitempty"`
-	MinDiskSize  int      `json:"min_disk_size,omitempty"`
-	Created      string   `json:"created_at,omitempty"`
+	ID            int      `json:"id,float64,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Type          string   `json:"type,omitempty"`
+	Distribution  string   `json:"distribution,omitempty"`
+	Slug          string   `json:"slug,omitempty"`
+	Public        bool     `json:"public,omitempty"`
+	Regions       []string `json:"regions,omitempty"`
+	MinDiskSize   int      `json:"min_disk_size,omitempty"`
+	SizeGigaBytes float64  `json:"size_gigabytes,omitempty"`
+	Created       string   `json:"created_at,omitempty"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	ErrorMessage  string   `json:"error_message,omitempty"`
 }
 
 // ImageUpdateRequest represents a request to update an image.
 type ImageUpdateRequest struct {
 	Name string `json:"name"`
+}
+
+// CustomImageCreateRequest represents a request to create a custom image.
+type CustomImageCreateRequest struct {
+	Name         string   `json:"name"`
+	Url          string   `json:"url"`
+	Region       string   `json:"region"`
+	Distribution string   `json:"distribution,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
 }
 
 type imageRoot struct {
@@ -60,6 +77,7 @@ type imagesRoot struct {
 type listImageOptions struct {
 	Private bool   `url:"private,omitempty"`
 	Type    string `url:"type,omitempty"`
+	Tag     string `url:"tag_name,omitempty"`
 }
 
 func (i Image) String() string {
@@ -89,6 +107,12 @@ func (s *ImagesServiceOp) ListUser(ctx context.Context, opt *ListOptions) ([]Ima
 	return s.list(ctx, opt, &listOpt)
 }
 
+// ListByTag lists all images with a specific tag applied.
+func (s *ImagesServiceOp) ListByTag(ctx context.Context, tag string, opt *ListOptions) ([]Image, *Response, error) {
+	listOpt := listImageOptions{Tag: tag}
+	return s.list(ctx, opt, &listOpt)
+}
+
 // GetByID retrieves an image by id.
 func (s *ImagesServiceOp) GetByID(ctx context.Context, imageID int) (*Image, *Response, error) {
 	if imageID < 1 {
@@ -107,6 +131,25 @@ func (s *ImagesServiceOp) GetBySlug(ctx context.Context, slug string) (*Image, *
 	return s.get(ctx, interface{}(slug))
 }
 
+func (s *ImagesServiceOp) Create(ctx context.Context, createRequest *CustomImageCreateRequest) (*Image, *Response, error) {
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, imageBasePath, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(imageRoot)
+	resp, err := s.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Image, resp, err
+}
+
 // Update an image name.
 func (s *ImagesServiceOp) Update(ctx context.Context, imageID int, updateRequest *ImageUpdateRequest) (*Image, *Response, error) {
 	if imageID < 1 {
@@ -118,7 +161,7 @@ func (s *ImagesServiceOp) Update(ctx context.Context, imageID int, updateRequest
 	}
 
 	path := fmt.Sprintf("%s/%d", imageBasePath, imageID)
-	req, err := s.client.NewRequest(ctx, "PUT", path, updateRequest)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, updateRequest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -1,0 +1,432 @@
+package godo
+
+import (
+	"bytes"
+	"context"
+	"encoding"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	kubernetesBasePath     = "/v2/kubernetes"
+	kubernetesClustersPath = kubernetesBasePath + "/clusters"
+	kubernetesOptionsPath  = kubernetesBasePath + "/options"
+)
+
+// KubernetesService is an interface for interfacing with the kubernetes endpoints
+// of the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/v2#kubernetes
+type KubernetesService interface {
+	Create(context.Context, *KubernetesClusterCreateRequest) (*KubernetesCluster, *Response, error)
+	Get(context.Context, string) (*KubernetesCluster, *Response, error)
+	GetKubeConfig(context.Context, string) (*KubernetesClusterConfig, *Response, error)
+	List(context.Context, *ListOptions) ([]*KubernetesCluster, *Response, error)
+	Update(context.Context, string, *KubernetesClusterUpdateRequest) (*KubernetesCluster, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+
+	CreateNodePool(ctx context.Context, clusterID string, req *KubernetesNodePoolCreateRequest) (*KubernetesNodePool, *Response, error)
+	GetNodePool(ctx context.Context, clusterID, poolID string) (*KubernetesNodePool, *Response, error)
+	ListNodePools(ctx context.Context, clusterID string, opts *ListOptions) ([]*KubernetesNodePool, *Response, error)
+	UpdateNodePool(ctx context.Context, clusterID, poolID string, req *KubernetesNodePoolUpdateRequest) (*KubernetesNodePool, *Response, error)
+	RecycleNodePoolNodes(ctx context.Context, clusterID, poolID string, req *KubernetesNodePoolRecycleNodesRequest) (*Response, error)
+	DeleteNodePool(ctx context.Context, clusterID, poolID string) (*Response, error)
+
+	GetOptions(context.Context) (*KubernetesOptions, *Response, error)
+}
+
+var _ KubernetesService = &KubernetesServiceOp{}
+
+// KubernetesServiceOp handles communication with Kubernetes methods of the DigitalOcean API.
+type KubernetesServiceOp struct {
+	client *Client
+}
+
+// KubernetesClusterCreateRequest represents a request to create a Kubernetes cluster.
+type KubernetesClusterCreateRequest struct {
+	Name        string   `json:"name,omitempty"`
+	RegionSlug  string   `json:"region,omitempty"`
+	VersionSlug string   `json:"version,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+
+	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
+}
+
+// KubernetesClusterUpdateRequest represents a request to update a Kubernetes cluster.
+type KubernetesClusterUpdateRequest struct {
+	Name string   `json:"name,omitempty"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+// KubernetesNodePoolCreateRequest represents a request to create a node pool for a
+// Kubernetes cluster.
+type KubernetesNodePoolCreateRequest struct {
+	Name  string   `json:"name,omitempty"`
+	Size  string   `json:"size,omitempty"`
+	Count int      `json:"count,omitempty"`
+	Tags  []string `json:"tags,omitempty"`
+}
+
+// KubernetesNodePoolUpdateRequest represents a request to update a node pool in a
+// Kubernetes cluster.
+type KubernetesNodePoolUpdateRequest struct {
+	Name  string   `json:"name,omitempty"`
+	Count int      `json:"count,omitempty"`
+	Tags  []string `json:"tags,omitempty"`
+}
+
+// KubernetesNodePoolRecycleNodesRequest represents a request to recycle a set of
+// nodes in a node pool. This will recycle the nodes by ID.
+type KubernetesNodePoolRecycleNodesRequest struct {
+	Nodes []string `json:"nodes,omitempty"`
+}
+
+// KubernetesCluster represents a Kubernetes cluster.
+type KubernetesCluster struct {
+	ID            string   `json:"id,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	RegionSlug    string   `json:"region,omitempty"`
+	VersionSlug   string   `json:"version,omitempty"`
+	ClusterSubnet string   `json:"cluster_subnet,omitempty"`
+	ServiceSubnet string   `json:"service_subnet,omitempty"`
+	IPv4          string   `json:"ipv4,omitempty"`
+	Endpoint      string   `json:"endpoint,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+
+	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
+
+	Status    *KubernetesClusterStatus `json:"status,omitempty"`
+	CreatedAt time.Time                `json:"created_at,omitempty"`
+	UpdatedAt time.Time                `json:"updated_at,omitempty"`
+}
+
+// Possible states for a cluster.
+const (
+	KubernetesClusterStatusProvisioning = KubernetesClusterStatusState("provisioning")
+	KubernetesClusterStatusRunning      = KubernetesClusterStatusState("running")
+	KubernetesClusterStatusDegraded     = KubernetesClusterStatusState("degraded")
+	KubernetesClusterStatusError        = KubernetesClusterStatusState("error")
+	KubernetesClusterStatusDeleted      = KubernetesClusterStatusState("deleted")
+	KubernetesClusterStatusInvalid      = KubernetesClusterStatusState("invalid")
+)
+
+// KubernetesClusterStatusState represents states for a cluster.
+type KubernetesClusterStatusState string
+
+var _ encoding.TextUnmarshaler = (*KubernetesClusterStatusState)(nil)
+
+// UnmarshalText unmarshals the state.
+func (s *KubernetesClusterStatusState) UnmarshalText(text []byte) error {
+	switch KubernetesClusterStatusState(strings.ToLower(string(text))) {
+	case KubernetesClusterStatusProvisioning:
+		*s = KubernetesClusterStatusProvisioning
+	case KubernetesClusterStatusRunning:
+		*s = KubernetesClusterStatusRunning
+	case KubernetesClusterStatusDegraded:
+		*s = KubernetesClusterStatusDegraded
+	case KubernetesClusterStatusError:
+		*s = KubernetesClusterStatusError
+	case KubernetesClusterStatusDeleted:
+		*s = KubernetesClusterStatusDeleted
+	case "", KubernetesClusterStatusInvalid:
+		*s = KubernetesClusterStatusInvalid
+	default:
+		return fmt.Errorf("unknown cluster state %q", string(text))
+	}
+	return nil
+}
+
+// KubernetesClusterStatus describes the status of a cluster.
+type KubernetesClusterStatus struct {
+	State   KubernetesClusterStatusState `json:"state,omitempty"`
+	Message string                       `json:"message,omitempty"`
+}
+
+// KubernetesNodePool represents a node pool in a Kubernetes cluster.
+type KubernetesNodePool struct {
+	ID    string   `json:"id,omitempty"`
+	Name  string   `json:"name,omitempty"`
+	Size  string   `json:"size,omitempty"`
+	Count int      `json:"count,omitempty"`
+	Tags  []string `json:"tags,omitempty"`
+
+	Nodes []*KubernetesNode `json:"nodes,omitempty"`
+}
+
+// KubernetesNode represents a Node in a node pool in a Kubernetes cluster.
+type KubernetesNode struct {
+	ID     string                `json:"id,omitempty"`
+	Name   string                `json:"name,omitempty"`
+	Status *KubernetesNodeStatus `json:"status,omitempty"`
+
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+// KubernetesNodeStatus represents the status of a particular Node in a Kubernetes cluster.
+type KubernetesNodeStatus struct {
+	State   string `json:"state,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// KubernetesOptions represents options available for creating Kubernetes clusters.
+type KubernetesOptions struct {
+	Versions []*KubernetesVersion  `json:"versions,omitempty"`
+	Regions  []*KubernetesRegion   `json:"regions,omitempty"`
+	Sizes    []*KubernetesNodeSize `json:"sizes,omitempty"`
+}
+
+// KubernetesVersion is a DigitalOcean Kubernetes release.
+type KubernetesVersion struct {
+	Slug              string `json:"slug,omitempty"`
+	KubernetesVersion string `json:"kubernetes_version,omitempty"`
+}
+
+// KubernetesNodeSize is a node sizes supported for Kubernetes clusters.
+type KubernetesNodeSize struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// KubernetesRegion is a region usable by Kubernetes clusters.
+type KubernetesRegion struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type kubernetesClustersRoot struct {
+	Clusters []*KubernetesCluster `json:"kubernetes_clusters,omitempty"`
+	Links    *Links               `json:"links,omitempty"`
+}
+
+type kubernetesClusterRoot struct {
+	Cluster *KubernetesCluster `json:"kubernetes_cluster,omitempty"`
+}
+
+type kubernetesNodePoolRoot struct {
+	NodePool *KubernetesNodePool `json:"node_pool,omitempty"`
+}
+
+type kubernetesNodePoolsRoot struct {
+	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
+	Links     *Links                `json:"links,omitempty"`
+}
+
+// Get retrieves the details of a Kubernetes cluster.
+func (svc *KubernetesServiceOp) Get(ctx context.Context, clusterID string) (*KubernetesCluster, *Response, error) {
+	path := fmt.Sprintf("%s/%s", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesClusterRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Cluster, resp, nil
+}
+
+// Create creates a Kubernetes cluster.
+func (svc *KubernetesServiceOp) Create(ctx context.Context, create *KubernetesClusterCreateRequest) (*KubernetesCluster, *Response, error) {
+	path := kubernetesClustersPath
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, create)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesClusterRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Cluster, resp, nil
+}
+
+// Delete deletes a Kubernetes cluster. There is no way to recover a cluster
+// once it has been destroyed.
+func (svc *KubernetesServiceOp) Delete(ctx context.Context, clusterID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// List returns a list of the Kubernetes clusters visible with the caller's API token.
+func (svc *KubernetesServiceOp) List(ctx context.Context, opts *ListOptions) ([]*KubernetesCluster, *Response, error) {
+	path := kubernetesClustersPath
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesClustersRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Clusters, resp, nil
+}
+
+// KubernetesClusterConfig is the content of a Kubernetes config file, which can be
+// used to interact with your Kubernetes cluster using `kubectl`.
+// See: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+type KubernetesClusterConfig struct {
+	KubeconfigYAML []byte
+}
+
+// GetKubeConfig returns a Kubernetes config file for the specified cluster.
+func (svc *KubernetesServiceOp) GetKubeConfig(ctx context.Context, clusterID string) (*KubernetesClusterConfig, *Response, error) {
+	path := fmt.Sprintf("%s/%s/kubeconfig", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	configBytes := bytes.NewBuffer(nil)
+	resp, err := svc.client.Do(ctx, req, configBytes)
+	if err != nil {
+		return nil, resp, err
+	}
+	res := &KubernetesClusterConfig{
+		KubeconfigYAML: configBytes.Bytes(),
+	}
+	return res, resp, nil
+}
+
+// Update updates a Kubernetes cluster's properties.
+func (svc *KubernetesServiceOp) Update(ctx context.Context, clusterID string, update *KubernetesClusterUpdateRequest) (*KubernetesCluster, *Response, error) {
+	path := fmt.Sprintf("%s/%s", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesClusterRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Cluster, resp, nil
+}
+
+// CreateNodePool creates a new node pool in an existing Kubernetes cluster.
+func (svc *KubernetesServiceOp) CreateNodePool(ctx context.Context, clusterID string, create *KubernetesNodePoolCreateRequest) (*KubernetesNodePool, *Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools", kubernetesClustersPath, clusterID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, create)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesNodePoolRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.NodePool, resp, nil
+}
+
+// GetNodePool retrieves an existing node pool in a Kubernetes cluster.
+func (svc *KubernetesServiceOp) GetNodePool(ctx context.Context, clusterID, poolID string) (*KubernetesNodePool, *Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools/%s", kubernetesClustersPath, clusterID, poolID)
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesNodePoolRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.NodePool, resp, nil
+}
+
+// ListNodePools lists all the node pools found in a Kubernetes cluster.
+func (svc *KubernetesServiceOp) ListNodePools(ctx context.Context, clusterID string, opts *ListOptions) ([]*KubernetesNodePool, *Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools", kubernetesClustersPath, clusterID)
+	path, err := addOptions(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesNodePoolsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.NodePools, resp, nil
+}
+
+// UpdateNodePool updates the details of an existing node pool.
+func (svc *KubernetesServiceOp) UpdateNodePool(ctx context.Context, clusterID, poolID string, update *KubernetesNodePoolUpdateRequest) (*KubernetesNodePool, *Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools/%s", kubernetesClustersPath, clusterID, poolID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPut, path, update)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesNodePoolRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.NodePool, resp, nil
+}
+
+// RecycleNodePoolNodes schedules nodes in a node pool for recycling.
+func (svc *KubernetesServiceOp) RecycleNodePoolNodes(ctx context.Context, clusterID, poolID string, recycle *KubernetesNodePoolRecycleNodesRequest) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools/%s/recycle", kubernetesClustersPath, clusterID, poolID)
+	req, err := svc.client.NewRequest(ctx, http.MethodPost, path, recycle)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+// DeleteNodePool deletes a node pool, and subsequently all the nodes in that pool.
+func (svc *KubernetesServiceOp) DeleteNodePool(ctx context.Context, clusterID, poolID string) (*Response, error) {
+	path := fmt.Sprintf("%s/%s/node_pools/%s", kubernetesClustersPath, clusterID, poolID)
+	req, err := svc.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := svc.client.Do(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
+}
+
+type kubernetesOptionsRoot struct {
+	Options *KubernetesOptions `json:"options,omitempty"`
+	Links   *Links             `json:"links,omitempty"`
+}
+
+// GetOptions returns options about the Kubernetes service, such as the versions available for
+// cluster creation.
+func (svc *KubernetesServiceOp) GetOptions(ctx context.Context) (*KubernetesOptions, *Response, error) {
+	path := kubernetesOptionsPath
+	req, err := svc.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	root := new(kubernetesOptionsRoot)
+	resp, err := svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	return root.Options, resp, nil
+}

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -26,6 +26,7 @@ type LoadBalancersService interface {
 }
 
 // LoadBalancer represents a DigitalOcean load balancer configuration.
+// Tags can only be provided upon the creation of a Load Balancer.
 type LoadBalancer struct {
 	ID                  string           `json:"id,omitempty"`
 	Name                string           `json:"name,omitempty"`
@@ -39,12 +40,17 @@ type LoadBalancer struct {
 	Region              *Region          `json:"region,omitempty"`
 	DropletIDs          []int            `json:"droplet_ids,omitempty"`
 	Tag                 string           `json:"tag,omitempty"`
+	Tags                []string         `json:"tags,omitempty"`
 	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
 func (l LoadBalancer) String() string {
 	return Stringify(l)
+}
+
+func (l LoadBalancer) URN() string {
+	return ToURN("LoadBalancer", l.ID)
 }
 
 // AsRequest creates a LoadBalancerRequest that can be submitted to Update with the current values of the LoadBalancer.
@@ -59,6 +65,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		RedirectHttpToHttps: l.RedirectHttpToHttps,
 		HealthCheck:         l.HealthCheck,
 	}
+
 	if l.HealthCheck != nil {
 		r.HealthCheck = &HealthCheck{}
 		*r.HealthCheck = *l.HealthCheck
@@ -126,6 +133,7 @@ type LoadBalancerRequest struct {
 	StickySessions      *StickySessions  `json:"sticky_sessions,omitempty"`
 	DropletIDs          []int            `json:"droplet_ids,omitempty"`
 	Tag                 string           `json:"tag,omitempty"`
+	Tags                []string         `json:"tags,omitempty"`
 	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
 }
 

--- a/vendor/github.com/digitalocean/godo/projects.go
+++ b/vendor/github.com/digitalocean/godo/projects.go
@@ -1,0 +1,302 @@
+package godo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+)
+
+const (
+	// DefaultProject is the ID you should use if you are working with your
+	// default project.
+	DefaultProject = "default"
+
+	projectsBasePath = "/v2/projects"
+)
+
+// ProjectsService is an interface for creating and managing Projects with the DigitalOcean API.
+// See: https://developers.digitalocean.com/documentation/documentation/v2/#projects
+type ProjectsService interface {
+	List(context.Context, *ListOptions) ([]Project, *Response, error)
+	GetDefault(context.Context) (*Project, *Response, error)
+	Get(context.Context, string) (*Project, *Response, error)
+	Create(context.Context, *CreateProjectRequest) (*Project, *Response, error)
+	Update(context.Context, string, *UpdateProjectRequest) (*Project, *Response, error)
+	Delete(context.Context, string) (*Response, error)
+
+	ListResources(context.Context, string, *ListOptions) ([]ProjectResource, *Response, error)
+	AssignResources(context.Context, string, ...interface{}) ([]ProjectResource, *Response, error)
+}
+
+// ProjectsServiceOp handles communication with Projects methods of the DigitalOcean API.
+type ProjectsServiceOp struct {
+	client *Client
+}
+
+// Project represents a DigitalOcean Project configuration.
+type Project struct {
+	ID          string `json:"id"`
+	OwnerUUID   string `json:"owner_uuid"`
+	OwnerID     uint64 `json:"owner_id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Purpose     string `json:"purpose"`
+	Environment string `json:"environment"`
+	IsDefault   bool   `json:"is_default"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// String creates a human-readable description of a Project.
+func (p Project) String() string {
+	return Stringify(p)
+}
+
+// CreateProjectRequest represents the request to create a new project.
+type CreateProjectRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Purpose     string `json:"purpose"`
+	Environment string `json:"environment"`
+}
+
+// UpdateProjectRequest represents the request to update project information.
+// This type expects certain attribute types, but is built this way to allow
+// nil values as well. See `updateProjectRequest` for the "real" types.
+type UpdateProjectRequest struct {
+	Name        interface{}
+	Description interface{}
+	Purpose     interface{}
+	Environment interface{}
+	IsDefault   interface{}
+}
+
+type updateProjectRequest struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Purpose     *string `json:"purpose"`
+	Environment *string `json:"environment"`
+	IsDefault   *bool   `json:"is_default"`
+}
+
+// MarshalJSON takes an UpdateRequest and converts it to the "typed" request
+// which is sent to the projects API. This is a PATCH request, which allows
+// partial attributes, so `null` values are OK.
+func (upr *UpdateProjectRequest) MarshalJSON() ([]byte, error) {
+	d := &updateProjectRequest{}
+	if str, ok := upr.Name.(string); ok {
+		d.Name = &str
+	}
+	if str, ok := upr.Description.(string); ok {
+		d.Description = &str
+	}
+	if str, ok := upr.Purpose.(string); ok {
+		d.Purpose = &str
+	}
+	if str, ok := upr.Environment.(string); ok {
+		d.Environment = &str
+	}
+	if val, ok := upr.IsDefault.(bool); ok {
+		d.IsDefault = &val
+	}
+
+	return json.Marshal(d)
+}
+
+type assignResourcesRequest struct {
+	Resources []string `json:"resources"`
+}
+
+// ProjectResource is the projects API's representation of a resource.
+type ProjectResource struct {
+	URN        string                `json:"urn"`
+	AssignedAt string                `json:"assigned_at"`
+	Links      *ProjectResourceLinks `json:"links"`
+	Status     string                `json:"status,omitempty"`
+}
+
+// ProjetResourceLinks specify the link for more information about the resource.
+type ProjectResourceLinks struct {
+	Self string `json:"self"`
+}
+
+type projectsRoot struct {
+	Projects []Project `json:"projects"`
+	Links    *Links    `json:"links"`
+}
+
+type projectRoot struct {
+	Project *Project `json:"project"`
+}
+
+type projectResourcesRoot struct {
+	Resources []ProjectResource `json:"resources"`
+	Links     *Links            `json:"links,omitempty"`
+}
+
+var _ ProjectsService = &ProjectsServiceOp{}
+
+// List Projects.
+func (p *ProjectsServiceOp) List(ctx context.Context, opts *ListOptions) ([]Project, *Response, error) {
+	path, err := addOptions(projectsBasePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectsRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Projects, resp, err
+}
+
+// GetDefault project.
+func (p *ProjectsServiceOp) GetDefault(ctx context.Context) (*Project, *Response, error) {
+	return p.getHelper(ctx, "default")
+}
+
+// Get retrieves a single project by its ID.
+func (p *ProjectsServiceOp) Get(ctx context.Context, projectID string) (*Project, *Response, error) {
+	return p.getHelper(ctx, projectID)
+}
+
+// Create a new project.
+func (p *ProjectsServiceOp) Create(ctx context.Context, cr *CreateProjectRequest) (*Project, *Response, error) {
+	req, err := p.client.NewRequest(ctx, http.MethodPost, projectsBasePath, cr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Project, resp, err
+}
+
+// Update an existing project.
+func (p *ProjectsServiceOp) Update(ctx context.Context, projectID string, ur *UpdateProjectRequest) (*Project, *Response, error) {
+	path := path.Join(projectsBasePath, projectID)
+	req, err := p.client.NewRequest(ctx, http.MethodPatch, path, ur)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Project, resp, err
+}
+
+// Delete an existing project. You cannot have any resources in a project
+// before deleting it. See the API documentation for more details.
+func (p *ProjectsServiceOp) Delete(ctx context.Context, projectID string) (*Response, error) {
+	path := path.Join(projectsBasePath, projectID)
+	req, err := p.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.Do(ctx, req, nil)
+}
+
+// ListResources lists all resources in a project.
+func (p *ProjectsServiceOp) ListResources(ctx context.Context, projectID string, opts *ListOptions) ([]ProjectResource, *Response, error) {
+	basePath := path.Join(projectsBasePath, projectID, "resources")
+	path, err := addOptions(basePath, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectResourcesRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Resources, resp, err
+}
+
+// AssignResources assigns one or more resources to a project. AssignResources
+// accepts resources in two possible formats:
+
+//  1. The resource type, like `&Droplet{ID: 1}` or `&FloatingIP{IP: "1.2.3.4"}`
+//  2. A valid DO URN as a string, like "do:droplet:1234"
+//
+// There is no unassign. To move a resource to another project, just assign
+// it to that other project.
+func (p *ProjectsServiceOp) AssignResources(ctx context.Context, projectID string, resources ...interface{}) ([]ProjectResource, *Response, error) {
+	path := path.Join(projectsBasePath, projectID, "resources")
+
+	ar := &assignResourcesRequest{
+		Resources: make([]string, len(resources)),
+	}
+
+	for i, resource := range resources {
+		switch resource.(type) {
+		case ResourceWithURN:
+			ar.Resources[i] = resource.(ResourceWithURN).URN()
+		case string:
+			ar.Resources[i] = resource.(string)
+		default:
+			return nil, nil, fmt.Errorf("%T must either be a string or have a valid URN method", resource)
+		}
+	}
+	req, err := p.client.NewRequest(ctx, http.MethodPost, path, ar)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectResourcesRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root.Resources, resp, err
+}
+
+func (p *ProjectsServiceOp) getHelper(ctx context.Context, projectID string) (*Project, *Response, error) {
+	path := path.Join(projectsBasePath, projectID)
+
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(projectRoot)
+	resp, err := p.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root.Project, resp, err
+}

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -59,6 +59,10 @@ func (f Volume) String() string {
 	return Stringify(f)
 }
 
+func (f Volume) URN() string {
+	return ToURN("Volume", f.ID)
+}
+
 type storageVolumesRoot struct {
 	Volumes []Volume `json:"volumes"`
 	Links   *Links   `json:"links"`

--- a/vendor/github.com/digitalocean/godo/strings.go
+++ b/vendor/github.com/digitalocean/godo/strings.go
@@ -5,9 +5,19 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 )
 
 var timestampType = reflect.TypeOf(Timestamp{})
+
+type ResourceWithURN interface {
+	URN() string
+}
+
+// ToURN converts the resource type and ID to a valid DO API URN.
+func ToURN(resourceType string, id interface{}) string {
+	return fmt.Sprintf("%s:%s:%v", "do", strings.ToLower(resourceType), id)
+}
 
 // Stringify attempts to create a string representation of DigitalOcean types
 func Stringify(message interface{}) string {

--- a/vendor/github.com/digitalocean/godo/tags.go
+++ b/vendor/github.com/digitalocean/godo/tags.go
@@ -35,6 +35,8 @@ type ResourceType string
 const (
 	//DropletResourceType holds the string representing our ResourceType of Droplet.
 	DropletResourceType ResourceType = "droplet"
+	//ImageResourceType holds the string representing our ResourceType of Image.
+	ImageResourceType ResourceType = "image"
 )
 
 // Resource represent a single resource for associating/disassociating with tags
@@ -45,13 +47,23 @@ type Resource struct {
 
 // TaggedResources represent the set of resources a tag is attached to
 type TaggedResources struct {
-	Droplets *TaggedDropletsResources `json:"droplets,omitempty"`
+	Count         int                      `json:"count"`
+	LastTaggedURI string                   `json:"last_tagged_uri,omitempty"`
+	Droplets      *TaggedDropletsResources `json:"droplets,omitempty"`
+	Images        *TaggedImagesResources   `json:"images"`
 }
 
 // TaggedDropletsResources represent the droplet resources a tag is attached to
 type TaggedDropletsResources struct {
-	Count      int      `json:"count,float64,omitempty"`
-	LastTagged *Droplet `json:"last_tagged,omitempty"`
+	Count         int      `json:"count,float64,omitempty"`
+	LastTagged    *Droplet `json:"last_tagged,omitempty"`
+	LastTaggedURI string   `json:"last_tagged_uri,omitempty"`
+}
+
+// TaggedImagesResources represent the image resources a tag is attached to
+type TaggedImagesResources struct {
+	Count         int    `json:"count,float64,omitempty"`
+	LastTaggedURI string `json:"last_tagged_uri,omitempty"`
 }
 
 // Tag represent DigitalOcean tag


### PR DESCRIPTION
This enables a consistent view on all DO resources managed by the cluster.

As a drive-by change, some struct initializations were changed to use named fields in order to be more robust towards (optional) field additions in the future.

digitalocean/godo had to be updated in order to access load balancer tags.