### PR TITLE
Support LB with status.Hostname instead of status.IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Support LB with status.Hostname instead of status.IP (@snormore)
 * Set default health check protocol to HTTP if health check path is given (@snormore)
 * Support custom annotation to specify HTTP2 ports (@timoreimann)
 * Use provider ID for setting LB droplet targets (@timoreimann)

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -64,6 +64,10 @@ Specify whether the DigitalOcean Load Balancer should pass encrypted data to bac
 
 Specifies the certificate ID used for https. To list available certificates and their IDs, install [doctl](https://github.com/digitalocean/doctl) and run `doctl compute certificate list`.
 
+## service.beta.kubernetes.io/do-loadbalancer-hostname
+
+Specifies the hostname used for the Service `status.Hostname` instead of assigning `status.IP` directly. This can be used to workaround the issue of [kube-proxy adding external LB address to node local iptables rule](https://github.com/kubernetes/kubernetes/issues/66607), which will break requests to an LB from in-cluster if the LB is expected to terminate SSL or proxy protocol. See the [examples/README](examples/README.md) for more detail.
+
 ## service.beta.kubernetes.io/do-loadbalancer-algorithm
 
 Specifies which algorithm the Load Balancer should use. Options are `round_robin`, `least_connections`. Defaults to `round_robin`.

--- a/docs/controllers/services/examples/http2-with-hostname-and-cert.yml
+++ b/docs/controllers/services/examples/http2-with-hostname-and-cert.yml
@@ -1,0 +1,38 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http2-with-cert-minimal
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
+    # "example.com" should be configured to point at the IP address of the DO load-balancer
+    service.beta.kubernetes.io/do-loadbalancer-hostname: "example.com"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http2
+      protocol: TCP
+      port: 443
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP

--- a/docs/controllers/services/examples/https-with-hostname-and-cert.yml
+++ b/docs/controllers/services/examples/https-with-hostname-and-cert.yml
@@ -1,0 +1,44 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: https-with-cert
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    service.beta.kubernetes.io/do-loadbalancer-algorithm: "round_robin"
+    service.beta.kubernetes.io/do-loadbalancer-tls-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
+    # "example.com" should be configured to point at the IP address of the DO load-balancer
+    service.beta.kubernetes.io/do-loadbalancer-hostname: "example.com"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 80
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP


### PR DESCRIPTION
Annotation for specifying the hostname used for the LB `status.Hostname` instead of assigning `status.IP`. This can be used to avoid this [iptables rule being written by kube-proxy](https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/proxy/iptables/proxier.go#L958-L979) for the IP. This is useful when using SSL or proxy protocol on the LB, which will break if the request doesn't goes through it, but instead is routed directly in-cluster.

## Example

 1. Deploy the manifest below.
 1. Wait for the service external IP to be available.
 1. Add a DNS record for your hostname
 1. Uncomment the hostname annotation in the manifest below. Deploy it.

```yaml
kind: Service
apiVersion: v1
metadata:
  name: hello
  annotations:
    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "1234-5678-9012-3456"
    service.beta.kubernetes.io/do-loadbalancer-protocol: "https"
    # service.beta.kubernetes.io/do-loadbalancer-hostname: "hello.example.com"
spec:
  type: LoadBalancer
  selector:
    app: hello
  ports:
    - name: https
      protocol: TCP
      port: 443
      targetPort: 80
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: hello
spec:
  replicas: 3
  template:
    metadata:
      labels:
        app: hello
    spec:
      containers:
      - name: hello
        image: snormore/hello
        ports:
        - containerPort: 80
          protocol: TCP

```

### Before

```
$ k get svc hello
NAME    TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)         AGE
hello   LoadBalancer   10.245.83.169   63.133.251.133   443:31962/TCP   3d8h
```

```
root@hello-848657bd59-2j4h2:/go# curl https://hello.example.com
curl: (35) error:140770FC:SSL routines:SSL23_GET_SERVER_HELLO:unknown protocol
```

### After

```
$ k get svc hello
NAME    TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)         AGE
hello   LoadBalancer   10.245.83.169   hello.example.com   443:31962/TCP   3d8h
```

```
root@hello-848657bd59-2j4h2:/go# curl https://hello.example.com
Hello, you've requested: /
```