### PR TITLE
Do not force HTTP with sticky-sessions

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -556,13 +556,6 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 		return nil, err
 	}
 
-	// If using sticky sessions and no (or tcp) protocol was specified,
-	// default to HTTP.
-	stickySessionsType := getStickySessionsType(service)
-	if stickySessionsType == stickySessionsTypeCookies && protocol == protocolTCP {
-		protocol = protocolHTTP
-	}
-
 	httpsPorts, err := getHTTPSPorts(service)
 	if err != nil {
 		return nil, err

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1250,7 +1250,7 @@ func Test_buildForwardingRules(t *testing.T) {
 			nil,
 		},
 		{
-			"default forwarding rules with sticky sessions",
+			"default forwarding rules with sticky sessions no protocol specified",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -1274,9 +1274,9 @@ func Test_buildForwardingRules(t *testing.T) {
 			},
 			[]godo.ForwardingRule{
 				{
-					EntryProtocol:  "http",
+					EntryProtocol:  "tcp",
 					EntryPort:      80,
-					TargetProtocol: "http",
+					TargetProtocol: "tcp",
 					TargetPort:     30000,
 					CertificateID:  "",
 					TlsPassthrough: false,
@@ -1285,7 +1285,7 @@ func Test_buildForwardingRules(t *testing.T) {
 			nil,
 		},
 		{
-			"http forwarding rules with sticky sessions",
+			"http forwarding rules with sticky sessions and http protocol",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -2649,86 +2649,6 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					UID:  "foobar123",
 					Annotations: map[string]string{
 						annDOProtocol:                 "http",
-						annDOStickySessionsType:       "cookies",
-						annDOStickySessionsCookieName: "DO-CCM",
-						annDOStickySessionsCookieTTL:  "300",
-					},
-				},
-				Spec: v1.ServiceSpec{
-					Ports: []v1.ServicePort{
-						{
-							Name:     "test",
-							Protocol: "TCP",
-							Port:     int32(80),
-							NodePort: int32(30000),
-						},
-					},
-				},
-			},
-			[]*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-3",
-					},
-				},
-			},
-			&godo.LoadBalancerRequest{
-				// cloudprovider.GetLoadBalancer name uses 'a' + service.UID
-				// as loadbalancer name
-				Name:       "afoobar123",
-				DropletIDs: []int{100, 101, 102},
-				Region:     "nyc3",
-				ForwardingRules: []godo.ForwardingRule{
-					{
-						EntryProtocol:  "http",
-						EntryPort:      80,
-						TargetProtocol: "http",
-						TargetPort:     30000,
-						CertificateID:  "",
-						TlsPassthrough: false,
-					},
-				},
-				HealthCheck: defaultHealthCheck("tcp", 30000, ""),
-				Algorithm:   "round_robin",
-				StickySessions: &godo.StickySessions{
-					Type:             "cookies",
-					CookieName:       "DO-CCM",
-					CookieTtlSeconds: 300,
-				},
-			},
-			nil,
-		},
-		{
-			"successful load balancer request with cookies sticky sessions defaults to http",
-			[]godo.Droplet{
-				{
-					ID:   100,
-					Name: "node-1",
-				},
-				{
-					ID:   101,
-					Name: "node-2",
-				},
-				{
-					ID:   102,
-					Name: "node-3",
-				},
-			},
-			&v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test",
-					UID:  "foobar123",
-					Annotations: map[string]string{
 						annDOStickySessionsType:       "cookies",
 						annDOStickySessionsCookieName: "DO-CCM",
 						annDOStickySessionsCookieTTL:  "300",

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -79,7 +79,7 @@ Specifies which stick session type the loadbalancer should use. Options are `non
 **Note**
  - Sticky sessions will route consistently to the same nodes, not pods, so you should avoid having more than one pod per node serving requests.
  - Sticky sessions require your Service to configure `externalTrafficPolicy: Local` to avoid NAT confusion on the way in.
- - If you do not specify an explicit protocol via annotation, and you use sticky sessions, then the protocol will default to HTTP instead of TCP.
+ - Using sticky sessions with only a TCP forwarding rule will not work as expected. Sticky sessions requires HTTP to function properly.
 
 ## service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name
 

--- a/docs/controllers/services/examples/http-with-sticky-sessions.yml
+++ b/docs/controllers/services/examples/http-with-sticky-sessions.yml
@@ -4,6 +4,7 @@ apiVersion: v1
 metadata:
   name: http-lb
   annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type: "cookies"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name: "example"
     service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl: "60"


### PR DESCRIPTION
This PR reverts https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/234 and adds a warning/note about using sticky sessions with only a TCP forwarding rule and how it will not work as expected.