### PR TITLE
Ensure annotation map exists prior to adding LB ID

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -368,6 +368,9 @@ func (l *loadBalancers) ensureLoadBalancerIDAnnot(service *v1.Service, lbID stri
 	// Make a copy so we don't mutate the shared informer cache from the cloud
 	// provider framework.
 	updated := service.DeepCopy()
+	if updated.ObjectMeta.Annotations == nil {
+		updated.ObjectMeta.Annotations = map[string]string{}
+	}
 	updated.ObjectMeta.Annotations[annoDOLoadBalancerID] = lbID
 
 	return patchService(l.resources.kclient, service, updated)

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -68,16 +68,18 @@ func (sb *serviceBuilder) build() *v1.Service {
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        fmt.Sprintf("service%d", sb.idx),
-			Namespace:   corev1.NamespaceDefault,
-			UID:         types.UID(fmt.Sprintf("%s-%s-%s-%s-%s", rep(7), rep(4), rep(4), rep(4), rep(12))),
-			Annotations: map[string]string{},
+			Name:      fmt.Sprintf("service%d", sb.idx),
+			Namespace: corev1.NamespaceDefault,
+			UID:       types.UID(fmt.Sprintf("%s-%s-%s-%s-%s", rep(7), rep(4), rep(4), rep(4), rep(12))),
 		},
 	}
 	if sb.isTypeLoadBalancer {
 		svc.Spec.Type = corev1.ServiceTypeLoadBalancer
 	}
 	if sb.loadBalancerID != "" {
+		if svc.Annotations == nil {
+			svc.Annotations = map[string]string{}
+		}
 		svc.Annotations[annoDOLoadBalancerID] = sb.loadBalancerID
 	}
 


### PR DESCRIPTION
Needed to prevent in panic when the service has no annotations whatsoever, which is the default state of annotation-less services.

Also update test service builder to leave annotations uninitialized by default in order to match the production state.

Follow-up of #245 that was discovered during end-to-end test execution.