### PR TITLE
Remove GO111MODULE export in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ VERSION ?= $(shell cat VERSION)
 REGISTRY ?= digitalocean
 GOVERSION ?= 1.12.3
 
-export GO111MODULE := off
-
 LDFLAGS ?= -X github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do.version=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitVersion=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitCommit=$(COMMIT) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=$(GIT_TREE_STATE)
 PKG ?= github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager
 


### PR DESCRIPTION
This was causing `make ci` to fail when not working from a GOPATH.