### PR TITLE
Assume HTTPS protocol on default TLS port when TLS option is given.

### DIFF
--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -769,6 +769,100 @@ func Test_buildForwardingRules(t *testing.T) {
 			nil,
 		},
 		{
+			"tls forwarding rules with certificate and derived tls port",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOCertificateID: "test-certificate",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+						{
+							Name:     "test-https",
+							Protocol: "TCP",
+							Port:     int32(443),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			[]godo.ForwardingRule{
+				{
+					EntryProtocol:  "tcp",
+					EntryPort:      80,
+					TargetProtocol: "tcp",
+					TargetPort:     30000,
+					CertificateID:  "",
+					TlsPassthrough: false,
+				},
+				{
+					EntryProtocol:  "https",
+					EntryPort:      443,
+					TargetProtocol: "http",
+					TargetPort:     30000,
+					CertificateID:  "test-certificate",
+					TlsPassthrough: false,
+				},
+			},
+			nil,
+		},
+		{
+			"tls forwarding rules with tls path through and derived tls port",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOTLSPassThrough: "true",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+						{
+							Name:     "test-https",
+							Protocol: "TCP",
+							Port:     int32(443),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			[]godo.ForwardingRule{
+				{
+					EntryProtocol:  "tcp",
+					EntryPort:      80,
+					TargetProtocol: "tcp",
+					TargetPort:     30000,
+					CertificateID:  "",
+					TlsPassthrough: false,
+				},
+				{
+					EntryProtocol:  "https",
+					EntryPort:      443,
+					TargetProtocol: "https",
+					TargetPort:     30000,
+					CertificateID:  "",
+					TlsPassthrough: true,
+				},
+			},
+			nil,
+		},
+		{
 			"invalid service protocol",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -35,14 +35,17 @@ The number of times a health check must pass for a backend Droplet to be marked 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-ports
 
 Specify which ports of the loadbalancer should use the https protocol. This is a comma separated list of ports (e.g. 443,6443,7443).
+If specified, exactly one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` and `service.beta.kubernetes.io/do-loadbalancer-certificate-id` must also be provided.
 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-passthrough
 
 Specify whether the DigitalOcean Load Balancer should pass encrypted data to backend droplets. This is optional. Options are `true` or `false`. Defaults to `false`.
+If enabled, ports specified in `service.beta.kubernetes.io/do-loadbalancer-tls-ports` will use https, or 443 if none are given.
 
 ## service.beta.kubernetes.io/do-loadbalancer-certificate-id
 
-Specifies the certificate ID used for https. This annotation is required if `service.beta.kubernetes.io/do-loadbalancer-tls-ports` is used. To list available certificates and their IDs, use `doctl compute certificate list` or find it in the [control panel](https://cloud.digitalocean.com/account/security).
+Specifies the certificate ID used for https. To list available certificates and their IDs, use `doctl compute certificate list` or find it in the [control panel](https://cloud.digitalocean.com/account/security).
+If enabled, ports specified in `service.beta.kubernetes.io/do-loadbalancer-tls-ports` will use https, or 443 if none are given.
 
 ## service.beta.kubernetes.io/do-loadbalancer-algorithm
 

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -44,7 +44,7 @@ If enabled, ports specified in `service.beta.kubernetes.io/do-loadbalancer-tls-p
 
 ## service.beta.kubernetes.io/do-loadbalancer-certificate-id
 
-Specifies the certificate ID used for https. To list available certificates and their IDs, use `doctl compute certificate list` or find it in the [control panel](https://cloud.digitalocean.com/account/security).
+Specifies the certificate ID used for https. To list available certificates and their IDs, install [doctl](https://github.com/digitalocean/doctl) and run `doctl compute certificate list`.
 If enabled, ports specified in `service.beta.kubernetes.io/do-loadbalancer-tls-ports` will use https, or 443 if none are given.
 
 ## service.beta.kubernetes.io/do-loadbalancer-algorithm

--- a/docs/controllers/services/examples/https-with-cert-nginx-minimal.yml
+++ b/docs/controllers/services/examples/https-with-cert-nginx-minimal.yml
@@ -1,0 +1,36 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: https-with-cert-minimal
+  annotations:
+    # No TLS port annotation needed since 443 is assumed for HTTPS when another TLS option annotation is given.
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "certificate-abc-123"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP


### PR DESCRIPTION
Previously, TLS options (such as the certificate ID or pass-through) would be ignored silently if either an HTTP* protocol or TLS port annotation was missing. With this change, we automatically enable the
HTTPS protocol on services exposing the default TLS port 443.

Effectively, this means that users may now omit the TLS port and protocol annotations for common use cases.

Fixes #192

@nanzhong @bouk @jcodybaker PTAL