### PR TITLE
Overwrite service load-balancer ID on mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Changed
+
+* Overwrite service load-balancer ID on mismatch (@timoreimann)
+
 ## v0.1.18 (beta) - Aug 9th 2019
 
 ### Changed

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -361,7 +361,7 @@ func (l *loadBalancers) retrieveLoadBalancer(ctx context.Context, service *v1.Se
 }
 
 func (l *loadBalancers) ensureLoadBalancerIDAnnot(service *v1.Service, lbID string) error {
-	if val := getLoadBalancerID(service); val != "" {
+	if val := getLoadBalancerID(service); val == lbID {
 		return nil
 	}
 


### PR DESCRIPTION
This change causes the service load-balancer ID annotation to be overwritten if it does not match the given load-balancer ID.

It is required to properly handle the case where the load-balancer is deleted manually: in that case, CCM won't be able to look up the load-balancer and create a new one. Without updating the ID, however, subsequent reconciliations will continue to use the old ID, fail to find one, try to create a new but fail because a load-balancer with the given name (based on the service UUID) already exists. At this point, the reconciliation attempt will loop endlessly.

We need to break the cycle by annotating the ID of the newly created load-balancer.