### PR TITLE
Set static flags in-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Set cloud tagging, authentication lookup skipping, and cloud provider flags in-code (@timoreimann)
 * Drop droplet cache usage in Instances implementation (@timoreimann)
 * Add note to README about CCM being already installed on DOKS (@snormore)
 * Set a custom user agent for the godo client (@andrewsomething)

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -30,11 +30,12 @@ import (
 )
 
 const (
+	// ProviderName specifies the name for the DigitalOcean provider
+	ProviderName        string = "digitalocean"
 	doAccessTokenEnv    string = "DO_ACCESS_TOKEN"
 	doOverrideAPIURLEnv string = "DO_OVERRIDE_URL"
 	doClusterIDEnv      string = "DO_CLUSTER_ID"
 	doClusterVPCIDEnv   string = "DO_CLUSTER_VPC_ID"
-	providerName        string = "digitalocean"
 )
 
 var version string
@@ -107,7 +108,7 @@ func newCloud() (cloudprovider.Interface, error) {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider(providerName, func(io.Reader) (cloudprovider.Interface, error) {
+	cloudprovider.RegisterCloudProvider(ProviderName, func(io.Reader) (cloudprovider.Interface, error) {
 		return newCloud()
 	})
 }
@@ -144,7 +145,7 @@ func (c *cloud) Routes() (cloudprovider.Routes, bool) {
 }
 
 func (c *cloud) ProviderName() string {
-	return providerName
+	return ProviderName
 }
 
 func (c *cloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -221,8 +221,8 @@ func dropletIDFromProviderID(providerID string) (int, error) {
 	}
 
 	// since split[0] is actually "digitalocean:"
-	if strings.TrimSuffix(split[0], ":") != providerName {
-		return 0, fmt.Errorf("provider name from providerID should be digitalocean: %s", providerID)
+	if strings.TrimSuffix(split[0], ":") != ProviderName {
+		return 0, fmt.Errorf("provider name from providerID should be %s: %s", ProviderName, providerID)
 	}
 
 	return strconv.Atoi(split[2])

--- a/docs/example-manifests/cloud-controller-manager.yml
+++ b/docs/example-manifests/cloud-controller-manager.yml
@@ -51,9 +51,7 @@ spec:
         name: digitalocean-cloud-controller-manager
         command:
           - "/bin/digitalocean-cloud-controller-manager"
-          - "--cloud-provider=digitalocean"
           - "--leader-elect=true"
-          - "--allow-untagged-cloud=true"
         resources:
           requests:
             cpu: 100m

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,14 +26,6 @@ All `kubelet`s in your cluster **MUST** set the flag `--cloud-provider=external`
 
 In the future, `--cloud-provider=external` will be the default. Learn more about the future of cloud providers in Kubernetes [here](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cloud-provider/cloud-provider-refactoring.md).
 
-#### --allow-untagged-cloud=true
-
-SIG Cloud Provider requires all cloud providers to specify a cluster ID in order to allow for a clear separation of multiple cloud controller managers managing several clusters in the same account. For the time being, this is not needed on DigitalOcean and thus **MUST** be disabled explicitly via the `--allow-untagged-cloud=true` flag. Otherwise, cloud controller manager will fail to start.
-
-(Note that earlier versions of the cloud controller manager set this option in-code; however, it had to be moved to a CLI argument to account for upstream bootstrapping changes that made it challenging to continue the programmatic approach.)
-
-As of this writing, there is [an ongoing debate](https://github.com/kubernetes/cloud-provider/issues/12) on whether the requirement to provide a cluster ID should be dropped again.
-
 #### --provider-id=digitalocean://\<droplet ID\>
 
 A so-called _provider ID_ annotation is attached to each node by the cloud controller manager that serves as a unique identifier to the cloud-specific VM representation. With DigitalOcean, the droplet ID is used for this purpose. The provider ID can be leveraged for efficient droplet lookups via the DigitalOcean API. Lacking the provider ID, a name-based lookup is mandated by the cloud provider interface. However, this is fairly expensive at DigitalOcean since the API does not support droplet retrieval based on names, meaning that the DigitalOcean cloud controller manager needs to iterate over all available droplets to find the one matching the desired name.


### PR DESCRIPTION
Set flags for which we know the values when configuring the Cobra run command. This allows us to drop parameters from the manifest which are highly unlikely to have any other value (though overriding via the CLI is still possible).

Probably a better way to tune the set parameters is to modify them on the `CloudControllerManagerOptions` variable which is used internally by `NewCloudControllerManagerCommand()` that we invoke. However, that latter command comes with a fair amount of flags boilerplate scaffolding that we would need to copy if we wanted to set options directly. We should rather submit a PR upstream to make configuration more flexible and less coarse-grained (i.e., not require to visit and update otherwise opaque flags).

Fixes #217