### PR TITLE
Annotate Service with LB ID and use for lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+* Annotate Service objects by load-balancer UUIDs to enable free LB renames and improve the DO API consumption performance (@timoreimann)
 * Update Kubernetes dependencies to 1.15.0 (@timoreimann)
 * Set default LB health check protocol to TCP if not specified (@snormore)
 * Default to HTTP for sticky sessions if no protocol is defined (@snormore)

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -117,7 +117,7 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	clientset := clientBuilder.ClientOrDie("do-shared-informers")
 	sharedInformer := informers.NewSharedInformerFactory(clientset, 0)
 
-	res := NewResourcesController(c.resources, sharedInformer.Core().V1().Services(), clientset, c.client)
+	res := NewResourcesController(c.resources, sharedInformer.Core().V1().Services(), clientset)
 
 	sharedInformer.Start(nil)
 	sharedInformer.WaitForCacheSync(nil)

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -71,7 +71,7 @@ func allLoadBalancerList(ctx context.Context, client *godo.Client) ([]godo.LoadB
 		}
 
 		if resp == nil {
-			return nil, fmt.Errorf("load balancers list request returned no response")
+			return nil, fmt.Error("load balancers list request returned no response")
 		}
 
 		list = append(list, lbs...)

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -18,6 +18,7 @@ package do
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func allLoadBalancerList(ctx context.Context, client *godo.Client) ([]godo.LoadB
 		}
 
 		if resp == nil {
-			return nil, fmt.Error("load balancers list request returned no response")
+			return nil, errors.New("load balancers list request returned no response")
 		}
 
 		list = append(list, lbs...)

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -52,7 +52,7 @@ func newInstances(resources *resources, region string) cloudprovider.Instances {
 // When nodeName identifies more than one droplet, only the first will be
 // considered.
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
-	droplet, err := dropletByName(ctx, i.resources.client, nodeName)
+	droplet, err := dropletByName(ctx, i.resources.gclient, nodeName)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 		return nil, err
 	}
 
-	droplet, err := dropletByID(ctx, i.resources.client, id)
+	droplet, err := dropletByID(ctx, i.resources.gclient, id)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (st
 
 // InstanceID returns the cloud provider ID of the droplet identified by nodeName.
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	droplet, err := dropletByName(ctx, i.resources.client, nodeName)
+	droplet, err := dropletByName(ctx, i.resources.gclient, nodeName)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +98,7 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 
 // InstanceType returns the type of the droplet identified by name.
 func (i *instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	droplet, err := dropletByName(ctx, i.resources.client, name)
+	droplet, err := dropletByName(ctx, i.resources.gclient, name)
 	if err != nil {
 		return "", err
 	}
@@ -113,7 +113,7 @@ func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID str
 		return "", err
 	}
 
-	droplet, err := dropletByID(ctx, i.resources.client, id)
+	droplet, err := dropletByID(ctx, i.resources.gclient, id)
 	if err != nil {
 		return "", err
 	}
@@ -142,7 +142,7 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 		return false, err
 	}
 
-	_, err = dropletByID(ctx, i.resources.client, id)
+	_, err = dropletByID(ctx, i.resources.gclient, id)
 	if err == nil {
 		return true, nil
 	}
@@ -166,7 +166,7 @@ func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID
 		return false, fmt.Errorf("error getting droplet ID from provider ID %q: %s", providerID, err)
 	}
 
-	droplet, err := dropletByID(ctx, i.resources.client, dropletID)
+	droplet, err := dropletByID(ctx, i.resources.gclient, dropletID)
 	if err != nil {
 		return false, fmt.Errorf("error getting droplet %q by ID: %s", dropletID, err)
 	}

