### PR TITLE
Allow to publish to Docker organizations other than DO's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ build:
 .PHONY: push
 push:
 
-ifeq ($(shell [[ $(BRANCH) != "master" && $(VERSION) != "dev" ]] && echo true ),true)
-	@echo "ERROR: Publishing image with a SEMVER version '$(VERSION)' is only allowed from master"
+ifeq ($(shell [[ $(REGISTRY) = "digitalocean" && $(BRANCH) != "master" && $(VERSION) != "dev" ]] && echo true ),true)
+	@echo "ERROR: Publishing image to the DO organization with a SEMVER version '$(VERSION)' is only allowed from master"
 else
 	@echo "==> Publishing $(REGISTRY)/digitalocean-cloud-controller-manager:$(VERSION)"
 	@docker push $(REGISTRY)/digitalocean-cloud-controller-manager:$(VERSION)


### PR DESCRIPTION
This can be helpful for testing, e.g., when pushing pre-release versions to `<personal org>/digitalocean-cloud-controller-manager`.