### PR TITLE
Fix stale cache node deletion

### DIFF
--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -87,7 +87,7 @@ func newCloud() (cloudprovider.Interface, error) {
 
 	clusterID := os.Getenv(doClusterIDEnv)
 	clusterVPCID := os.Getenv(doClusterVPCIDEnv)
-	resources := newResources(clusterID, clusterVPCID)
+	resources := newResources(clusterID, clusterVPCID, doClient)
 
 	return &cloud{
 		client:        doClient,

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -141,6 +141,11 @@ func (i *instances) InstanceExistsByProviderID(_ context.Context, providerID str
 		return false, err
 	}
 
+	err = i.resources.SyncDroplet(id)
+	if err != nil {
+		return false, err
+	}
+
 	_, found := i.resources.DropletByID(id)
 	if !found {
 		// this is the case where we know the droplet is gone so we return false

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -89,7 +89,7 @@ func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (st
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	droplet, found := i.resources.DropletByName(string(nodeName))
 	if !found {
-		// NOTE attempt to sync once if not found. This will guarantee that nodes are actually non-existant and not missing due to a stale cache.
+		// NOTE attempt to sync once if not found. This will guarantee that nodes are actually non-existent and not missing due to a stale cache.
 		err := i.resources.SyncDroplets(ctx)
 		if err != nil {
 			return "", err

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1958,7 +1958,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := newFakeLBClient(&fakeLBService{})
-			fakeResources := newResources("", "")
+			fakeResources := newResources("", "", nil)
 			fakeResources.UpdateDroplets(test.droplets)
 
 			lb := &loadBalancers{
@@ -2034,7 +2034,7 @@ func Test_buildLoadBalancerRequestWithClusterID(t *testing.T) {
 				},
 			}
 			fakeClient := newFakeLBClient(&fakeLBService{})
-			fakeResources := newResources(test.clusterID, test.vpcID)
+			fakeResources := newResources(test.clusterID, test.vpcID, nil)
 			fakeResources.clusterVPCID = test.vpcID
 			fakeResources.UpdateDroplets([]godo.Droplet{
 				{
@@ -2173,7 +2173,7 @@ func Test_nodeToDropletIDs(t *testing.T) {
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := newFakeLBClient(&fakeLBService{})
-			fakeResources := newResources("", "")
+			fakeResources := newResources("", "", nil)
 			fakeResources.UpdateDroplets(test.droplets)
 
 			lb := &loadBalancers{
@@ -2278,7 +2278,7 @@ func Test_GetLoadBalancer(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			fakeResources := newResources("", "")
+			fakeResources := newResources("", "", nil)
 			fakeResources.UpdateLoadBalancers(test.lbs)
 
 			lb := &loadBalancers{
@@ -2482,7 +2482,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				updateFn: test.updateFn,
 			}
 			fakeClient := newFakeLBClient(fakeLB)
-			fakeResources := newResources("", "")
+			fakeResources := newResources("", "", nil)
 			fakeResources.UpdateDroplets(test.droplets)
 			fakeResources.UpdateLoadBalancers(test.lbs)
 

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -177,8 +177,8 @@ func (c *resources) UpdateLoadBalancers(lbs []godo.LoadBalancer) {
 	c.loadBalancerNameMap = newNameMap
 }
 
-func (c *resources) SyncDroplet(id int) error {
-	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
+func (c *resources) SyncDroplet(ctx context.Context, id int) error {
+	ctx, cancel := context.WithTimeout(ctx, syncResourcesTimeout)
 	defer cancel()
 
 	droplet, res, err := c.client.Droplets.Get(ctx, id)
@@ -212,8 +212,8 @@ func (c *resources) SyncDroplet(id int) error {
 	return nil
 }
 
-func (c *resources) SyncDroplets() error {
-	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
+func (c *resources) SyncDroplets(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, syncResourcesTimeout)
 	defer cancel()
 
 	droplets, err := allDropletList(ctx, c.client)
@@ -308,7 +308,7 @@ func (r *ResourcesController) Run(stopCh <-chan struct{}) {
 // DigitalOcean API.
 func (r *ResourcesController) syncResources() error {
 	klog.V(2).Info("syncing droplet resources.")
-	err := r.resources.SyncDroplets()
+	err := r.resources.SyncDroplets(context.Background())
 	if err != nil {
 		klog.Errorf("failed to sync droplet resources: %s.", err)
 	} else {

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -48,6 +48,8 @@ type resources struct {
 	clusterID    string
 	clusterVPCID string
 
+	client *godo.Client
+
 	dropletIDMap        map[int]*godo.Droplet
 	dropletNameMap      map[string]*godo.Droplet
 	loadBalancerIDMap   map[string]*godo.LoadBalancer
@@ -56,10 +58,12 @@ type resources struct {
 	mutex sync.RWMutex
 }
 
-func newResources(clusterID, clusterVPCID string) *resources {
+func newResources(clusterID, clusterVPCID string, client *godo.Client) *resources {
 	return &resources{
 		clusterID:    clusterID,
 		clusterVPCID: clusterVPCID,
+
+		client: client,
 
 		dropletIDMap:        make(map[int]*godo.Droplet),
 		dropletNameMap:      make(map[string]*godo.Droplet),
@@ -173,6 +177,32 @@ func (c *resources) UpdateLoadBalancers(lbs []godo.LoadBalancer) {
 	c.loadBalancerNameMap = newNameMap
 }
 
+func (c *resources) SyncDroplets() error {
+	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
+	defer cancel()
+
+	droplets, err := allDropletList(ctx, c.client)
+	if err != nil {
+		return err
+	}
+
+	c.UpdateDroplets(droplets)
+	return nil
+}
+
+func (c *resources) SyncLoadBalancers() error {
+	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
+	defer cancel()
+
+	lbs, err := allLoadBalancerList(ctx, c.client)
+	if err != nil {
+		return err
+	}
+
+	c.UpdateLoadBalancers(lbs)
+	return nil
+}
+
 type syncer interface {
 	Sync(name string, period time.Duration, stopCh <-chan struct{}, fn func() error)
 }
@@ -242,24 +272,19 @@ func (r *ResourcesController) Run(stopCh <-chan struct{}) {
 // syncResources updates the local resources representation from the
 // DigitalOcean API.
 func (r *ResourcesController) syncResources() error {
-	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
-	defer cancel()
-
 	klog.V(2).Info("syncing droplet resources.")
-	droplets, err := allDropletList(ctx, r.gclient)
+	err := r.resources.SyncDroplets()
 	if err != nil {
 		klog.Errorf("failed to sync droplet resources: %s.", err)
 	} else {
-		r.resources.UpdateDroplets(droplets)
 		klog.V(2).Info("synced droplet resources.")
 	}
 
 	klog.V(2).Info("syncing load-balancer resources.")
-	lbs, err := allLoadBalancerList(ctx, r.gclient)
+	err = r.resources.SyncLoadBalancers()
 	if err != nil {
 		klog.Errorf("failed to sync load-balancer resources: %s.", err)
 	} else {
-		r.resources.UpdateLoadBalancers(lbs)
 		klog.V(2).Info("synced load-balancer resources.")
 	}
 

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -67,7 +67,7 @@ func TestResources_DropletByID(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			resources := newResources("", "")
+			resources := newResources("", "", nil)
 			resources.UpdateDroplets(test.droplets)
 
 			droplet, found := resources.DropletByID(test.findID)
@@ -110,7 +110,7 @@ func TestResources_DropletByName(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			resources := newResources("", "")
+			resources := newResources("", "", nil)
 			resources.UpdateDroplets(test.droplets)
 
 			droplet, found := resources.DropletByName(test.findName)
@@ -172,7 +172,7 @@ func TestResources_LoadBalancerByID(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			resources := newResources("", "")
+			resources := newResources("", "", nil)
 			resources.UpdateLoadBalancers(test.lbs)
 
 			lb, found := resources.LoadBalancerByID(test.findID)
@@ -225,7 +225,7 @@ func TestResources_AddLoadBalancer(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			resources := newResources("", "")
+			resources := newResources("", "", nil)
 			resources.UpdateLoadBalancers(test.lbs)
 
 			resources.AddLoadBalancer(test.newLB)
@@ -254,6 +254,149 @@ func TestResources_LoadBalancers(t *testing.T) {
 	sort.Slice(foundLBs, func(a, b int) bool { return foundLBs[a].ID < foundLBs[b].ID })
 	if want, got := lbs, foundLBs; !reflect.DeepEqual(want, got) {
 		t.Errorf("incorrect lbs\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestResources_SyncDroplets(t *testing.T) {
+	tests := []struct {
+		name              string
+		dropletsSvc       godo.DropletsService
+		expectedResources *resources
+		err               error
+	}{
+		{
+			name: "happy path",
+			dropletsSvc: &fakeDropletService{
+				listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+					return []godo.Droplet{{ID: 2, Name: "two"}}, newFakeOKResponse(), nil
+				},
+			},
+			expectedResources: &resources{
+				dropletIDMap:   map[int]*godo.Droplet{2: {ID: 2, Name: "two"}},
+				dropletNameMap: map[string]*godo.Droplet{"two": {ID: 2, Name: "two"}},
+			},
+			err: nil,
+		},
+		{
+			name: "droplets svc failure",
+			dropletsSvc: &fakeDropletService{
+				listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+					return nil, newFakeNotOKResponse(), errors.New("droplets svc fail")
+				},
+			},
+			expectedResources: &resources{
+				dropletIDMap:   map[int]*godo.Droplet{1: {ID: 1, Name: "one"}},
+				dropletNameMap: map[string]*godo.Droplet{"one": {ID: 1, Name: "one"}},
+			},
+			err: errors.New("droplets svc fail"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &godo.Client{
+				Droplets: test.dropletsSvc,
+			}
+			fakeResources := newResources("", "", client)
+			fakeResources.UpdateDroplets([]godo.Droplet{
+				{ID: 1, Name: "one"},
+			})
+
+			err := fakeResources.SyncDroplets()
+			if test.err != nil {
+				if !reflect.DeepEqual(err, test.err) {
+					t.Errorf("incorrect err\nwant: %#v\n got: %#v", test.err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("did not expect err but got: %s", err)
+				return
+			}
+
+			if want, got := test.expectedResources.dropletIDMap, fakeResources.dropletIDMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect droplet id map\nwant: %#v\n got: %#v", want, got)
+			}
+			if want, got := test.expectedResources.dropletNameMap, fakeResources.dropletNameMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect droplet name map\nwant: %#v\n got: %#v", want, got)
+			}
+		})
+	}
+}
+
+func TestResources_SyncLoadBalancers(t *testing.T) {
+	tests := []struct {
+		name              string
+		lbsSvc            godo.LoadBalancersService
+		expectedResources *resources
+		err               error
+	}{
+		{
+			name: "happy path",
+			lbsSvc: &fakeLBService{
+				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+					return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
+				},
+			},
+			expectedResources: &resources{
+				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"2": {ID: "2", Name: "two"}},
+				loadBalancerNameMap: map[string]*godo.LoadBalancer{"two": {ID: "2", Name: "two"}},
+			},
+			err: nil,
+		},
+		{
+			name: "lbs svc failure",
+			lbsSvc: &fakeLBService{
+				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+					return nil, newFakeNotOKResponse(), errors.New("lbs svc fail")
+				},
+			},
+			expectedResources: &resources{
+				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"1": {ID: "1", Name: "one"}},
+				loadBalancerNameMap: map[string]*godo.LoadBalancer{"one": {ID: "1", Name: "one"}},
+			},
+			err: errors.New("lbs svc fail"),
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &godo.Client{
+				LoadBalancers: test.lbsSvc,
+			}
+			fakeResources := newResources("", "", client)
+			fakeResources.UpdateDroplets([]godo.Droplet{
+				{ID: 1, Name: "one"},
+			})
+			fakeResources.UpdateLoadBalancers([]godo.LoadBalancer{
+				{ID: "1", Name: "one"},
+			})
+
+			err := fakeResources.SyncLoadBalancers()
+			if test.err != nil {
+				if !reflect.DeepEqual(err, test.err) {
+					t.Errorf("incorrect err\nwant: %#v\n got: %#v", test.err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("did not expect err but got: %s", err)
+				return
+			}
+
+			if want, got := test.expectedResources.loadBalancerIDMap, fakeResources.loadBalancerIDMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect lb id map\nwant: %#v\n got: %#v", want, got)
+			}
+			if want, got := test.expectedResources.loadBalancerNameMap, fakeResources.loadBalancerNameMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect lb name map\nwant: %#v\n got: %#v", want, got)
+			}
+		})
 	}
 }
 
@@ -299,9 +442,6 @@ var (
 )
 
 func TestResourcesController_Run(t *testing.T) {
-	fakeResources := newResources(clusterID, "")
-	kclient := fake.NewSimpleClientset()
-	inf := informers.NewSharedInformerFactory(kclient, 0)
 	gclient := &godo.Client{
 		Droplets: &fakeDropletService{
 			listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
@@ -314,6 +454,9 @@ func TestResourcesController_Run(t *testing.T) {
 			},
 		},
 	}
+	fakeResources := newResources(clusterID, "", gclient)
+	kclient := fake.NewSimpleClientset()
+	inf := informers.NewSharedInformerFactory(kclient, 0)
 
 	res := NewResourcesController(fakeResources, inf.Core().V1().Services(), kclient, gclient)
 	stop := make(chan struct{})
@@ -329,102 +472,6 @@ func TestResourcesController_Run(t *testing.T) {
 		// Terminate goroutines just in case.
 		close(stop)
 		t.Errorf("resources calls: %d tags calls: %d", syncer.synced["resources syncer"], syncer.synced["tags syncer"])
-	}
-}
-
-func TestResourcesController_SyncResources(t *testing.T) {
-	tests := []struct {
-		name              string
-		dropletsSvc       godo.DropletsService
-		lbsSvc            godo.LoadBalancersService
-		expectedResources *resources
-	}{
-		{
-			name: "happy path",
-			dropletsSvc: &fakeDropletService{
-				listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
-					return []godo.Droplet{{ID: 2, Name: "two"}}, newFakeOKResponse(), nil
-				},
-			},
-			lbsSvc: &fakeLBService{
-				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-					return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
-				},
-			},
-			// both droplet and lb resources updated
-			expectedResources: &resources{
-				dropletIDMap:        map[int]*godo.Droplet{2: {ID: 2, Name: "two"}},
-				dropletNameMap:      map[string]*godo.Droplet{"two": {ID: 2, Name: "two"}},
-				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"2": {ID: "2", Name: "two"}},
-				loadBalancerNameMap: map[string]*godo.LoadBalancer{"two": {ID: "2", Name: "two"}},
-			},
-		},
-		{
-			name: "droplets svc failure",
-			dropletsSvc: &fakeDropletService{
-				listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
-					return nil, newFakeNotOKResponse(), errors.New("droplets svc fail")
-				},
-			},
-			lbsSvc: &fakeLBService{
-				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-					return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
-				},
-			},
-			// only lb resources updated
-			expectedResources: &resources{
-				dropletIDMap:        map[int]*godo.Droplet{1: {ID: 1, Name: "one"}},
-				dropletNameMap:      map[string]*godo.Droplet{"one": {ID: 1, Name: "one"}},
-				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"2": {ID: "2", Name: "two"}},
-				loadBalancerNameMap: map[string]*godo.LoadBalancer{"two": {ID: "2", Name: "two"}},
-			},
-		},
-		{
-			name: "lbs svc failure",
-			dropletsSvc: &fakeDropletService{
-				listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
-					return []godo.Droplet{{ID: 2, Name: "two"}}, newFakeOKResponse(), nil
-				},
-			},
-			lbsSvc: &fakeLBService{
-				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-					return nil, newFakeNotOKResponse(), errors.New("lbs svc fail")
-				},
-			},
-			// only droplet resources updated
-			expectedResources: &resources{
-				dropletIDMap:        map[int]*godo.Droplet{2: {ID: 2, Name: "two"}},
-				dropletNameMap:      map[string]*godo.Droplet{"two": {ID: 2, Name: "two"}},
-				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"1": {ID: "1", Name: "one"}},
-				loadBalancerNameMap: map[string]*godo.LoadBalancer{"one": {ID: "1", Name: "one"}},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			fakeResources := newResources("", "")
-			fakeResources.UpdateDroplets([]godo.Droplet{
-				{ID: 1, Name: "one"},
-			})
-			fakeResources.UpdateLoadBalancers([]godo.LoadBalancer{
-				{ID: "1", Name: "one"},
-			})
-			kclient := fake.NewSimpleClientset()
-			inf := informers.NewSharedInformerFactory(kclient, 0)
-			gclient := &godo.Client{
-				Droplets:      test.dropletsSvc,
-				LoadBalancers: test.lbsSvc,
-			}
-			res := NewResourcesController(fakeResources, inf.Core().V1().Services(), kclient, gclient)
-			res.syncResources()
-			if want, got := test.expectedResources, res.resources; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect resources\nwant: %#v\n got: %#v", want, got)
-			}
-		})
 	}
 }
 
@@ -544,7 +591,7 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			fakeResources := newResources("", "")
+			fakeResources := newResources("", "", nil)
 			for _, lb := range test.lbs {
 				lb := lb
 				fakeResources.loadBalancerIDMap[lb.ID] = lb

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -348,7 +348,7 @@ func TestResources_SyncDroplet(t *testing.T) {
 			fakeResources.dropletIDMap = test.initialResources.dropletIDMap
 			fakeResources.dropletNameMap = test.initialResources.dropletNameMap
 
-			err := fakeResources.SyncDroplet(1)
+			err := fakeResources.SyncDroplet(context.Background(), 1)
 			if test.err != nil {
 				if !reflect.DeepEqual(err, test.err) {
 					t.Errorf("incorrect err\nwant: %#v\n got: %#v", test.err, err)
@@ -418,7 +418,7 @@ func TestResources_SyncDroplets(t *testing.T) {
 				{ID: 1, Name: "one"},
 			})
 
-			err := fakeResources.SyncDroplets()
+			err := fakeResources.SyncDroplets(context.Background())
 			if test.err != nil {
 				if !reflect.DeepEqual(err, test.err) {
 					t.Errorf("incorrect err\nwant: %#v\n got: %#v", test.err, err)


### PR DESCRIPTION
There is a race condition that can happen at the moment when a stale resource cache for droplets can cause nodes to be deleted. The race happens when the cache for droplets is missing an actual droplet that was created since the last sync and the node controller tries to check for the existence of that node.

This PR moves the logic for update droplets and lbs into the resources struct, and introduces a `SyncDroplet` method that ensure that a droplet, given by id, is up to date in the cache. When the existence check is run, we first ensure that the droplet is up to date in the cache, before looking for its existence.

There is still a window here where a race is possible (sync run started before `SyncDroplet` is called, but doesn't finish until after `SyncDroplet` is complete and before `GetDropletByID` is called, but this window should be very unlikely).