### PR TITLE
bump-version: remove sembump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ else
   GIT_TREE_STATE=dirty
 endif
 
-## Bump the version in the version file. Set BUMP to [ patch | major | minor ]
-BUMP := patch
-
 COMMIT ?= $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 VERSION ?= $(shell cat VERSION)
@@ -48,8 +45,8 @@ e2e:
 
 .PHONY: bump-version
 bump-version: 
-	@go get -u github.com/jessfraz/junk/sembump # update sembump tool
-	$(eval NEW_VERSION = $(shell sembump --kind $(BUMP) $(VERSION)))
+	@[ "${NEW_VERSION}" ] || ( echo "NEW_VERSION must be set (ex. make NEW_VERSION=v1.x.x bump-version)"; exit 1 )
+	@(echo ${NEW_VERSION} | grep -E "^v") || ( echo "NEW_VERSION must be a semver ('v' prefix is required)"; exit 1 )
 	@echo "Bumping VERSION from $(VERSION) to $(NEW_VERSION)"
 	@echo $(NEW_VERSION) > VERSION
 	@cp releases/${VERSION}.yml releases/${NEW_VERSION}.yml

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This will create a binary with version `dev` and docker image pushed to
 To release a new version first bump the version:
 
 ```bash
-make bump-version
+make NEW_VERSION=v1.0.0 bump-version
 ```
 
 Make sure everything looks good. Create a new branch with all changes:


### PR DESCRIPTION
Following suit with https://github.com/digitalocean/csi-digitalocean/pull/147

```
$ make bump-version
make: sembump: Command not found
go: finding github.com/jessfraz/junk/sembump latest
go: finding github.com/jessfraz/junk latest
go: downloading github.com/jessfraz/junk v0.0.0-20190525220952-288569a5afad
go: extracting github.com/jessfraz/junk v0.0.0-20190525220952-288569a5afad
-> unzip /Users/snormore/go/pkg/mod/cache/download/github.com/jessfraz/junk/@v/v0.0.0-20190525220952-288569a5afad.zip: case-insensitive file name collision: "md2pdf/VERSION" and "md2pdf/version"
go get github.com/jessfraz/junk/sembump: unzip /Users/snormore/go/pkg/mod/cache/download/github.com/jessfraz/junk/@v/v0.0.0-20190525220952-288569a5afad.zip: case-insensitive file name collision: "md2pdf/VERSION" and "md2pdf/version"
make: *** [bump-version] Error 1
```