### PR TITLE
Prepend the DO-specific tag component to the cluster ID.

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -97,6 +97,9 @@ const (
 	lbStatusNew     = "new"
 	lbStatusActive  = "active"
 	lbStatusErrored = "errored"
+
+	// This is the DO-specific tag component prepended to the cluster ID.
+	tagPrefixClusterID = "k8s"
 )
 
 var errLBNotFound = errors.New("loadbalancer not found")
@@ -328,7 +331,7 @@ func (l *loadBalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 
 	var tags []string
 	if l.clusterID != "" {
-		tags = []string{l.clusterID}
+		tags = []string{fmt.Sprintf("%s:%s", tagPrefixClusterID, l.clusterID)}
 	}
 
 	return &godo.LoadBalancerRequest{

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1766,11 +1766,11 @@ func Test_buildLoadBalancerRequestWithClusterID(t *testing.T) {
 	}
 	fakeClient := newFakeLBClient(&fakeLBService{}, fakeDropletSvc)
 
-	wantTags := []string{"fdda2d9d-0856-4ca4-b8ee-27ca8bfecc77"}
+	clusterID := "fdda2d9d-0856-4ca4-b8ee-27ca8bfecc77"
 	lb := &loadBalancers{
 		client:    fakeClient,
 		region:    "nyc3",
-		clusterID: wantTags[0],
+		clusterID: clusterID,
 	}
 
 	lbr, err := lb.buildLoadBalancerRequest(service, nodes)
@@ -1778,6 +1778,7 @@ func Test_buildLoadBalancerRequestWithClusterID(t *testing.T) {
 		t.Errorf("got error: %s", err)
 	}
 
+	wantTags := []string{fmt.Sprintf("%s:%s", tagPrefixClusterID, clusterID)}
 	if !reflect.DeepEqual(lbr.Tags, wantTags) {
 		t.Errorf("got tags %q, want %q", lbr.Tags, wantTags)
 	}


### PR DESCRIPTION
Addresses an oversight spotted by @bouk [here](https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/170#pullrequestreview-205834323).