### PR TITLE
Remove maintainers section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,3 @@ This will create a binary with version `v0.1.8` and docker image pushed to
 
 ## Contributing
 At DigitalOcean we value and love our community! If you have any issues or would like to contribute, feel free to open an issue/PR and cc any of the maintainers below.
-
-### Maintainers
-* Andrew Sy Kim - @andrewsykim
-* Billie Cleek - @bhcleek
-* Timo Reimann - @timoreimann


### PR DESCRIPTION
It is prone to changes. Additionally, maintainers are best accessed differently (e.g., through the [contributors page](https://github.com/digitalocean/digitalocean-cloud-controller-manager/graphs/contributors) or by letting maintainers respond to community activities on their own).

Follow-up of #155.