### PR TITLE
Clean up godo client usage in prod and test code

### DIFF
--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -28,6 +28,13 @@ import (
 	"github.com/digitalocean/godo"
 )
 
+func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService) *godo.Client {
+	return &godo.Client{
+		Droplets:      fakeDroplet,
+		LoadBalancers: fakeLB,
+	}
+}
+
 func newFakeOKResponse() *godo.Response {
 	return newFakeResponse(http.StatusOK)
 }
@@ -75,8 +82,8 @@ func linksForPage(page int) *godo.Links {
 }
 
 func TestAllDropletList(t *testing.T) {
-	client := &godo.Client{
-		Droplets: &fakeDropletService{
+	client := newFakeDropletClient(
+		&fakeDropletService{
 			listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				// Simulate pagination
 				droplets := []godo.Droplet{
@@ -90,7 +97,7 @@ func TestAllDropletList(t *testing.T) {
 				return droplets, resp, nil
 			},
 		},
-	}
+	)
 
 	droplets, err := allDropletList(context.Background(), client)
 	if err != nil {
@@ -106,8 +113,8 @@ func TestAllDropletList(t *testing.T) {
 }
 
 func TestAllLoadBalancerList(t *testing.T) {
-	client := &godo.Client{
-		LoadBalancers: &fakeLBService{
+	client := newFakeLBClient(
+		&fakeLBService{
 			listFn: func(ctx context.Context, opt *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 				// Simulate pagination
 				lbs := []godo.LoadBalancer{
@@ -121,7 +128,7 @@ func TestAllLoadBalancerList(t *testing.T) {
 				return lbs, resp, nil
 			},
 		},
-	}
+	)
 
 	lbs, err := allLoadBalancerList(context.Background(), client)
 	if err != nil {

--- a/cloud-controller-manager/do/droplets_test.go
+++ b/cloud-controller-manager/do/droplets_test.go
@@ -93,11 +93,8 @@ func (f *fakeDropletService) Neighbors(ctx context.Context, dropletID int) ([]go
 	return f.neighborsFunc(ctx, dropletID)
 }
 
-func newFakeClient(fake *fakeDropletService) *godo.Client {
-	client := godo.NewClient(nil)
-	client.Droplets = fake
-
-	return client
+func newFakeDropletClient(fakeDroplet *fakeDropletService) *godo.Client {
+	return newFakeClient(fakeDroplet, nil)
 }
 
 func newFakeDroplet() *godo.Droplet {
@@ -161,7 +158,7 @@ func TestNodeAddresses(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	expectedAddresses := []v1.NodeAddress{
@@ -197,7 +194,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		resp := newFakeOKResponse()
 		return droplet, resp, nil
 	}
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	expectedAddresses := []v1.NodeAddress{
@@ -236,7 +233,7 @@ func TestInstanceID(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	id, err := instances.InstanceID(context.TODO(), "test-droplet")
@@ -259,7 +256,7 @@ func TestInstanceType(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	instanceType, err := instances.InstanceType(context.TODO(), "test-droplet")
@@ -280,7 +277,7 @@ func Test_InstanceShutdownByProviderID(t *testing.T) {
 		return droplet, resp, nil
 	}
 
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	instances := newInstances(res, "nyc1")
 
 	shutdown, err := instances.InstanceShutdownByProviderID(context.TODO(), "digitalocean://123")
@@ -378,7 +375,7 @@ func TestDropletMatching(t *testing.T) {
 				return droplets, resp, nil
 			}
 
-			res := &resources{gclient: newFakeClient(fake)}
+			res := &resources{gclient: newFakeDropletClient(fake)}
 			instances := newInstances(res, "nyc1")
 
 			addresses, err := instances.NodeAddresses(context.Background(), types.NodeName(test.nodeName))

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -337,18 +337,18 @@ var (
 )
 
 func TestResourcesController_Run(t *testing.T) {
-	gclient := &godo.Client{
-		Droplets: &fakeDropletService{
+	gclient := newFakeClient(
+		&fakeDropletService{
 			listFunc: func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{{ID: 2, Name: "two"}}, newFakeOKResponse(), nil
 			},
 		},
-		LoadBalancers: &fakeLBService{
+		&fakeLBService{
 			listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 				return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
 			},
 		},
-	}
+	)
 	fakeResources := newResources(clusterID, "", gclient)
 	kclient := fake.NewSimpleClientset()
 	inf := informers.NewSharedInformerFactory(kclient, 0)
@@ -486,14 +486,13 @@ func TestResourcesController_SyncTags(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			gclient := &godo.Client{
-				Droplets: nil,
-				LoadBalancers: &fakeLBService{
+			gclient := newFakeLBClient(
+				&fakeLBService{
 					listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
 						return test.lbs, newFakeOKResponse(), nil
 					},
 				},
-			}
+			)
 
 			fakeResources := newResources("", "", gclient)
 			fakeTagsService := test.tagSvc

--- a/cloud-controller-manager/do/zones_test.go
+++ b/cloud-controller-manager/do/zones_test.go
@@ -38,7 +38,7 @@ func TestZones_GetZoneByNodeName(t *testing.T) {
 		return droplets, resp, nil
 	}
 
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	zones := newZones(res, "nyc1")
 
 	expected := cloudprovider.Zone{Region: "test1"}
@@ -62,7 +62,7 @@ func TestZones_GetZoneByProviderID(t *testing.T) {
 		resp := newFakeOKResponse()
 		return droplet, resp, nil
 	}
-	res := &resources{gclient: newFakeClient(fake)}
+	res := &resources{gclient: newFakeDropletClient(fake)}
 	zones := newZones(res, "nyc1")
 
 	expected := cloudprovider.Zone{Region: "test1"}


### PR DESCRIPTION
Removes the extra godo client that was maintained on the `loadBalancers` struct; we already maintain one on the shared resources variable.

Additionally, create fake clients more consistently through factory functions that return bare `godo.Client` structs with the relevant APIs stubbed out. This prevents accidentally calling the real DO API.