### PR TITLE
e2e: Do not poll winding down LB if it was never created

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -227,6 +227,14 @@ func TestE2E(t *testing.T) {
 				// dangling. Therefore, we make sure to stick around until it's
 				// gone for sure, which we presume is the case if requests
 				// cannot be delivered anymore due to a network error.
+
+				// We skip this step if the LB address was never populated,
+				// however, indicating that the test never came that far.
+				if lbAddr == "" {
+					l.Println("Load balancer IP address was never assigned -- skipping check for winded down LB")
+					return
+				}
+
 				cl := &http.Client{
 					Timeout: 5 * time.Second,
 				}


### PR DESCRIPTION
Our end-to-end test cleans up after itself, which includes any created services to make sure external LBs are deleted as well. To verify that the delete has properly completed, we try to send requests over the LB until it starts to return errors (which means the LB must be gone).

It is okay to skip this step if no load balancer IP was able received.