### PR TITLE
Makefile: Fix check-headers target and header violations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,5 +102,7 @@ test:
 
 .PHONY: check-headers
 check-headers:
-	@./ci/headers-*.sh
+	@./ci/headers-bash.sh
+	@./ci/headers-docker.sh
+	@./ci/headers-go.sh
 

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloud-controller-manager/do/zones_test.go
+++ b/cloud-controller-manager/do/zones_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package do
 
 import (


### PR DESCRIPTION
The target would previously not work (because the wildcard in the command did not apply).