### PR TITLE
Set a custom user agent for the godo client.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOVERSION ?= 1.12.3
 
 export GO111MODULE := off
 
-LDFLAGS ?= -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitVersion=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitCommit=$(COMMIT) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=$(GIT_TREE_STATE)
+LDFLAGS ?= -X github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do.version=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitVersion=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitCommit=$(COMMIT) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=$(GIT_TREE_STATE)
 PKG ?= github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager
 
 all: test

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -37,6 +37,8 @@ const (
 	providerName        string = "digitalocean"
 )
 
+var version string
+
 type tokenSource struct {
 	AccessToken string
 }
@@ -65,6 +67,11 @@ func newCloud() (cloudprovider.Interface, error) {
 	if overrideURL := os.Getenv(doOverrideAPIURLEnv); overrideURL != "" {
 		opts = append(opts, godo.SetBaseURL(overrideURL))
 	}
+
+	if version == "" {
+		version = "dev"
+	}
+	opts = append(opts, godo.SetUserAgent("digitalocean-cloud-controller-manager/"+version))
 
 	if token == "" {
 		return nil, fmt.Errorf("environment variable %q is required", doAccessTokenEnv)


### PR DESCRIPTION
Currently, requests made by digitalocean-cloud-controller-manager send `godo/$godoVersion` as their user agent. This change updates the user agent to use the format `digitalocean-cloud-controller-manager/$ccmVersion godo/$godoVersion` in order to help us better understand `godo` usage.