### PR TITLE
Fix EnsureLoadBalancerDeleted for happy path and cache consistency

### DIFF
--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -135,13 +135,25 @@ func (c *resources) AddLoadBalancer(lb godo.LoadBalancer) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
+	c.deleteLB(lb)
+	c.loadBalancerIDMap[lb.ID] = &lb
+	c.loadBalancerNameMap[lb.Name] = &lb
+}
+
+func (c *resources) DeleteLoadBalancer(lb godo.LoadBalancer) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.deleteLB(lb)
+}
+
+// deleteLB expects c.mutex to be hold.
+func (c *resources) deleteLB(lb godo.LoadBalancer) {
 	existingLB, found := c.loadBalancerIDMap[lb.ID]
 	if found {
 		delete(c.loadBalancerIDMap, existingLB.ID)
 		delete(c.loadBalancerNameMap, existingLB.Name)
 	}
-	c.loadBalancerIDMap[lb.ID] = &lb
-	c.loadBalancerNameMap[lb.Name] = &lb
 }
 
 func (c *resources) UpdateLoadBalancers(lbs []godo.LoadBalancer) {

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -155,6 +155,54 @@ func TestResources_AddLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestResources_DeleteLoadBalancer(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingLBs     []godo.LoadBalancer
+		deletedLB       godo.LoadBalancer
+		expectedIDMap   map[string]*godo.LoadBalancer
+		expectedNameMap map[string]*godo.LoadBalancer
+	}{
+		{
+			name:        "delete missing",
+			existingLBs: []godo.LoadBalancer{{ID: "1", Name: "existing"}},
+			deletedLB:   godo.LoadBalancer{ID: "2", Name: "other"},
+			expectedIDMap: map[string]*godo.LoadBalancer{
+				"1": {ID: "1", Name: "existing"},
+			},
+			expectedNameMap: map[string]*godo.LoadBalancer{
+				"existing": {ID: "1", Name: "existing"},
+			},
+		},
+		{
+			name:            "delete existing",
+			existingLBs:     []godo.LoadBalancer{{ID: "1", Name: "existing"}},
+			deletedLB:       godo.LoadBalancer{ID: "1", Name: "existing"},
+			expectedIDMap:   map[string]*godo.LoadBalancer{},
+			expectedNameMap: map[string]*godo.LoadBalancer{},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			resources := newResources("", "", nil)
+			resources.UpdateLoadBalancers(test.existingLBs)
+
+			resources.DeleteLoadBalancer(test.deletedLB)
+
+			if want, got := test.expectedIDMap, resources.loadBalancerIDMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect id map\nwant :%#v\n got: %#v", want, got)
+			}
+			if want, got := test.expectedNameMap, resources.loadBalancerNameMap; !reflect.DeepEqual(want, got) {
+				t.Errorf("incorrect name map\nwant :%#v\n got: %#v", want, got)
+			}
+		})
+	}
+}
+
 func TestResources_LoadBalancers(t *testing.T) {
 	lbs := []*godo.LoadBalancer{{ID: "1"}, {ID: "2"}}
 	resources := &resources{


### PR DESCRIPTION
`EnsureLoadBalancerDeleted` was defective in two aspects:

1. The happy path returned an error even when the delete operation succeeded. While this would fix itself eventually as the cloud provider service controller put the Service object back into its work
   queue and succeed on a subsequent retry once our internal load-balancer cache synchronized with the DO API, the bug leads to one or more warning events being emitted and extra delays.
1. The load-balancer cache was not updated to remove the deleted load-balancer. This is not a problem in the general case but becomes one if users tried to re-enable the load-balancer again before the cache was able to synchronize. (At this point, `EnsureLoadBalancer` would attempt to update a non-existing load-balancer.)

This change fixes both problems.

Further details:

- Remove extra call to `GetLoadBalancer` from `EnsureLoadBalancerDeleted` in favor of `l.resources.LoadBalancerByName`: the only difference is that the former additionally returns an error if the load-balancer state is not yet active, which is something we do not care about when deleting.
- Check response for nil prior to accessing fields.
- Add `DeleteLoadBalancer` method to resources and extract deletion logic into separate function for shared usage with `AddLoadBalancer`.
- Use placeholder variable for unused context in `GetLoadBalancerName`.
- Add tests for changed and added code.