### PR TITLE
Default to health check protocol http if health check path is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Set default health check protocol to HTTP if health check path is given (@snormore)
+
 ## v0.1.16 (beta) - Jul 16th 2019
 
 ### Added

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -560,8 +560,12 @@ func getProtocol(service *v1.Service) (string, error) {
 // falling back to TCP if not specified.
 func healthCheckProtocol(service *v1.Service) (string, error) {
 	protocol := service.Annotations[annDOHealthCheckProtocol]
+	path := healthCheckPath(service)
 
 	if protocol == "" {
+		if path != "" {
+			return protocolHTTP, nil
+		}
 		return protocolTCP, nil
 	}
 

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1591,7 +1591,7 @@ func Test_buildHealthCheck(t *testing.T) {
 			healthcheck: defaultHealthCheck("http", 30000, ""),
 		},
 		{
-			name: "http health check with path",
+			name: "http health check with https and certificate",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -1637,7 +1637,7 @@ func Test_buildHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			healthcheck: defaultHealthCheck("tcp", 30000, "/health"),
+			healthcheck: defaultHealthCheck("http", 30000, "/health"),
 		},
 		{
 			name: "invalid health check using protocol override",
@@ -2163,7 +2163,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						TlsPassthrough: false,
 					},
 				},
-				HealthCheck: defaultHealthCheck("tcp", 30000, "/health"),
+				HealthCheck: defaultHealthCheck("http", 30000, "/health"),
 				Algorithm:   "round_robin",
 				StickySessions: &godo.StickySessions{
 					Type: "none",
@@ -2241,7 +2241,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						TlsPassthrough: false,
 					},
 				},
-				HealthCheck: defaultHealthCheck("tcp", 30000, "/health"),
+				HealthCheck: defaultHealthCheck("http", 30000, "/health"),
 				Algorithm:   "round_robin",
 				StickySessions: &godo.StickySessions{
 					Type: "none",


### PR DESCRIPTION
In the v0.1.16 release we changed the behaviour slightly around how we set the health check protocol default if not specified explicitly. Previously we would use the service protocol as the default. Currently we default to TCP if not specified explicitly. This breaks the case where a health check path is specified but no health check protocol, because now we get an error back from the DO LB API of `health check path isn't available for TCP`. This PR updates the behaviour so that if a health check path is specified, but no health check protocol, then default to HTTP as the health check protocol.