--- a/cloud-controller-manager/do/droplets_test.go
+++ b/cloud-controller-manager/do/droplets_test.go
@@ -161,7 +161,7 @@ func TestNodeAddresses(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	expectedAddresses := []v1.NodeAddress{
@@ -197,7 +197,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		resp := newFakeOKResponse()
 		return droplet, resp, nil
 	}
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	expectedAddresses := []v1.NodeAddress{
@@ -236,7 +236,7 @@ func TestInstanceID(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	id, err := instances.InstanceID(context.TODO(), "test-droplet")
@@ -259,7 +259,7 @@ func TestInstanceType(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	instanceType, err := instances.InstanceType(context.TODO(), "test-droplet")
@@ -280,7 +280,7 @@ func Test_InstanceShutdownByProviderID(t *testing.T) {
 		return droplet, resp, nil
 	}
 
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	shutdown, err := instances.InstanceShutdownByProviderID(context.TODO(), "digitalocean://123")
@@ -378,7 +378,7 @@ func TestDropletMatching(t *testing.T) {
 				return droplets, resp, nil
 			}
 
-			res := &resources{client: newFakeClient(fake)}
+			res := &resources{gclient: newFakeClient(fake)}
 			instances := newInstances(res, "nyc1")
 
 			addresses, err := instances.NodeAddresses(context.Background(), types.NodeName(test.nodeName))

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -218,9 +218,10 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	switch err {
 	case nil:
 		// LB existing
+		lbID := lb.ID
 		lb, _, err = l.client.LoadBalancers.Update(ctx, lb.ID, lbRequest)
 		if err != nil {
-			return nil, fmt.Errorf("failed to update load-balancer with ID %s: %s", lb.ID, err)
+			return nil, fmt.Errorf("failed to update load-balancer with ID %s: %s", lbID, err)
 		}
 
 	case errLBNotFound:

--- a/cloud-controller-manager/do/patch.go
+++ b/cloud-controller-manager/do/patch.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+func patchService(client clientset.Interface, cur, mod *v1.Service) error {
+	curJSON, err := json.Marshal(cur)
+	if err != nil {
+		return fmt.Errorf("failed to serialize current service object: %s", err)
+	}
+
+	modJSON, err := json.Marshal(mod)
+	if err != nil {
+		return fmt.Errorf("failed to serialize modified service object: %s", err)
+	}
+
+	patch, err := strategicpatch.CreateTwoWayMergePatch(curJSON, modJSON, v1.Service{})
+	if err != nil {
+		return fmt.Errorf("failed to create 2-way merge patch: %s", err)
+	}
+	if len(patch) == 0 || string(patch) == "{}" {
+		return nil
+	}
+	_, err = client.CoreV1().Services(cur.Namespace).Patch(cur.Name, types.StrategicMergePatchType, patch, "")
+	if err != nil {
+		return fmt.Errorf("failed to patch service object %s/%s: %s", cur.Namespace, cur.Name, err)
+	}
+
+	return nil
+}

--- a/cloud-controller-manager/do/patch_test.go
+++ b/cloud-controller-manager/do/patch_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPatchService(t *testing.T) {
+	cur := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "service",
+			Namespace:   metav1.NamespaceDefault,
+			Annotations: map[string]string{},
+		},
+	}
+	mod := cur.DeepCopy()
+	mod.Annotations["copy"] = "true"
+
+	cs := fake.NewSimpleClientset()
+	if _, err := cs.CoreV1().Services(metav1.NamespaceDefault).Create(cur); err != nil {
+		t.Fatalf("failed to create service: %s", err)
+	}
+
+	err := patchService(cs, cur, mod)
+	if err != nil {
+		t.Fatalf("failed to patch service: %s", err)
+	}
+
+	svc, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get(cur.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get service: %s", err)
+	}
+
+	want := "true"
+	got := svc.Annotations["copy"]
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -267,6 +267,8 @@ func (r *ResourcesController) syncTags() error {
 			id = loadBalancerIDsByName[name]
 		}
 
+		// Renamed load-balancers that have no LB ID set yet would still be
+		// missed, so check again if we have an ID now.
 		if id != "" {
 			res = append(res, godo.Resource{
 				ID:   id,

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -48,27 +48,30 @@ type resources struct {
 	clusterID    string
 	clusterVPCID string
 
-	client *godo.Client
+	gclient *godo.Client
+	kclient kubernetes.Interface
 
-	dropletIDMap        map[int]*godo.Droplet
-	dropletNameMap      map[string]*godo.Droplet
-	loadBalancerIDMap   map[string]*godo.LoadBalancer
-	loadBalancerNameMap map[string]*godo.LoadBalancer
+	dropletIDMap   map[int]*godo.Droplet
+	dropletNameMap map[string]*godo.Droplet
 
 	mutex sync.RWMutex
 }
 
-func newResources(clusterID, clusterVPCID string, client *godo.Client) *resources {
+// newResources initializes a new resources instance.
+
+// kclient can only be set during the cloud.Initialize call since that is when
+// the cloud provider framework provides us with a clientset. Fortunately, the
+// initialization order guarantees that kclient won't be consumed prior to it
+// being set.
+func newResources(clusterID, clusterVPCID string, gclient *godo.Client) *resources {
 	return &resources{
 		clusterID:    clusterID,
 		clusterVPCID: clusterVPCID,
 
-		client: client,
+		gclient: gclient,
 
-		dropletIDMap:        make(map[int]*godo.Droplet),
-		dropletNameMap:      make(map[string]*godo.Droplet),
-		loadBalancerIDMap:   make(map[string]*godo.LoadBalancer),
-		loadBalancerNameMap: make(map[string]*godo.LoadBalancer),
+		dropletIDMap:   make(map[int]*godo.Droplet),
+		dropletNameMap: make(map[string]*godo.Droplet),
 	}
 }
 
@@ -83,35 +86,6 @@ func (c *resources) Droplets() []*godo.Droplet {
 	}
 
 	return droplets
-}
-
-func (c *resources) LoadBalancerByID(id string) (droplet *godo.LoadBalancer, found bool) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	lb, found := c.loadBalancerIDMap[id]
-	return lb, found
-}
-
-func (c *resources) LoadBalancerByName(name string) (droplet *godo.LoadBalancer, found bool) {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	lb, found := c.loadBalancerNameMap[name]
-	return lb, found
-}
-
-func (c *resources) LoadBalancers() []*godo.LoadBalancer {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	var lbs []*godo.LoadBalancer
-	for _, lb := range c.loadBalancerIDMap {
-		lb := lb
-		lbs = append(lbs, lb)
-	}
-
-	return lbs
 }
 
 func (c *resources) UpdateDroplets(droplets []godo.Droplet) {
@@ -131,53 +105,11 @@ func (c *resources) UpdateDroplets(droplets []godo.Droplet) {
 	c.dropletNameMap = newNameMap
 }
 
-func (c *resources) AddLoadBalancer(lb godo.LoadBalancer) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.deleteLB(lb)
-	c.loadBalancerIDMap[lb.ID] = &lb
-	c.loadBalancerNameMap[lb.Name] = &lb
-}
-
-func (c *resources) DeleteLoadBalancer(lb godo.LoadBalancer) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.deleteLB(lb)
-}
-
-// deleteLB expects c.mutex to be hold.
-func (c *resources) deleteLB(lb godo.LoadBalancer) {
-	existingLB, found := c.loadBalancerIDMap[lb.ID]
-	if found {
-		delete(c.loadBalancerIDMap, existingLB.ID)
-		delete(c.loadBalancerNameMap, existingLB.Name)
-	}
-}
-
-func (c *resources) UpdateLoadBalancers(lbs []godo.LoadBalancer) {
-	newIDMap := make(map[string]*godo.LoadBalancer)
-	newNameMap := make(map[string]*godo.LoadBalancer)
-
-	for _, lb := range lbs {
-		lb := lb
-		newIDMap[lb.ID] = &lb
-		newNameMap[lb.Name] = &lb
-	}
-
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	c.loadBalancerIDMap = newIDMap
-	c.loadBalancerNameMap = newNameMap
-}
-
 func (c *resources) SyncDroplet(ctx context.Context, id int) error {
 	ctx, cancel := context.WithTimeout(ctx, syncResourcesTimeout)
 	defer cancel()
 
-	droplet, res, err := c.client.Droplets.Get(ctx, id)
+	droplet, res, err := c.gclient.Droplets.Get(ctx, id)
 	if err != nil {
 		if res != nil && res.StatusCode == http.StatusNotFound {
 			c.mutex.Lock()
@@ -212,25 +144,12 @@ func (c *resources) SyncDroplets(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, syncResourcesTimeout)
 	defer cancel()
 
-	droplets, err := allDropletList(ctx, c.client)
+	droplets, err := allDropletList(ctx, c.gclient)
 	if err != nil {
 		return err
 	}
 
 	c.UpdateDroplets(droplets)
-	return nil
-}
-
-func (c *resources) SyncLoadBalancers() error {
-	ctx, cancel := context.WithTimeout(context.Background(), syncResourcesTimeout)
-	defer cancel()
-
-	lbs, err := allLoadBalancerList(ctx, c.client)
-	if err != nil {
-		return err
-	}
-
-	c.UpdateLoadBalancers(lbs)
 	return nil
 }
 
@@ -266,7 +185,6 @@ func (s *tickerSyncer) Sync(name string, period time.Duration, stopCh <-chan str
 // synchronizes when needed.
 type ResourcesController struct {
 	kclient   kubernetes.Interface
-	gclient   *godo.Client
 	svcLister v1lister.ServiceLister
 
 	resources *resources
@@ -277,13 +195,12 @@ type ResourcesController struct {
 func NewResourcesController(
 	r *resources,
 	inf v1informers.ServiceInformer,
-	k kubernetes.Interface,
-	g *godo.Client,
+	client kubernetes.Interface,
 ) *ResourcesController {
+	r.kclient = client
 	return &ResourcesController{
 		resources: r,
-		kclient:   k,
-		gclient:   g,
+		kclient:   client,
 		svcLister: inf.Lister(),
 		syncer:    &tickerSyncer{},
 	}
@@ -311,14 +228,6 @@ func (r *ResourcesController) syncResources() error {
 		klog.V(2).Info("synced droplet resources.")
 	}
 
-	klog.V(2).Info("syncing load-balancer resources.")
-	err = r.resources.SyncLoadBalancers()
-	if err != nil {
-		klog.Errorf("failed to sync load-balancer resources: %s.", err)
-	} else {
-		klog.V(2).Info("synced load-balancer resources.")
-	}
-
 	return nil
 }
 
@@ -328,18 +237,22 @@ func (r *ResourcesController) syncTags() error {
 	ctx, cancel := context.WithTimeout(context.Background(), syncTagsTimeout)
 	defer cancel()
 
-	lbs := r.resources.LoadBalancers()
+	lbs, err := allLoadBalancerList(ctx, r.resources.gclient)
+	if err != nil {
+		return fmt.Errorf("failed to list load-balancers: %s", err)
+	}
 
-	// Collect tag resources for known load balancer names (i.e., services
-	// with type=LoadBalancer.)
+	// Collect tag resources for known load balancers (i.e., services with
+	// type=LoadBalancer that either have our own LB ID annotation set or go by
+	// a matching name).
 	svcs, err := r.svcLister.List(labels.Everything())
 	if err != err {
 		return fmt.Errorf("failed to list services: %s", err)
 	}
 
-	loadBalancers := make(map[string]string, len(lbs))
+	loadBalancerIDsByName := make(map[string]string, len(lbs))
 	for _, lb := range lbs {
-		loadBalancers[lb.Name] = lb.ID
+		loadBalancerIDsByName[lb.Name] = lb.ID
 	}
 
 	var res []godo.Resource
@@ -348,8 +261,13 @@ func (r *ResourcesController) syncTags() error {
 			continue
 		}
 
-		name := getDefaultLoadBalancerName(svc)
-		if id, ok := loadBalancers[name]; ok {
+		id := getLoadBalancerID(svc)
+		if id == "" {
+			name := getDefaultLoadBalancerName(svc)
+			id = loadBalancerIDsByName[name]
+		}
+
+		if id != "" {
 			res = append(res, godo.Resource{
 				ID:   id,
 				Type: godo.ResourceType(godo.LoadBalancerResourceType),
@@ -370,7 +288,7 @@ func (r *ResourcesController) syncTags() error {
 		// when we set the tag on LB creation. For LBs that have been created
 		// prior to CCM using cluster IDs, however, we need to create the tag
 		// explicitly.
-		_, _, err = r.gclient.Tags.Create(ctx, &godo.TagCreateRequest{
+		_, _, err = r.resources.gclient.Tags.Create(ctx, &godo.TagCreateRequest{
 			Name: tag,
 		})
 		if err != nil {
@@ -393,7 +311,7 @@ func (r *ResourcesController) tagResources(res []godo.Resource) error {
 	ctx, cancel := context.WithTimeout(context.Background(), syncTagsTimeout)
 	defer cancel()
 	tag := buildK8sTag(r.resources.clusterID)
-	resp, err := r.gclient.Tags.TagResources(ctx, tag, &godo.TagResourcesRequest{
+	resp, err := r.resources.gclient.Tags.TagResources(ctx, tag, &godo.TagResourcesRequest{
 		Resources: res,
 	})
 

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -33,11 +33,66 @@ import (
 	"github.com/digitalocean/godo"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+type serviceBuilder struct {
+	idx                int
+	isTypeLoadBalancer bool
+	loadBalancerID     string
+}
+
+func newSvcBuilder(idx int) *serviceBuilder {
+	return &serviceBuilder{
+		idx: idx,
+	}
+}
+
+func (sb *serviceBuilder) setTypeLoadBalancer(isTypeLoadBalancer bool) *serviceBuilder {
+	sb.isTypeLoadBalancer = isTypeLoadBalancer
+	return sb
+}
+
+func (sb *serviceBuilder) setLoadBalancerID(id string) *serviceBuilder {
+	sb.loadBalancerID = id
+	return sb
+}
+
+func (sb *serviceBuilder) build() *v1.Service {
+	rep := func(num int) string {
+		return strings.Repeat(strconv.Itoa(sb.idx), num)
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        fmt.Sprintf("service%d", sb.idx),
+			Namespace:   corev1.NamespaceDefault,
+			UID:         types.UID(fmt.Sprintf("%s-%s-%s-%s-%s", rep(7), rep(4), rep(4), rep(4), rep(12))),
+			Annotations: map[string]string{},
+		},
+	}
+	if sb.isTypeLoadBalancer {
+		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+	}
+	if sb.loadBalancerID != "" {
+		svc.Annotations[annoDOLoadBalancerID] = sb.loadBalancerID
+	}
+
+	return svc
+}
+
+func lbName(idx int) string {
+	svc := newSvcBuilder(idx).build()
+	return getDefaultLoadBalancerName(svc)
+}
+
+func createLBSvc(idx int) *corev1.Service {
+	return newSvcBuilder(idx).setTypeLoadBalancer(true).build()
+}
 
 func TestResources_Droplets(t *testing.T) {
 	droplets := []*godo.Droplet{
@@ -55,168 +110,6 @@ func TestResources_Droplets(t *testing.T) {
 	sort.Slice(foundDroplets, func(a, b int) bool { return foundDroplets[a].ID < foundDroplets[b].ID })
 	if want, got := droplets, foundDroplets; !reflect.DeepEqual(want, got) {
 		t.Errorf("incorrect droplets\nwant: %#v\n got: %#v", want, got)
-	}
-}
-
-func TestResources_LoadBalancerByID(t *testing.T) {
-	tests := []struct {
-		name    string
-		lbs     []godo.LoadBalancer
-		findID  string
-		foundLB *godo.LoadBalancer
-		found   bool
-	}{
-		{
-			name:    "existing lb",
-			lbs:     []godo.LoadBalancer{{ID: "1", Name: "one"}},
-			findID:  "1",
-			foundLB: &godo.LoadBalancer{ID: "1", Name: "one"},
-			found:   true,
-		},
-		{
-			name:    "missing lb",
-			lbs:     []godo.LoadBalancer{{ID: "1", Name: "one"}},
-			findID:  "two",
-			foundLB: nil,
-			found:   false,
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := newResources("", "", nil)
-			resources.UpdateLoadBalancers(test.lbs)
-
-			lb, found := resources.LoadBalancerByID(test.findID)
-			if want, got := test.found, found; want != got {
-				t.Errorf("incorrect found\nwant: %#v\n got: %#v", want, got)
-			}
-			if want, got := test.foundLB, lb; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect lb\nwant: %#v\n got: %#v", want, got)
-			}
-		})
-	}
-}
-
-func TestResources_AddLoadBalancer(t *testing.T) {
-	tests := []struct {
-		name            string
-		lbs             []godo.LoadBalancer
-		newLB           godo.LoadBalancer
-		expectedIDMap   map[string]*godo.LoadBalancer
-		expectedNameMap map[string]*godo.LoadBalancer
-	}{
-		{
-			name:  "update existing",
-			lbs:   []godo.LoadBalancer{{ID: "1", Name: "one"}},
-			newLB: godo.LoadBalancer{ID: "1", Name: "new"},
-			expectedIDMap: map[string]*godo.LoadBalancer{
-				"1": {ID: "1", Name: "new"},
-			},
-			expectedNameMap: map[string]*godo.LoadBalancer{
-				"new": {ID: "1", Name: "new"},
-			},
-		},
-		{
-			name:  "update new",
-			lbs:   []godo.LoadBalancer{{ID: "1", Name: "one"}},
-			newLB: godo.LoadBalancer{ID: "2", Name: "two"},
-			expectedIDMap: map[string]*godo.LoadBalancer{
-				"1": {ID: "1", Name: "one"},
-				"2": {ID: "2", Name: "two"},
-			},
-			expectedNameMap: map[string]*godo.LoadBalancer{
-				"one": {ID: "1", Name: "one"},
-				"two": {ID: "2", Name: "two"},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := newResources("", "", nil)
-			resources.UpdateLoadBalancers(test.lbs)
-
-			resources.AddLoadBalancer(test.newLB)
-
-			if want, got := test.expectedIDMap, resources.loadBalancerIDMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect id map\nwant :%#v\n got: %#v", want, got)
-			}
-			if want, got := test.expectedNameMap, resources.loadBalancerNameMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect name map\nwant :%#v\n got: %#v", want, got)
-			}
-		})
-	}
-}
-
-func TestResources_DeleteLoadBalancer(t *testing.T) {
-	tests := []struct {
-		name            string
-		existingLBs     []godo.LoadBalancer
-		deletedLB       godo.LoadBalancer
-		expectedIDMap   map[string]*godo.LoadBalancer
-		expectedNameMap map[string]*godo.LoadBalancer
-	}{
-		{
-			name:        "delete missing",
-			existingLBs: []godo.LoadBalancer{{ID: "1", Name: "existing"}},
-			deletedLB:   godo.LoadBalancer{ID: "2", Name: "other"},
-			expectedIDMap: map[string]*godo.LoadBalancer{
-				"1": {ID: "1", Name: "existing"},
-			},
-			expectedNameMap: map[string]*godo.LoadBalancer{
-				"existing": {ID: "1", Name: "existing"},
-			},
-		},
-		{
-			name:            "delete existing",
-			existingLBs:     []godo.LoadBalancer{{ID: "1", Name: "existing"}},
-			deletedLB:       godo.LoadBalancer{ID: "1", Name: "existing"},
-			expectedIDMap:   map[string]*godo.LoadBalancer{},
-			expectedNameMap: map[string]*godo.LoadBalancer{},
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			resources := newResources("", "", nil)
-			resources.UpdateLoadBalancers(test.existingLBs)
-
-			resources.DeleteLoadBalancer(test.deletedLB)
-
-			if want, got := test.expectedIDMap, resources.loadBalancerIDMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect id map\nwant :%#v\n got: %#v", want, got)
-			}
-			if want, got := test.expectedNameMap, resources.loadBalancerNameMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect name map\nwant :%#v\n got: %#v", want, got)
-			}
-		})
-	}
-}
-
-func TestResources_LoadBalancers(t *testing.T) {
-	lbs := []*godo.LoadBalancer{{ID: "1"}, {ID: "2"}}
-	resources := &resources{
-		loadBalancerIDMap: map[string]*godo.LoadBalancer{
-			lbs[0].ID: lbs[0],
-			lbs[1].ID: lbs[1],
-		},
-	}
-
-	foundLBs := resources.LoadBalancers()
-	// order found lbs by id so we can compare
-	sort.Slice(foundLBs, func(a, b int) bool { return foundLBs[a].ID < foundLBs[b].ID })
-	if want, got := lbs, foundLBs; !reflect.DeepEqual(want, got) {
-		t.Errorf("incorrect lbs\nwant: %#v\n got: %#v", want, got)
 	}
 }
 
@@ -402,79 +295,6 @@ func TestResources_SyncDroplets(t *testing.T) {
 	}
 }
 
-func TestResources_SyncLoadBalancers(t *testing.T) {
-	tests := []struct {
-		name              string
-		lbsSvc            godo.LoadBalancersService
-		expectedResources *resources
-		err               error
-	}{
-		{
-			name: "happy path",
-			lbsSvc: &fakeLBService{
-				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-					return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
-				},
-			},
-			expectedResources: &resources{
-				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"2": {ID: "2", Name: "two"}},
-				loadBalancerNameMap: map[string]*godo.LoadBalancer{"two": {ID: "2", Name: "two"}},
-			},
-			err: nil,
-		},
-		{
-			name: "lbs svc failure",
-			lbsSvc: &fakeLBService{
-				listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-					return nil, newFakeNotOKResponse(), errors.New("lbs svc fail")
-				},
-			},
-			expectedResources: &resources{
-				loadBalancerIDMap:   map[string]*godo.LoadBalancer{"1": {ID: "1", Name: "one"}},
-				loadBalancerNameMap: map[string]*godo.LoadBalancer{"one": {ID: "1", Name: "one"}},
-			},
-			err: errors.New("lbs svc fail"),
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			client := &godo.Client{
-				LoadBalancers: test.lbsSvc,
-			}
-			fakeResources := newResources("", "", client)
-			fakeResources.UpdateDroplets([]godo.Droplet{
-				{ID: 1, Name: "one"},
-			})
-			fakeResources.UpdateLoadBalancers([]godo.LoadBalancer{
-				{ID: "1", Name: "one"},
-			})
-
-			err := fakeResources.SyncLoadBalancers()
-			if test.err != nil {
-				if !reflect.DeepEqual(err, test.err) {
-					t.Errorf("incorrect err\nwant: %#v\n got: %#v", test.err, err)
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("did not expect err but got: %s", err)
-				return
-			}
-
-			if want, got := test.expectedResources.loadBalancerIDMap, fakeResources.loadBalancerIDMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect lb id map\nwant: %#v\n got: %#v", want, got)
-			}
-			if want, got := test.expectedResources.loadBalancerNameMap, fakeResources.loadBalancerNameMap; !reflect.DeepEqual(want, got) {
-				t.Errorf("incorrect lb name map\nwant: %#v\n got: %#v", want, got)
-			}
-		})
-	}
-}
-
 type recordingSyncer struct {
 	*tickerSyncer
 
@@ -524,7 +344,7 @@ func TestResourcesController_Run(t *testing.T) {
 			},
 		},
 		LoadBalancers: &fakeLBService{
-			listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+			listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 				return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
 			},
 		},
@@ -533,7 +353,7 @@ func TestResourcesController_Run(t *testing.T) {
 	kclient := fake.NewSimpleClientset()
 	inf := informers.NewSharedInformerFactory(kclient, 0)
 
-	res := NewResourcesController(fakeResources, inf.Core().V1().Services(), kclient, gclient)
+	res := NewResourcesController(fakeResources, inf.Core().V1().Services(), kclient)
 	stop := make(chan struct{})
 	syncer := newRecordingSyncer(2, stop)
 	res.syncer = syncer
@@ -550,55 +370,35 @@ func TestResourcesController_Run(t *testing.T) {
 	}
 }
 
-func lbName(idx int) string {
-	svc := createSvc(idx, false)
-	return getDefaultLoadBalancerName(svc)
-}
-
-func createSvc(idx int, isTypeLoadBalancer bool) *corev1.Service {
-	rep := func(num int) string {
-		return strings.Repeat(strconv.Itoa(idx), num)
-	}
-
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("service%d", idx),
-			UID:  types.UID(fmt.Sprintf("%s-%s-%s-%s-%s", rep(7), rep(4), rep(4), rep(4), rep(12))),
-		},
-	}
-	if isTypeLoadBalancer {
-		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-	}
-	return svc
-}
-
 func TestResourcesController_SyncTags(t *testing.T) {
 	testcases := []struct {
 		name        string
 		services    []*corev1.Service
-		lbs         []*godo.LoadBalancer
+		lbs         []godo.LoadBalancer
 		tagSvc      *fakeTagsService
 		errMsg      string
 		tagRequests []*godo.TagResourcesRequest
 	}{
 		{
 			name:     "no matching services",
-			services: []*corev1.Service{createSvc(1, true)},
-			lbs: []*godo.LoadBalancer{
+			services: []*corev1.Service{createLBSvc(1)},
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(2)},
 			},
 		},
 		{
-			name:     "service without LoadBalancer type",
-			services: []*corev1.Service{createSvc(1, false)},
-			lbs: []*godo.LoadBalancer{
+			name: "service without LoadBalancer type",
+			services: []*corev1.Service{
+				newSvcBuilder(1).setTypeLoadBalancer(false).build(),
+			},
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(1)},
 			},
 		},
 		{
 			name:     "unrecoverable resource tagging error",
-			services: []*corev1.Service{createSvc(1, true)},
-			lbs: []*godo.LoadBalancer{
+			services: []*corev1.Service{createLBSvc(1)},
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(1)},
 			},
 			tagSvc: newFakeTagsServiceWithFailure(0, errors.New("no tagging for you")),
@@ -606,8 +406,8 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		},
 		{
 			name:     "unrecoverable resource creation error",
-			services: []*corev1.Service{createSvc(1, true)},
-			lbs: []*godo.LoadBalancer{
+			services: []*corev1.Service{createLBSvc(1)},
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(1)},
 			},
 			tagSvc: newFakeTagsServiceWithFailure(1, errors.New("no tag creating for you")),
@@ -616,9 +416,9 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		{
 			name: "success on first resource tagging",
 			services: []*corev1.Service{
-				createSvc(1, true),
+				createLBSvc(1),
 			},
-			lbs: []*godo.LoadBalancer{
+			lbs: []godo.LoadBalancer{
 				{Name: lbName(1)},
 			},
 			tagSvc: newFakeTagsService(clusterIDTag),
@@ -626,10 +426,10 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		{
 			name: "multiple tags",
 			services: []*corev1.Service{
-				createSvc(1, true),
-				createSvc(2, true),
+				createLBSvc(1),
+				createLBSvc(2),
 			},
-			lbs: []*godo.LoadBalancer{
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(1)},
 				{ID: "2", Name: lbName(2)},
 			},
@@ -652,12 +452,32 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		{
 			name: "success on second resource tagging",
 			services: []*corev1.Service{
-				createSvc(1, true),
+				createLBSvc(1),
 			},
-			lbs: []*godo.LoadBalancer{
+			lbs: []godo.LoadBalancer{
 				{ID: "1", Name: lbName(1)},
 			},
 			tagSvc: newFakeTagsService(),
+		},
+		{
+			name: "found LB resource by ID annotation",
+			services: []*corev1.Service{
+				newSvcBuilder(1).setTypeLoadBalancer(true).setLoadBalancerID("f7968b52-4ed9-4a16-af8b-304253f04e20").build(),
+			},
+			lbs: []godo.LoadBalancer{
+				{Name: "renamed-lb"},
+			},
+			tagSvc: newFakeTagsService(clusterIDTag),
+			tagRequests: []*godo.TagResourcesRequest{
+				{
+					Resources: []godo.Resource{
+						{
+							ID:   "f7968b52-4ed9-4a16-af8b-304253f04e20",
+							Type: godo.LoadBalancerResourceType,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -666,17 +486,21 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			fakeResources := newResources("", "", nil)
-			for _, lb := range test.lbs {
-				lb := lb
-				fakeResources.loadBalancerIDMap[lb.ID] = lb
+			gclient := &godo.Client{
+				Droplets: nil,
+				LoadBalancers: &fakeLBService{
+					listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+						return test.lbs, newFakeOKResponse(), nil
+					},
+				},
 			}
+
+			fakeResources := newResources("", "", gclient)
 			fakeTagsService := test.tagSvc
 			if fakeTagsService == nil {
 				fakeTagsService = newFakeTagsServiceWithFailure(0, errors.New("tags service not configured, should probably not have been called"))
 			}
 
-			gclient := godo.NewClient(nil)
 			gclient.Tags = fakeTagsService
 			kclient := fake.NewSimpleClientset()
 
@@ -688,7 +512,7 @@ func TestResourcesController_SyncTags(t *testing.T) {
 			}
 
 			sharedInformer := informers.NewSharedInformerFactory(kclient, 0)
-			res := NewResourcesController(fakeResources, sharedInformer.Core().V1().Services(), kclient, gclient)
+			res := NewResourcesController(fakeResources, sharedInformer.Core().V1().Services(), kclient)
 			sharedInformer.Start(nil)
 			sharedInformer.WaitForCacheSync(nil)
 

--- a/cloud-controller-manager/do/zones.go
+++ b/cloud-controller-manager/do/zones.go
@@ -52,7 +52,7 @@ func (z zones) GetZoneByProviderID(ctx context.Context, providerID string) (clou
 		return cloudprovider.Zone{}, err
 	}
 
-	d, err := dropletByID(ctx, z.resources.client, id)
+	d, err := dropletByID(ctx, z.resources.gclient, id)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}
@@ -64,7 +64,7 @@ func (z zones) GetZoneByProviderID(ctx context.Context, providerID string) (clou
 // by nodeName. GetZoneByNodeName only sets the Region field of the returned
 // cloudprovider.Zone.
 func (z zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
-	d, err := dropletByName(ctx, z.resources.client, nodeName)
+	d, err := dropletByName(ctx, z.resources.gclient, nodeName)
 	if err != nil {
 		return cloudprovider.Zone{}, err
 	}

--- a/cloud-controller-manager/do/zones_test.go
+++ b/cloud-controller-manager/do/zones_test.go
@@ -38,7 +38,7 @@ func TestZones_GetZoneByNodeName(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	zones := newZones(res, "nyc1")
 
 	expected := cloudprovider.Zone{Region: "test1"}
@@ -62,7 +62,7 @@ func TestZones_GetZoneByProviderID(t *testing.T) {
 		resp := newFakeOKResponse()
 		return droplet, resp, nil
 	}
-	res := &resources{client: newFakeClient(fake)}
+	res := &resources{gclient: newFakeClient(fake)}
 	zones := newZones(res, "nyc1")
 
 	expected := cloudprovider.Zone{Region: "test1"}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,17 @@ The primary purpose of the variable is to allow DigitalOcean customers to easily
 
 When a cluster is created in a non-default VPC for the region, the environment variable `DO_CLUSTER_VPC_ID` must be specified or Load Balancer creation for services will fail.
 
+### Load-balancer ID annotations
+
+`digitalocean-cloud-controller-manager` attaches the UUID of load-balancers to the corresponding Service objects (given they are of type `LoadBalancer`) using the `service.k8s.digitalocean.com/load-balancer-id` annotation. This serves two purposes:
+
+1. To support load-balancer renames without impacting the correct working of `digitalocean-cloud-controller-manager`.
+2. To efficiently look up load-balancer resources in the DigitalOcean API.
+
+The annotation is added for both newly created and existing load-balancers. However, existing load-balancers lacking the annotation yet can only be associated correctly if they were not renamed before. Otherwise, the renamed load-balancer will be considered missing and a new one will be created instead, leaving the old one dangling.
+
+It is also possible to start owning an unmanaged load-balancer by adding the annotation manually prior to setting the Service type to `LoadBalancer`. Note however every load-balancer should be owned by exactly one `digitalocean-cloud-controller-manager` instance only to prevent concurrent and presumably conflicting modifications.
+
 ## Deployment
 
 ### Token

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ Starting with version v0.1.17, `digitalocean-cloud-controller-manager` attaches 
 
 `digitalocean-cloud-controller-manager` annotates new and existing Services. Note that a load-balancer that is renamed before the annotation is added will be lost, and a new one will be created.
 
-You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. If you do this while the Service is already being managed by another cluster, however, the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
+You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. Do not do this while it is being managed by another cluster, or the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
 
 ## Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,7 +77,7 @@ When a cluster is created in a non-default VPC for the region, the environment v
 
 ### Load-balancer ID annotations
 
-`digitalocean-cloud-controller-manager` attaches the UUID of load-balancers to the corresponding Service objects (given they are of type `LoadBalancer`) using the `kubernetes.digitalocean.com/load-balancer-id` annotation. This serves two purposes:
+Starting with version v0.1.17, `digitalocean-cloud-controller-manager` attaches the UUID of load-balancers to the corresponding Service objects (given they are of type `LoadBalancer`) using the `kubernetes.digitalocean.com/load-balancer-id` annotation. This serves two purposes:
 
 1. To support load-balancer renames.
 2. To efficiently look up load-balancer resources in the DigitalOcean API.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,14 +77,14 @@ When a cluster is created in a non-default VPC for the region, the environment v
 
 ### Load-balancer ID annotations
 
-`digitalocean-cloud-controller-manager` attaches the UUID of load-balancers to the corresponding Service objects (given they are of type `LoadBalancer`) using the `service.k8s.digitalocean.com/load-balancer-id` annotation. This serves two purposes:
+`digitalocean-cloud-controller-manager` attaches the UUID of load-balancers to the corresponding Service objects (given they are of type `LoadBalancer`) using the `kubernetes.digitalocean.com/load-balancer-id` annotation. This serves two purposes:
 
-1. To support load-balancer renames without impacting the correct working of `digitalocean-cloud-controller-manager`.
+1. To support load-balancer renames.
 2. To efficiently look up load-balancer resources in the DigitalOcean API.
 
-The annotation is added for both newly created and existing load-balancers. However, existing load-balancers lacking the annotation yet can only be associated correctly if they were not renamed before. Otherwise, the renamed load-balancer will be considered missing and a new one will be created instead, leaving the old one dangling.
+`digitalocean-cloud-controller-manager` annotates new and existing Services. Note that a load-balancer that is renamed before the annotation is added will be lost, and a new one will be created.
 
-It is also possible to start owning an unmanaged load-balancer by adding the annotation manually prior to setting the Service type to `LoadBalancer`. Note however every load-balancer should be owned by exactly one `digitalocean-cloud-controller-manager` instance only to prevent concurrent and presumably conflicting modifications.
+You can have `digitalocean-cloud-controller-manager` own an existing load-balancer by annotating the Service with the UUID of the load-balancer (but before setting the type to `LoadBalancer`). Do not do this while it is being managed by another cluster, or otherwise the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
 
 ## Deployment
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,7 +84,7 @@ Starting with version v0.1.17, `digitalocean-cloud-controller-manager` attaches 
 
 `digitalocean-cloud-controller-manager` annotates new and existing Services. Note that a load-balancer that is renamed before the annotation is added will be lost, and a new one will be created.
 
-You can have `digitalocean-cloud-controller-manager` own an existing load-balancer by annotating the Service with the UUID of the load-balancer (but before setting the type to `LoadBalancer`). Do not do this while it is being managed by another cluster, or otherwise the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
+You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. If you do this while the Service is already being managed by another cluster, however, the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
 
 ## Deployment
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,6 +267,7 @@ k8s.io/apiextensions-apiserver/pkg/features
 # k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/uuid
@@ -277,6 +278,10 @@ k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/intstr
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+k8s.io/apimachinery/pkg/util/json
+k8s.io/apimachinery/pkg/util/mergepatch
+k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/util/errors
@@ -286,12 +291,10 @@ k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/util/waitgroup
 k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/util/clock
-k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/conversion/queryparams
-k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/cache
@@ -302,15 +305,12 @@ k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
 k8s.io/apimachinery/pkg/api/equality
-k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/api/validation/path
 k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/apis/meta/v1/validation
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
 k8s.io/apimachinery/pkg/util/rand
-k8s.io/apimachinery/pkg/util/mergepatch
-k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/yaml
@@ -622,11 +622,11 @@ k8s.io/klog
 # k8s.io/kube-controller-manager v0.0.0 => k8s.io/kube-controller-manager v0.0.0-20190620085942-b7f18460b210
 k8s.io/kube-controller-manager/config/v1alpha1
 # k8s.io/kube-openapi v0.0.0-20190401085232-94e1e7b7574c
+k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/builder
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/handler
 k8s.io/kube-openapi/pkg/util
-k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/schemaconv
 # k8s.io/kubernetes v1.15.0
 k8s.io/kubernetes/cmd/cloud-controller-manager/app


### PR DESCRIPTION
This change decouples load-balancer names from their identity, thereby permitting renames that do not impact associations to Services any longer.

Instead of the load-balancer name, we use the immutable load-balancer UUID. As a beneficial side-effect, we can eliminate the local load-balancer cache since the DigitalOcean API allows for direct lookups by UUID in O(1) (vs. O(n) that we previously experienced when iterating through all load-balancers existing in a given account).

Load-balancer IDs are added to their corresponding Service objects as annotations. This happens both on load-balancer creates as well as most retrieval operations (e.g., `EnsureLoadBalancer`) in order to annotate pre-existing Services as well. When no load-balancer ID can be found, we fall back to doing lookups by name.

Apologies for the somewhat bloated PR, which is mostly due to the test changes required by both leveraging the LB UUID as well as removing the LB cache. Unfortunately, these two should really go together. #243 would be helpful to have, but I did not want to add yet another refactoring in the same PR.

Additional changes this PR makes:

- Add new getter method `retrieveAndAnnotateLoadBalancer` to retrieve a load-balancer by ID or name (based on the availability of the LB ID annotation), and patch the associated Service object with the found ID.
- Use new getter method in `{Get,Ensure,Update}LoadBalancer` and `EnsureLoadBalancerDeleted`.
- Exclude load-balancer activity status check from `GetLoadBalancer` as this is not the purpose of the method. (It is a pure getter without any logic.)
- Save on API calls in `EnsureLoadBalancer` by leveraging the LoadBalancer value returned by the new getter method.
- Improve clarity/readability of `EnsureLoadBalancer` by introducing a switch case statement.
- Remove the load-balancer cache and reintroduce logic around name-based lookups that existed previously.
- Remove the extra Kubernetes client maintained on the `ResourcesController` in favor of the client already managed by the `resources` struct.
- Update the tagging service to use LB IDs for lookups.
- Annotate errors.

Additional test-related changes:

- Extend and refactor tests.
- Use bare `godo.Client` for tests instead of `godo.NewClient`. The former comes with no initialization whatsoever, thus preventing us from running against the real DigitalOcean API during tests accidentally. Additionally, we also fail hard if a used API is not stubbed out.

Fixes #224