### PR TITLE
Add HTTP/2 support for LBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Changed
 
-- Update Kubernetes dependencies to 1.15 (@timoreimann)
+* Update Kubernetes dependencies to 1.15 (@timoreimann)
+* HTTP/2 support for LB services (@snormore)
+* Default LB health check protocol to TCP if not specified (@snormore)
+* Default to HTTP for sticky sessions if no protocol is defined (@snormore)
 
 ## v0.1.15 (beta) - Jun 27th 2019
 

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -14,7 +14,11 @@ The path used to check if a backend droplet is healthy. Defaults to "/".
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol
 
-The health check protocol to use to check if a backend droplet is healthy. Defaults to `tcp` if not specified. Options are `tcp` and `http`.
+The health check protocol to use to check if a backend droplet is healthy. Defaults to `tcp` if not specified. Options are `tcp`, `http`, and `http2`.
+
+**Note**
+ - If a `service.beta.kubernetes.io/do-loadbalancer-tls-ports` is specified, and `service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol` is not `http2`, then `https` is used as the service protocol.
+ - If `http2` is specified, then either `service.beta.kubernetes.io/do-loadbalancer-certificate-id` or `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` must be specified since SSL is required for HTTP/2 DigitalOcean LBs.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds
 

--- a/docs/controllers/services/examples/http2-with-cert-nginx.yml
+++ b/docs/controllers/services/examples/http2-with-cert-nginx.yml
@@ -1,0 +1,36 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: https-with-cert-minimal
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP

--- a/docs/controllers/services/examples/http2-with-pass-through-nginx.yml
+++ b/docs/controllers/services/examples/http2-with-pass-through-nginx.yml
@@ -1,0 +1,43 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: https-with-tls-pass-through
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
+    service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-tls-passthrough: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        - containerPort: 443
+          protocol: TCP

--- a/docs/controllers/services/examples/http2-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/http2-with-sticky-sessions.yml
@@ -1,0 +1,51 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http2-lb
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type: "cookies"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name: "example"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl: "60"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  # This is necessary for sticky-sessions to avoid NAT
+  # confusion on the way in.
+  externalTrafficPolicy: Local
+  ports:
+    - name: http
+      protocol: TCP
+      port: 443
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+      # This is necessary for sticky-sessions because it can
+      # only consistently route to to the same nodes, not pods.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: hello
+            topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Currently pushed to `snormore/digitalocean-cloud-controller-manager:dev` if you want to try it out.

~Rebased on top of https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/236 and includes changes from https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/235 and https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/234 until they're merged.~

~Rebased on top of https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/235.~

### Example

```
kind: Service
apiVersion: v1
metadata:
  name: hello
  annotations:
    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "my-cert-uuid"
    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
spec:
  type: LoadBalancer
  selector:
    app: hello
  ports:
    - name: http
      protocol: TCP
      port: 443
      targetPort: 80
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: hello
spec:
  replicas: 3
  template:
    metadata:
      labels:
        app: hello
    spec:
      containers:
      - name: hello
        image: snormore/hello
        ports:
        - containerPort: 80
          protocol: TCP
```

```
$ curl -v https://blue.snormore.dev
...
* Using HTTP2, server supports multi-use
...
Hello, you've requested: /
```