### PR TITLE
Add sticky session annotation note about externalTrafficPolicy Local and max one pod per node

### DIFF
--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -55,6 +55,10 @@ Specifies which algorithm the Load Balancer should use. Options are `round_robin
 
 Specifies which stick session type the loadbalancer should use. Options are `none` or `cookies`.
 
+**Note**
+ - Sticky sessions will route consistently to the same nodes, not pods, so you should avoid having more than one pod per node serving requests.
+ - Sticky sessions require your Service to configure `externalTrafficPolicy: Local` to avoid NAT confusion on the way in.
+
 ## service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name
 
 Specifies what cookie name to use for the DO load balancer sticky session. This annotation is required if `service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type` is set to `cookies`.

--- a/docs/controllers/services/examples/http-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/http-with-sticky-sessions.yml
@@ -40,11 +40,11 @@ spec:
         - containerPort: 80
           protocol: TCP
       # This is necessary for sticky-sessions because it can
-      # only consistently route to to the same nodes, not pods. 
+      # only consistently route to the same nodes, not pods.
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                app: hello
+                app: nginx-example
             topologyKey: kubernetes.io/hostname

--- a/docs/controllers/services/examples/https-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/https-with-sticky-sessions.yml
@@ -2,9 +2,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: http-lb
+  name: https-lb
   annotations:
-    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "https"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type: "cookies"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name: "example"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl: "60"
@@ -18,7 +19,7 @@ spec:
   ports:
     - name: http
       protocol: TCP
-      port: 80
+      port: 443
       targetPort: 80
 
 ---

--- a/docs/controllers/services/examples/https-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/https-with-sticky-sessions.yml
@@ -41,11 +41,11 @@ spec:
         - containerPort: 80
           protocol: TCP
       # This is necessary for sticky-sessions because it can
-      # only consistently route to to the same nodes, not pods. 
+      # only consistently route to the same nodes, not pods.
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                app: hello
+                app: nginx-example
             topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Add notes indicating:
 - Sticky sessions will route consistently to the same nodes, not pods, so you should avoid having more than one pod per node serving requests.
 - Sticky sessions require your Service to configure `externalTrafficPolicy: Local` to avoid NAT confusion on the way in.