### PR TITLE
Default health check protocol to TCP if not specified

### DIFF
--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -14,7 +14,7 @@ The path used to check if a backend droplet is healthy. Defaults to "/".
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol
 
-The health check protocol to use to check if a backend droplet is healthy. Defaults to the protocol used in `service.beta.kubernetes.io/do-loadbalancer-protocol`. Options are `tcp` and `http`.
+The health check protocol to use to check if a backend droplet is healthy. Defaults to `tcp` if not specified. Options are `tcp` and `http`.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds
 


### PR DESCRIPTION
Default health check protocol to TCP if not specified, since DO LBs support only TCP or HTTP for these anyway. https://developers.digitalocean.com/documentation/v2/#load-balancers

First of 2 PRs to be extracted from https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/231