### PR TITLE
Default to HTTP for sticky sessions if no protocol is defined

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -127,6 +127,10 @@ const (
 
 	// This is the DO-specific tag component prepended to the cluster ID.
 	tagPrefixClusterID = "k8s"
+
+	// Sticky sessions types.
+	stickySessionsTypeNone    = "none"
+	stickySessionsTypeCookies = "cookies"
 )
 
 var errLBNotFound = errors.New("loadbalancer not found")
@@ -442,7 +446,7 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 	// If using sticky sessions and no (or tcp) protocol was specified,
 	// default to HTTP.
 	stickySessionsType := getStickySessionsType(service)
-	if stickySessionsType == "cookies" && protocol == "tcp" {
+	if stickySessionsType == stickySessionsTypeCookies && protocol == "tcp" {
 		protocol = "http"
 	}
 
@@ -494,7 +498,7 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 func buildStickySessions(service *v1.Service) (*godo.StickySessions, error) {
 	t := getStickySessionsType(service)
 
-	if t == "none" {
+	if t == stickySessionsTypeNone {
 		return &godo.StickySessions{
 			Type: t,
 		}, nil
@@ -679,10 +683,10 @@ func getStickySessionsType(service *v1.Service) string {
 	t := service.Annotations[annDOStickySessionsType]
 
 	switch t {
-	case "cookies":
-		return "cookies"
+	case stickySessionsTypeCookies:
+		return stickySessionsTypeCookies
 	default:
-		return "none"
+		return stickySessionsTypeNone
 	}
 }
 

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -439,6 +439,13 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 		tlsPorts = append(tlsPorts, 443)
 	}
 
+	// If using sticky sessions and no (or tcp) protocol was specified,
+	// default to HTTP.
+	stickySessionsType := getStickySessionsType(service)
+	if stickySessionsType == "cookies" && protocol == "tcp" {
+		protocol = "http"
+	}
+
 	if len(tlsPorts) > 0 {
 		if certificateID == "" && !tlsPassThrough {
 			return nil, errors.New("must set certificate id or enable tls pass through")

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -58,6 +58,7 @@ Specifies which stick session type the loadbalancer should use. Options are `non
 **Note**
  - Sticky sessions will route consistently to the same nodes, not pods, so you should avoid having more than one pod per node serving requests.
  - Sticky sessions require your Service to configure `externalTrafficPolicy: Local` to avoid NAT confusion on the way in.
+ - If you do not specify an explicit protocol via annotation, and you use sticky sessions, then the protocol will default to HTTP instead of TCP.
 
 ## service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name
 

--- a/docs/controllers/services/examples/http-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/http-with-sticky-sessions.yml
@@ -4,7 +4,6 @@ apiVersion: v1
 metadata:
   name: http-lb
   annotations:
-    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type: "cookies"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name: "example"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl: "60"


### PR DESCRIPTION
This PR updates `buildForwardingRules` to default to protocol `http` if sticky sessions enabled and `tcp` (or no protocol) is set. Otherwise this can be pretty confusing for the user if they don't explicitly define the protocol via annotation. 