### PR TITLE
loadbalancers: don't use pointer to loop variable in load balancers map

### DIFF
--- a/cloud-controller-manager/do/faketagssvc_test.go
+++ b/cloud-controller-manager/do/faketagssvc_test.go
@@ -36,6 +36,8 @@ type fakeTagsService struct {
 	// failError is the error to return when failOnRequest is >= 0. When not
 	// given, a default error is returned. Ignored when failOnRequest is < 0.
 	failError error
+
+	tagRequests []*godo.TagResourcesRequest
 }
 
 func newFakeTagsService(tags ...string) *fakeTagsService {
@@ -109,6 +111,8 @@ func (f *fakeTagsService) TagResources(ctx context.Context, name string, tagRequ
 	if !f.tags[name] {
 		return newFakeResponse(http.StatusNotFound), fmt.Errorf("tag %q does not exist", name)
 	}
+
+	f.tagRequests = append(f.tagRequests, tagRequest)
 
 	return newFakeOKResponse(), nil
 }

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -99,9 +99,9 @@ func (r *ResourcesController) sync() error {
 		return fmt.Errorf("failed to list services: %s", err)
 	}
 
-	loadBalancers := make(map[string]*godo.LoadBalancer, len(lbs))
+	loadBalancers := make(map[string]string, len(lbs))
 	for _, lb := range lbs {
-		loadBalancers[lb.Name] = &lb
+		loadBalancers[lb.Name] = lb.ID
 	}
 
 	var res []godo.Resource
@@ -111,9 +111,9 @@ func (r *ResourcesController) sync() error {
 		}
 
 		name := cloudprovider.GetLoadBalancerName(svc)
-		if lb, ok := loadBalancers[name]; ok {
+		if id, ok := loadBalancers[name]; ok {
 			res = append(res, godo.Resource{
-				ID:   lb.ID,
+				ID:   id,
 				Type: godo.ResourceType(resourceTypeLoadBalancer),
 			})
 		}

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -152,11 +152,11 @@ func TestTagsSync(t *testing.T) {
 					Resources: []godo.Resource{
 						{
 							ID:   "1",
-							Type: "load_balancer",
+							Type: resourceTypeLoadBalancer,
 						},
 						{
 							ID:   "2",
-							Type: "load_balancer",
+							Type: resourceTypeLoadBalancer,
 						},
 					},
 				},

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -18,8 +18,10 @@ package do
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -60,11 +62,12 @@ func createSvc(idx int, isTypeLoadBalancer bool) *corev1.Service {
 
 func TestTagsSync(t *testing.T) {
 	testcases := []struct {
-		name     string
-		services []*corev1.Service
-		lbListFn func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
-		tagSvc   *fakeTagsService
-		errMsg   string
+		name        string
+		services    []*corev1.Service
+		lbListFn    func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
+		tagSvc      *fakeTagsService
+		errMsg      string
+		tagRequests []*godo.TagResourcesRequest
 	}{
 		{
 			name: "LB service fails",
@@ -126,6 +129,40 @@ func TestTagsSync(t *testing.T) {
 			tagSvc: newFakeTagsService(clusterIDTag),
 		},
 		{
+			name: "multiple tags",
+			services: []*corev1.Service{
+				createSvc(1, true),
+				createSvc(2, true),
+			},
+			lbListFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+				return []godo.LoadBalancer{
+					{
+						Name: lbName(1),
+						ID:   "1",
+					},
+					{
+						Name: lbName(2),
+						ID:   "2",
+					},
+				}, newFakeOKResponse(), nil
+			},
+			tagSvc: newFakeTagsService(clusterIDTag),
+			tagRequests: []*godo.TagResourcesRequest{
+				{
+					Resources: []godo.Resource{
+						{
+							ID:   "1",
+							Type: "load_balancer",
+						},
+						{
+							ID:   "2",
+							Type: "load_balancer",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "success on second resource tagging",
 			services: []*corev1.Service{
 				createSvc(1, true),
@@ -177,6 +214,12 @@ func TestTagsSync(t *testing.T) {
 
 			if wantErr && !strings.Contains(err.Error(), test.errMsg) {
 				t.Errorf("error message %q does not contain %q", err.Error(), test.errMsg)
+			}
+
+			if test.tagRequests != nil && !reflect.DeepEqual(test.tagRequests, fakeTagsService.tagRequests) {
+				want, _ := json.Marshal(test.tagRequests)
+				got, _ := json.Marshal(fakeTagsService.tagRequests)
+				t.Errorf("unexpected tagRequests %s != %s", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
`loadBalancers[lb.Name] = &lb` was getting a pointer to the loop variable, not to the value inside the slice (tricky Go escape semantics...). This meant that every value in the map would point to the same value, which would be the load balancer returned last from the API. So if there were multiple load balancers only the last one would get the cluster tag applied.

I changed it to have the IDs in the map instead of the load balancer pointers. I also added a test that actually verifies that the correct API requests are made.