### PR TITLE
Makefile: git add -N new release files on version bump.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ bump-version:
 	@sed -i'' -e 's/${VERSION}/${NEW_VERSION}/g' docs/getting-started.md
 	@sed -i'' -e 's/${VERSION}/${NEW_VERSION}/g' README.md
 	@sed -i'' -e 's/${VERSION}/${NEW_VERSION}/g' docs/example-manifests/cloud-controller-manager.yml
+	git add --intent-to-add releases/${NEW_VERSION}.yml
 	@rm docs/example-manifests/cloud-controller-manager.yml-e README.md-e docs/getting-started.md-e releases/${NEW_VERSION}.yml-e
 
 .PHONY: clean


### PR DESCRIPTION
This should hopefully prevent version bumpers from forgetting to commit the added set of release files (like I did before and fixed after the fact through fa31e15498fd2ca7fea0ccabe82573475274518d).