### PR TITLE
Default to health check protocol http if health check path is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Set default health check protocol to HTTP if health check path is given (@snormore)
 * Support custom annotation to specify HTTP2 ports (@timoreimann)
 * Use provider ID for setting LB droplet targets (@timoreimann)
 * Annotate Service objects by load-balancer UUIDs to enable free LB renames and improve the DO API consumption performance (@timoreimann)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -690,8 +690,12 @@ func getProtocol(service *v1.Service) (string, error) {
 // falling back to TCP if not specified.
 func healthCheckProtocol(service *v1.Service) (string, error) {
 	protocol := service.Annotations[annDOHealthCheckProtocol]
+	path := healthCheckPath(service)
 
 	if protocol == "" {
+		if path != "" {
+			return protocolHTTP, nil
+		}
 		return protocolTCP, nil
 	}
 

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1814,7 +1814,7 @@ func Test_buildHealthCheck(t *testing.T) {
 			healthcheck: defaultHealthCheck("http", 30000, ""),
 		},
 		{
-			name: "http health check with path",
+			name: "http health check with https and certificate",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -1860,7 +1860,7 @@ func Test_buildHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			healthcheck: defaultHealthCheck("tcp", 30000, "/health"),
+			healthcheck: defaultHealthCheck("http", 30000, "/health"),
 		},
 		{
 			name: "invalid health check using protocol override",
@@ -2386,7 +2386,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						TlsPassthrough: false,
 					},
 				},
-				HealthCheck: defaultHealthCheck("tcp", 30000, "/health"),
+				HealthCheck: defaultHealthCheck("http", 30000, "/health"),
 				Algorithm:   "round_robin",
 				StickySessions: &godo.StickySessions{
 					Type: "none",
@@ -2464,7 +2464,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 						TlsPassthrough: false,
 					},
 				},
-				HealthCheck: defaultHealthCheck("tcp", 30000, "/health"),
+				HealthCheck: defaultHealthCheck("http", 30000, "/health"),
 				Algorithm:   "round_robin",
 				StickySessions: &godo.StickySessions{
 					Type: "none",


### PR DESCRIPTION
Following up on https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/260

In the v0.1.16 release we changed the behaviour slightly around how we set the health check protocol default if not specified explicitly. Previously we would use the service protocol as the default. Currently we default to TCP if not specified explicitly. This breaks the case where a health check path is specified but no health check protocol, because now we get an error back from the DO LB API of `health check path isn't available for TCP`. This PR updates the behaviour so that if a health check path is specified, but no health check protocol, then default to HTTP as the health check protocol.