### PR TITLE
Fix e2e instructions and add a Docker runner for them

### DIFF
--- a/e2e/.dockerignore
+++ b/e2e/.dockerignore
@@ -1,0 +1,1 @@
+kubeconfig-e2e.*

--- a/e2e/.env.sample
+++ b/e2e/.env.sample
@@ -1,0 +1,6 @@
+DIGITALOCEAN_ACCESS_TOKEN=secret
+KOPS_REGION=sfo2
+S3_ENDPOINT=sfo2.digitaloceanspaces.com
+S3_ACCESS_KEY_ID=id
+S3_SECRET_ACCESS_KEY=secret
+KOPS_CLUSTER_NAME=ccme2e.example.com

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,3 @@
+# environment variables file
+!.env.sample
+.env*

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2017 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.12
+
+WORKDIR /root
+
+# Install kubectl
+RUN curl -LfO https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
+
+# Install kops
+RUN curl -Lfo kops https://github.com/kubernetes/kops/releases/download/$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | grep tag_name | cut -d '"' -f 4)/kops-linux-amd64 && \
+    chmod +x ./kops && \
+    mv ./kops /usr/local/bin/
+
+# Install doctl
+ARG DOCTL_VERSION="1.22.0"
+RUN curl -LfO https://github.com/digitalocean/doctl/releases/download/v${DOCTL_VERSION}/doctl-${DOCTL_VERSION}-linux-amd64.tar.gz && \
+    tar xf doctl-${DOCTL_VERSION}-linux-amd64.tar.gz && \
+    mv doctl /usr/local/bin
+
+# Install s3cmd and jq
+RUN apt-get update -qq && \
+    apt-get install -y s3cmd

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,10 +6,10 @@ It may be run either locally or on the CI.
 
 ## usage
 
-The easiest way to run the end-to-end test is to execute `e2e.sh`. It requires the following environment variables to be set:
+The easiest way to run the end-to-end test is to execute `docker.sh test`. It requires the following environment variables to be set or available in a `.env` file:
 
 - `DIGITALOCEAN_ACCESS_TOKEN`: the DigitalOcean access token
-- `KOPS_REGION`: the DigitalOcean region (e.g., _SFO2_)
+- `KOPS_REGION`: the DigitalOcean region (e.g., _sfo2_)
 - `S3_ENDPOINT`: the Spaces endpoint; should consist of the `KOPS_REGION` followed by the official Spaces API host (e.g., _sfo2.digitaloceanspaces.com_)
 - `S3_ACCESS_KEY_ID`: the Spaces access key ID
 - `S3_SECRET_ACCESS_KEY`: the Spaces secret access key ID
@@ -25,6 +25,6 @@ The following environment parameters are optional:
 
 ## resource cleanup
 
-The end-to-end tests clean up resources used on the DigitalOcean cloud after themselves on completion (either successful or erroneous). In the case that teardown does not complete for whatever reason (say, because of a crash of the tests or resources being in an irreparable state), the `cleanup-resources.sh` script can be used to remove the resources explicitly.
+The end-to-end tests clean up resources used on the DigitalOcean cloud after themselves on completion (either successful or erroneous). In the case that teardown does not complete for whatever reason (say, because of a crash of the tests or resources being in an irreparable state), the `docker.sh clean <ID> <NAME>` script can be used to remove the resources explicitly.
 
 See the script's header for details.

--- a/e2e/docker.sh
+++ b/e2e/docker.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 DigitalOcean
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+COMMAND=${1:-}
+TARGET_SCRIPT=$(case "${COMMAND}" in
+  (test)  echo "e2e.sh";;
+  (clean) echo "scripts/cleanup-resources.sh";;
+esac)
+
+if [ -z "${TARGET_SCRIPT}" ]; then
+    echo "usage: $(basename "$0") test|clean" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_DIR="${SCRIPT_DIR}/.."
+
+(
+    cd ${PROJECT_DIR}
+
+    DOCKER_RUN_ARGS=""
+    if [ -f e2e/.env ]; then
+        DOCKER_RUN_ARGS="--env-file e2e/.env"
+    fi
+
+    docker build -t do-ccm-e2e e2e
+    docker run \
+        --rm -it \
+        -v ${PROJECT_DIR}:/app \
+        -v ${HOME}/.ssh:/root/.ssh:ro \
+        -w /app \
+        -e DIGITALOCEAN_ACCESS_TOKEN \
+        -e KOPS_REGION \
+        -e S3_ENDPOINT \
+        -e S3_ACCESS_KEY_ID \
+        -e S3_SECRET_ACCESS_KEY \
+        -e KOPS_CLUSTER_NAME \
+        ${DOCKER_RUN_ARGS} \
+        do-ccm-e2e \
+        e2e/${TARGET_SCRIPT}
+)

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -38,5 +38,5 @@ echo "==> installing dependencies..."
   cd "${SCRIPT_DIR}"
   echo "==> running E2E tests..."
   # shellcheck disable=SC2086
-  go test -v -timeout 1h -count 1 -tags integration ${RUN} "./..."
+  GO111MODULE=on go test -mod=vendor -v -timeout 1h -count 1 -tags integration ${RUN} "./..."
 )

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -48,7 +48,7 @@ const (
 // (to clean up any previous left-overs) and after testing.
 func TestE2E(t *testing.T) {
 	var missingEnvs []string
-	for _, env := range []string{kopsEnvVarClusterName, kopsEnvVarStateStore} {
+	for _, env := range []string{kopsEnvVarClusterName} {
 		if _, ok := os.LookupEnv(env); !ok {
 			missingEnvs = append(missingEnvs, env)
 		}

--- a/e2e/scripts/setup_cluster.sh
+++ b/e2e/scripts/setup_cluster.sh
@@ -34,7 +34,16 @@ fi
 readonly KUBERNETES_VERSION="$1"
 readonly NUM_NODES="$2"
 
-SSH_PUBLIC_KEYFILE="${SSH_PUBLIC_KEYFILE:-${SCRIPT_DIR}/id_rsa.pub}"
+SSH_PUBLIC_KEYFILE=${SSH_PUBLIC_KEYFILE:-${HOME}/.ssh/id_rsa.pub}
+if [ ! -f ${SSH_PUBLIC_KEYFILE} ]; then
+  echo "${SSH_PUBLIC_KEYFILE} does not exist"
+  exit 1
+fi
+SSH_KEY_FINGERPRINT="$(ssh-keygen -E md5 -lf ${SSH_PUBLIC_KEYFILE} | cut -d " " -f 2 | sed -e "s/^MD5://")"
+if ! doctl compute ssh-key get ${SSH_KEY_FINGERPRINT}; then
+  echo "${SSH_PUBLIC_KEYFILE} (${SSH_KEY_FINGERPRINT}) does not exist in your DO account"
+  exit 1
+fi
 
 ensure_deps
 


### PR DESCRIPTION
Noticed a couple things that were off in the e2e instructions, and also wanted an isolated way to run this in a Docker image.