### PR TITLE
Use provider IDs for setting LB droplet targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Use provider ID for setting LB droplet targets (@timoreimann)
 * Annotate Service objects by load-balancer UUIDs to enable free LB renames and improve the DO API consumption performance (@timoreimann)
 
 ## v0.1.16 (beta) - Jul 16th 2019

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -40,7 +40,7 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 		}
 
 		if resp == nil {
-			return nil, fmt.Errorf("droplets list request returned no response ")
+			return nil, errors.New("droplets list request returned no response")
 		}
 
 		list = append(list, droplets...)

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -225,5 +225,11 @@ func dropletIDFromProviderID(providerID string) (int, error) {
 		return 0, fmt.Errorf("provider name from providerID should be %s: %s", ProviderName, providerID)
 	}
 
-	return strconv.Atoi(split[2])
+	digits := split[2]
+	dropletID, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert digits %q: %s", digits, err)
+	}
+
+	return dropletID, nil
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,9 +36,13 @@ A solution to the problem is to pass the provider ID (aka droplet ID) via the ku
 
 DigitalOcean's managed Kubernetes offering DOKS sets the provider ID on each worker node kubelet instance.
 
-### Kubernetes node names must match the droplet name, private ipv4 ip or public ipv4 ip
+### Kubernetes node name overriding
 
-By default, the kubelet will name nodes based on the node's hostname. On DigitalOcean, node hostnames are set based on the name of the droplet. If you decide to override the hostname on kubelets with `--hostname-override`, this will also override the node name in Kubernetes. It is important that the node name on Kubernetes matches either the droplet name, private ipv4 ip or the public ipv4 ip, otherwise cloud controller manager cannot find the corresponding droplet to nodes.
+By default, the kubelet will name nodes based on the node's hostname. On DigitalOcean, node hostnames are set based on the name of the droplet. If you decide to override the hostname on kubelets with `--hostname-override`, this will also override the node name in Kubernetes.
+
+Overriding the hostname is okay if provider IDs are injected by the kubelet. (See the previous section.) If that is not the case or there are nodes lacking the provider ID, however, then the Kubenretes node name must match either the droplet name, private ipv4 IP, or the public ipv4 IP. Otherwise, `cloud-controller-manager` won't be able to find the corresponding droplets in the DigitalOcean API and consequently fail to bootstrap nodes.
+
+### Kubernetes nodes can be reached via IP address only
 
 When setting the droplet host name as the node name (which is the default), Kubernetes will try to reach the node using its host name. However, this won't work since host names aren't resovable on DO. For example, when you run `kubectl logs` you will get an error like so:
 


### PR DESCRIPTION
Node objects may contain a provider ID of the kind `digitalocean://<droplet ID>`. At times when we need to specify the set of target droplets for load-balancer creates and updates, we now check
for the availablity of provider IDs and use them directly without relying on the local droplets cache.

This change renders the droplets cache obsolete: it was originally introduced to better support accounts with a large number of droplets. For such cases, the provider ID should be injected through the kubelet directly. Consequently, we drop the cache and resort to listing all droplets from the API only when nodes do not come with a provider ID, which should be acceptable for smaller accounts.