### PR TITLE
Add warning about LB ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here are some examples of how you could leverage `digitalocean-cloud-controller-
 
 When creating load-balancers through CCM (via `LoadBalancer`-typed Services), it is important that you **must not change the DO load-balancer configuration manually.** Such changes will eventually be reverted by the reconciliation loop built into CCM. The only exception to this are load-balancer names which can be changed starting with CCM v0.1.17.
 
-The only place to make load-balancer configuration changes is through the Service object.
+The only safe place to make load-balancer configuration changes is through the Service object.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here are some examples of how you could leverage `digitalocean-cloud-controller-
 
 ## Production advise
 
-When creating load-balancers through CCM (via `LoadBalancer`-typed Services), it is important that you **must not change the DO load-balancer configuration manually.** Such changes will eventually be reverted by the reconciliation loop built into CCM. The only exception to this are load-balancer names which can be changed starting with CCM v0.1.17.
+When creating load-balancers through CCM (via `LoadBalancer`-typed Services), it is important that you **must not change the DO load-balancer configuration manually.** Such changes will eventually be reverted by the reconciliation loop built into CCM.
 
 The only safe place to make load-balancer configuration changes is through the Service object.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Here are some examples of how you could leverage `digitalocean-cloud-controller-
 * [loadbalancers](docs/controllers/services/examples/)
 * [node labels and addresses](docs/controllers/node/examples/)
 
+## Production advise
+
+When creating load-balancers through CCM (via `LoadBalancer`-typed Services), it is important that you **must not change the DO load-balancer configuration manually.** Such changes will eventually be reverted by the reconciliation loop built into CCM. The only exception to this are load-balancer names which can be changed starting with CCM v0.1.17.
+
+The only place to make load-balancer configuration changes is through the Service object.
+
 ## Development
 
 Requirements:


### PR DESCRIPTION
This adds a warning to the README file about the implications of LBs changed manually and outside of the cluster.

Addresses https://github.com/digitalocean/digitalocean-cloud-controller-manager/issues/239#issuecomment-516824411