### PR TITLE
Remove RBAC rules for persistent volumes

### DIFF
--- a/docs/example-manifests/cloud-controller-manager.yml
+++ b/docs/example-manifests/cloud-controller-manager.yml
@@ -128,15 +128,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   verbs:
   - create

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,7 +62,6 @@ Currently `digitalocean-cloud-controller-manager` implements:
 
 In the future, it may implement:
 
-* volumecontroller - responsible for creating, deleting, attaching and detaching DO block storage.
 * routecontroller - responsible for creating firewall rules
 
 ### Resource Tagging


### PR DESCRIPTION
It was decided a fair time ago that volumes integration is to be handled by CSI. As such, we can reduce the RBAC rules and remove references from the documentation about volumes.