### PR TITLE
Reduce API interactions around LB tag synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Changed
+
+* Reduce API interactions around LB tag synchronization (@timoreimann)
+
 ## v0.1.17 (beta) - Aug 6th 2019
 
 ### Added


### PR DESCRIPTION
This change reduces the times we need to talk to the DO API with regards to LB tag synchronization. Specifically, we do so in two ways:

- by increasing the synchronization interval from 1 minute to 15 minutes: previously, a lower interval was chosen to populate the local LB cache, which is not necessary anymore now that the cache has been dropped in #245.
- by checking if we have any `LoadBalancer`-typed services and skipping reaching out to the LB API endpoint if we do not.

Additional changes:

- Remove obsolete interval/timeout constants.
- Update test to explicitly return an error from the fake LB service in case where we do not expect it to be called.