### PR TITLE
Support custom annotation to specify HTTP2 ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Added
 
 * Support custom annotation to specify HTTP2 ports (@timoreimann)
-
-### Added
-
 * Use provider ID for setting LB droplet targets (@timoreimann)
 * Annotate Service objects by load-balancer UUIDs to enable free LB renames and improve the DO API consumption performance (@timoreimann)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+* Support custom annotation to specify HTTP2 ports (@timoreimann)
+
+### Added
+
 * Use provider ID for setting LB droplet targets (@timoreimann)
 * Annotate Service objects by load-balancer UUIDs to enable free LB renames and improve the DO API consumption performance (@timoreimann)
 

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -8,6 +8,8 @@ See example Kubernetes Services using LoadBalancers [here](examples/).
 
 The default protocol for DigitalOcean Load Balancers. Options are `tcp`, `http`, `https`, and `http2`. Defaults to `tcp`.
 
+Certain annotations may override the default protocol. See the more specific descriptions below.
+
 If `https` or `http2` is specified, then either `service.beta.kubernetes.io/do-loadbalancer-certificate-id` or `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` must be specified as well.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-path
@@ -36,13 +38,23 @@ The number of times a health check must pass for a backend Droplet to be marked 
 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-ports
 
-Specify which ports of the loadbalancer should use the https or http2 protocol. This is a comma separated list of ports (e.g. 443,6443,7443).
+Specify which ports of the loadbalancer should use the HTTPS protocol. This is a comma separated list of ports (e.g. 443,6443,7443).
 
 If specified, exactly one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` and `service.beta.kubernetes.io/do-loadbalancer-certificate-id` must also be provided.
 
-If no TLS port is specified but one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` or `service.beta.kubernetes.io/do-loadbalancer-certificate-id` is, then port 443 is assumed to be used for TLS.
+If no HTTPS port is specified but one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` or `service.beta.kubernetes.io/do-loadbalancer-certificate-id` is, then port 443 is assumed to be used for HTTPS. This does not hold if `service.beta.kubernetes.io/do-loadbalancer-http2-ports` already specifies 443.
 
-If TLS ports are specified (either implicitly or explicitly) and `service.beta.kubernetes.io/do-loadbalancer-protocol` is not `http2`, then `https` is used as the service protocol for the TLS ports.
+Ports must not be shared between this annotation and `service.beta.kubernetes.io/do-loadbalancer-http2-ports`.
+
+## service.beta.kubernetes.io/do-loadbalancer-http2-ports
+
+Specify which ports of the loadbalancer should use the HTTP2 protocol. This is a comma separated list of ports (e.g. 443,6443,7443).
+
+If specified, exactly one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` and `service.beta.kubernetes.io/do-loadbalancer-certificate-id` must also be provided.
+
+The annotation is required for implicit HTTP2 usage, i.e., when `service.beta.kubernetes.io/do-loadbalancer-protocol` is not set to `http2`. (Unlike `service.beta.kubernetes.io/do-loadbalancer-tls-ports`, no default port is assumed for HTTP2 in order to retain compatibility with the semantics of implicit HTTPS usage.)
+
+Ports must not be shared between this annotation and `service.beta.kubernetes.io/do-loadbalancer-tls-ports`.
 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-passthrough
 

--- a/docs/controllers/services/examples/http2-with-cert-nginx.yml
+++ b/docs/controllers/services/examples/http2-with-cert-nginx.yml
@@ -4,8 +4,7 @@ apiVersion: v1
 metadata:
   name: http2-with-cert-minimal
   annotations:
-    # HTTP2 port annotation for 443 needed since it defaults to HTTPS.
-    service.beta.kubernetes.io/do-loadbalancer-http2-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
     service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
 spec:
   type: LoadBalancer

--- a/docs/controllers/services/examples/http2-with-cert-nginx.yml
+++ b/docs/controllers/services/examples/http2-with-cert-nginx.yml
@@ -2,10 +2,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: https-with-cert-minimal
+  name: http2-with-cert-minimal
   annotations:
+    # HTTP2 port annotation for 443 needed since it defaults to HTTPS.
+    service.beta.kubernetes.io/do-loadbalancer-http2-ports: "443"
     service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
-    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
 spec:
   type: LoadBalancer
   selector:

--- a/docs/controllers/services/examples/http2-with-pass-through-nginx.yml
+++ b/docs/controllers/services/examples/http2-with-pass-through-nginx.yml
@@ -2,10 +2,11 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: https-with-tls-pass-through
+  name: http2-with-tls-pass-through
   annotations:
-    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
-    service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    # HTTP2 port annotation for 443 needed since it defaults to HTTPS.
+    service.beta.kubernetes.io/do-loadbalancer-http2-ports: "443"
     service.beta.kubernetes.io/do-loadbalancer-tls-passthrough: "true"
 spec:
   type: LoadBalancer

--- a/docs/controllers/services/examples/http2-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/http2-with-sticky-sessions.yml
@@ -41,11 +41,11 @@ spec:
         - containerPort: 80
           protocol: TCP
       # This is necessary for sticky-sessions because it can
-      # only consistently route to to the same nodes, not pods.
+      # only consistently route to the same nodes, not pods.
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                app: hello
+                app: nginx-example
             topologyKey: kubernetes.io/hostname

--- a/docs/controllers/services/examples/https-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/https-with-sticky-sessions.yml
@@ -17,7 +17,7 @@ spec:
   # confusion on the way in.
   externalTrafficPolicy: Local
   ports:
-    - name: http
+    - name: https
       protocol: TCP
       port: 443
       targetPort: 80


### PR DESCRIPTION
The new annotation enables to run all protocols concurrently by allowing to specify HTTP* ports independently while maintaining backwards compatibility with the existing logic. In particular, port 443 continues to default to HTTPS unless it is explicitly bound to HTTPS.

We also add a guard preventing conflicting port sharing across both the HTTPS and HTTP2 protocols.

Fixes #254