### PR TITLE
Add support for PROXY protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* loadbalancers: add support for PROXY protocol (@timoreimann)
 * loadbalancers: support numeric health check parameters (@timoreimann)
 
 ## v0.1.10 (beta) - Feb 26th 2019

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -87,12 +87,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:a2295338b18f3898280ba8f2b5b37d4f7694612a6b730be5276a405a7e592ac1"
+  digest = "1:a710ae2a66582fe9c9cad8f04cdae91bcd594592efc88f331c50b6cf3cafc727"
   name = "github.com/digitalocean/godo"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "169afd3c4cd2071b82740787dae2d8c714db0821"
-  version = "v1.7.5"
+  revision = "cd71616aba666a6c51fd79af3ee9210960c5ccaf"
+  version = "v1.9.0"
 
 [[projects]]
   digest = "1:4189ee6a3844f555124d9d2656fe7af02fca961c2a9bad9074789df13a0c62e0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,8 +43,8 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[constraint]]
-  version = "v1.7.5"
   name = "github.com/digitalocean/godo"
+  version = "1.9.0"
 
 [[constraint]]
   branch = "master"

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1370,6 +1370,82 @@ func Test_getRedirectHTTPToHTTPS(t *testing.T) {
 
 }
 
+func Test_getEnableProxyProtocol(t *testing.T) {
+	testcases := []struct {
+		name                    string
+		service                 *v1.Service
+		wantErr                 bool
+		wantEnableProxyProtocol bool
+	}{
+		{
+			name: "enabled",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOEnableProxyProtocol: "true",
+					},
+				},
+			},
+			wantErr:                 false,
+			wantEnableProxyProtocol: true,
+		},
+		{
+			name: "disabled",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOEnableProxyProtocol: "false",
+					},
+				},
+			},
+			wantErr:                 false,
+			wantEnableProxyProtocol: false,
+		},
+		{
+			name: "annotation missing",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+				},
+			},
+			wantErr:                 false,
+			wantEnableProxyProtocol: false,
+		},
+		{
+			name: "illegal value",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOEnableProxyProtocol: "42",
+					},
+				},
+			},
+			wantErr:                 true,
+			wantEnableProxyProtocol: false,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			gotEnabledProxyProtocol, err := getEnableProxyProtocol(test.service)
+			if test.wantErr != (err != nil) {
+				t.Errorf("got error %q, want error: %t", err, test.wantErr)
+			}
+
+			if gotEnabledProxyProtocol != test.wantEnableProxyProtocol {
+				t.Fatalf("got enabled proxy protocol %t, want %t", gotEnabledProxyProtocol, test.wantEnableProxyProtocol)
+			}
+		})
+	}
+}
+
 func Test_buildLoadBalancerRequest(t *testing.T) {
 	testcases := []struct {
 		name          string

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -1,6 +1,8 @@
 # Service Annotations
 
-DigitalOcean cloud controller manager watches for Services of type `LoadBalancer` and will create corresponding DigitalOcean Load Balancers matching the Kubernetes service. The Load Balancer can be configured by applying annotations to the Service resource. The following annotations can be used:
+DigitalOcean cloud controller manager watches for Services of type `LoadBalancer` and will create corresponding DigitalOcean Load Balancers matching the Kubernetes service. The Load Balancer can be configured by applying annotations to the Service resource. The annotations listed below can be used.
+
+See example Kubernetes Services using LoadBalancers [here](examples/).
 
 ## service.beta.kubernetes.io/do-loadbalancer-protocol
 
@@ -62,4 +64,6 @@ Specifies the TTL of cookies used for loadbalancer sticky sessions. This annotat
 
 Indicates whether or not http traffic should be redirected to https. Options are `true` or `false`. Defaults to `false`.
 
-See example Kubernetes Services using LoadBalancers [here](examples/).
+## service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol
+
+Indicates whether PROXY protocol should be enabled. Options are `true` or `false`. Defaults to `false`.

--- a/docs/controllers/services/examples/http-nginx-with-proxy-protocol.yml
+++ b/docs/controllers/services/examples/http-nginx-with-proxy-protocol.yml
@@ -1,0 +1,34 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-lb
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.7.5"
+	libraryVersion = "1.9.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -42,6 +42,7 @@ type LoadBalancer struct {
 	Tag                 string           `json:"tag,omitempty"`
 	Tags                []string         `json:"tags,omitempty"`
 	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol bool             `json:"enable_proxy_protocol,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -63,6 +64,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		DropletIDs:          append([]int(nil), l.DropletIDs...),
 		Tag:                 l.Tag,
 		RedirectHttpToHttps: l.RedirectHttpToHttps,
+		EnableProxyProtocol: l.EnableProxyProtocol,
 		HealthCheck:         l.HealthCheck,
 	}
 
@@ -135,6 +137,7 @@ type LoadBalancerRequest struct {
 	Tag                 string           `json:"tag,omitempty"`
 	Tags                []string         `json:"tags,omitempty"`
 	RedirectHttpToHttps bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol bool             `json:"enable_proxy_protocol,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/github.com/digitalocean/godo/storage.go
+++ b/vendor/github.com/digitalocean/godo/storage.go
@@ -53,6 +53,7 @@ type Volume struct {
 	CreatedAt       time.Time `json:"created_at"`
 	FilesystemType  string    `json:"filesystem_type"`
 	FilesystemLabel string    `json:"filesystem_label"`
+	Tags            []string  `json:"tags"`
 }
 
 func (f Volume) String() string {
@@ -76,13 +77,14 @@ type storageVolumeRoot struct {
 // VolumeCreateRequest represents a request to create a block store
 // volume.
 type VolumeCreateRequest struct {
-	Region          string `json:"region"`
-	Name            string `json:"name"`
-	Description     string `json:"description"`
-	SizeGigaBytes   int64  `json:"size_gigabytes"`
-	SnapshotID      string `json:"snapshot_id"`
-	FilesystemType  string `json:"filesystem_type"`
-	FilesystemLabel string `json:"filesystem_label"`
+	Region          string   `json:"region"`
+	Name            string   `json:"name"`
+	Description     string   `json:"description"`
+	SizeGigaBytes   int64    `json:"size_gigabytes"`
+	SnapshotID      string   `json:"snapshot_id"`
+	FilesystemType  string   `json:"filesystem_type"`
+	FilesystemLabel string   `json:"filesystem_label"`
+	Tags            []string `json:"tags"`
 }
 
 // ListVolumes lists all storage volumes.


### PR DESCRIPTION
Adds a new annotation `service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol` to
toggle PROXY protocol usage on and off.