### PR TITLE
Add support for customizing remaining, numeric health check parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+
+* loadbalancers: support numeric health check parameters (@timoreimann)
+
 ## v0.1.10 (beta) - Feb 26th 2019
 
 * loadbalancers: don't use pointer to loop variable in load balancers map (@bouk)

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -14,6 +14,22 @@ The path used to check if a backend droplet is healthy. Defaults to "/".
 
 The health check protocol to use to check if a backend droplet is healthy. Defaults to the protocol used in `service.beta.kubernetes.io/do-loadbalancer-protocol`. Options are `tcp` and `http`.
 
+## service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds
+
+The number of seconds between between two consecutive health checks. The value must be between 3 and 300. If not specified, the default value is 3.
+
+## service.beta.kubernetes.io/do-loadbalancer-healthcheck-response-timeout-seconds
+
+The number of seconds the Load Balancer instance will wait for a response until marking a health check as failed. The value must be between 3 and 300. If not specified, the default value is 5.
+
+## service.beta.kubernetes.io/do-loadbalancer-healthcheck-unhealthy-threshold
+
+The number of times a health check must fail for a backend Droplet to be marked "unhealthy" and be removed from the pool for the given service. The vaule must be between 2 and 10. If not specified, the default value is 3.
+
+## service.beta.kubernetes.io/do-loadbalancer-healthcheck-healthy-threshold
+
+The number of times a health check must pass for a backend Droplet to be marked "healthy" for the given service and be re-added to the pool. The vaule must be between 2 and 10. If not specified, the default value is 5.
+
 ## service.beta.kubernetes.io/do-loadbalancer-tls-ports
 
 Specify which ports of the loadbalancer should use the https protocol. This is a comma separated list of ports (e.g. 443,6443,7443).

--- a/docs/controllers/services/examples/http-nginx-with-healthcheck-numeric-values.yml
+++ b/docs/controllers/services/examples/http-nginx-with-healthcheck-numeric-values.yml
@@ -1,0 +1,38 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-lb
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds: "8"
+    service.beta.kubernetes.io/do-loadbalancer-healthcheck-response-timeout-seconds: "6"
+    service.beta.kubernetes.io/do-loadbalancer-healthcheck-unhealthy-threshold: "2"
+    service.beta.kubernetes.io/do-loadbalancer-healthcheck-healthy-threshold: "2"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP


### PR DESCRIPTION
The existing, default parameters slightly vary from the defaults that DO LB provides. In order to avoid introducing behavioral changes, we kept them accordingly.

Details:
- Add and parse new annotations.
- Refactor and extend tests.
- Extend service annotation documentation.
- Add example.
- Update change log.