### PR TITLE
Gracefully handle DO lets_encrypt cert rotation

### DIFF
--- a/cloud-controller-manager/do/certificates.go
+++ b/cloud-controller-manager/do/certificates.go
@@ -1,0 +1,7 @@
+package do
+
+const (
+	// DO Certificate types
+	certTypeLetsEncrypt = "lets_encrypt"
+	certTypeCustom      = "custom"
+)

--- a/cloud-controller-manager/do/certificates.go
+++ b/cloud-controller-manager/do/certificates.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package do
 
 const (

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -176,6 +176,19 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			expectedServiceCertID: "test-cert-id",
 			expectedLBCertID:      "test-cert-id",
 		},
+		{
+			name: "[lets_encrypt] LB cert ID does not exit and service cert ID does",
+			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
+				lb, _ := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeLetsEncrypt)
+				lbService.store[lb.ID] = lb
+
+				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
+				certService.store[cert.ID] = cert
+				return service
+			},
+			expectedServiceCertID: "service-cert-id",
+			expectedLBCertID:      "service-cert-id",
+		},
 
 		// custom test cases
 		{
@@ -227,6 +240,19 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			expectedServiceCertID: "service-cert-id",
 			expectedLBCertID:      "test-cert-id",
 			err:                   fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, "service-cert-id"),
+		},
+		{
+			name: "[custom] LB cert ID does not exit and service cert ID does",
+			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
+				lb, _ := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
+				lbService.store[lb.ID] = lb
+
+				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
+				certService.store[cert.ID] = cert
+				return service
+			},
+			expectedServiceCertID: "service-cert-id",
+			expectedLBCertID:      "service-cert-id",
 		},
 	}
 

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -18,7 +18,6 @@ package do
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -140,17 +139,6 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			expectedLBCertID:      "test-cert-id",
 		},
 		{
-			name: "[letsencrypt] LB cert ID and service cert ID match and correspond to non-existent cert",
-			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
-				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeLetsEncrypt)
-				lbService.store[lb.ID] = lb
-				return createServiceWithCert(lb.ID, cert.ID)
-			},
-			expectedLBCertID:      "test-cert-id",
-			expectedServiceCertID: "test-cert-id",
-			err:                   fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, "test-cert-id"),
-		},
-		{
 			name: "[letsencrypt] LB cert ID and service cert ID differ and both certs exist",
 			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
 				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeLetsEncrypt)
@@ -203,17 +191,6 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			expectedLBCertID:      "test-cert-id",
 		},
 		{
-			name: "[custom] LB cert ID and service cert ID match and correspond to non-existent cert",
-			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
-				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
-				lbService.store[lb.ID] = lb
-				return createServiceWithCert(lb.ID, cert.ID)
-			},
-			expectedLBCertID:      "test-cert-id",
-			expectedServiceCertID: "test-cert-id",
-			err:                   fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, "test-cert-id"),
-		},
-		{
 			name: "[custom] LB cert ID and service cert ID differ and both certs exist",
 			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
 				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
@@ -226,20 +203,6 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			},
 			expectedServiceCertID: "service-cert-id",
 			expectedLBCertID:      "service-cert-id",
-		},
-		{
-			name: "[custom] LB cert ID exists and service cert ID does not",
-			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
-				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
-				lbService.store[lb.ID] = lb
-				certService.store[cert.ID] = cert
-
-				service, _ := createServiceAndCert(lb.ID, "service-cert-id", certTypeCustom)
-				return service
-			},
-			expectedServiceCertID: "service-cert-id",
-			expectedLBCertID:      "test-cert-id",
-			err:                   fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, "service-cert-id"),
 		},
 		{
 			name: "[custom] LB cert ID does not exit and service cert ID does",

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -276,9 +276,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				}
 
 				if !reflect.DeepEqual(err, test.err) {
-					t.Error("error does not match test case expectation")
-					t.Logf("expected: %v", test.err)
-					t.Logf("actual: %v", err)
+					t.Errorf("got error %q, want: %q", err, test.err)
 				}
 
 				service, err = fakeResources.kclient.CoreV1().Services(service.Namespace).Get(service.Name, metav1.GetOptions{})
@@ -288,7 +286,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 
 				serviceCertID := getCertificateID(service)
 				if test.expectedServiceCertID != serviceCertID {
-					t.Errorf("got service certificate ID: %s, wanted: %s", test.expectedServiceCertID, serviceCertID)
+					t.Errorf("got service certificate ID: %s, want: %s", test.expectedServiceCertID, serviceCertID)
 				}
 
 				godoLoadBalancer, _, err := lbService.Get(context.Background(), getLoadBalancerID(service))
@@ -297,7 +295,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				}
 				lbCertID := getCertificateIDFromLB(godoLoadBalancer)
 				if test.expectedLBCertID != lbCertID {
-					t.Errorf("got load-balancer certificate ID: %s, wanted: %s", test.expectedLBCertID, lbCertID)
+					t.Errorf("got load-balancer certificate ID: %s, want: %s", test.expectedLBCertID, lbCertID)
 				}
 			})
 		}

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -89,7 +89,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 		err                   error
 	}{
 		{
-			name: "validate default test values, tls not enabled",
+			name: "default test values, tls not enabled",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -205,6 +205,8 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
 				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
 				lbService.store[lb.ID] = lb
+				certService.store[cert.ID] = cert
+
 				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
 				certService.store[cert.ID] = cert
 				return service
@@ -218,11 +220,13 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				lb, cert := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
 				lbService.store[lb.ID] = lb
 				certService.store[cert.ID] = cert
+
 				service, _ := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
 				return service
 			},
-			expectedServiceCertID: "test-cert-id",
+			expectedServiceCertID: "service-cert-id",
 			expectedLBCertID:      "test-cert-id",
+			err:                   fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, "service-cert-id"),
 		},
 	}
 

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+)
+
+type fakeCertService struct {
+	getFn    func(context.Context, string) (*godo.Certificate, *godo.Response, error)
+	listFn   func(context.Context, *godo.ListOptions) ([]godo.Certificate, *godo.Response, error)
+	createFn func(context.Context, *godo.CertificateRequest) (*godo.Certificate, *godo.Response, error)
+	deleteFn func(ctx context.Context, lbID string) (*godo.Response, error)
+}
+
+func (f *fakeCertService) Get(ctx context.Context, certID string) (*godo.Certificate, *godo.Response, error) {
+	return f.getFn(ctx, certID)
+}
+
+func (f *fakeCertService) List(ctx context.Context, listOpts *godo.ListOptions) ([]godo.Certificate, *godo.Response, error) {
+	return f.listFn(ctx, listOpts)
+}
+
+func (f *fakeCertService) Create(ctx context.Context, crtr *godo.CertificateRequest) (*godo.Certificate, *godo.Response, error) {
+	return f.createFn(ctx, crtr)
+}
+
+func (f *fakeCertService) Delete(ctx context.Context, certID string) (*godo.Response, error) {
+	return f.deleteFn(ctx, certID)
+}

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -113,9 +113,7 @@ func createService(lbID string) *v1.Service {
 func Test_LBaaSCertificateScenarios(t *testing.T) {
 	testcases := []struct {
 		name                  string
-		droplets              []godo.Droplet
 		setupFn               func(fakeLBService, kvCertService) *v1.Service
-		service               *v1.Service
 		expectedServiceCertID string
 		expectedLBCertID      string
 		err                   error

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -312,10 +312,11 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 					t.Fatalf("failed to get service from fake client: %s", err)
 				}
 
-				if tc.expectedServiceCertID != getCertificateID(service) {
+				serviceCertID := getCertificateID(service)
+				if tc.expectedServiceCertID != serviceCertID {
 					t.Error("unexpected service certificate ID annotation")
 					t.Logf("expected: %s", tc.expectedServiceCertID)
-					t.Logf("actual: %s", getCertificateID(service))
+					t.Logf("actual: %s", serviceCertID)
 				}
 
 				godoLoadBalancer, _, err := lbService.Get(context.TODO(), getLoadBalancerID(service))

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -220,7 +220,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				lbService.store[lb.ID] = lb
 				certService.store[cert.ID] = cert
 
-				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
+				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeCustom)
 				certService.store[cert.ID] = cert
 				return service
 			},
@@ -234,7 +234,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				lbService.store[lb.ID] = lb
 				certService.store[cert.ID] = cert
 
-				service, _ := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
+				service, _ := createServiceAndCert(lb.ID, "service-cert-id", certTypeCustom)
 				return service
 			},
 			expectedServiceCertID: "service-cert-id",
@@ -247,7 +247,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				lb, _ := createHTTPSLB(443, 30000, "test-lb-id", "test-cert-id", certTypeCustom)
 				lbService.store[lb.ID] = lb
 
-				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeLetsEncrypt)
+				service, cert := createServiceAndCert(lb.ID, "service-cert-id", certTypeCustom)
 				certService.store[cert.ID] = cert
 				return service
 			},

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -28,8 +28,9 @@ import (
 	"github.com/digitalocean/godo"
 )
 
-func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService) *godo.Client {
+func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService, fakeCert *fakeCertService) *godo.Client {
 	return &godo.Client{
+		Certificates:  fakeCert,
 		Droplets:      fakeDroplet,
 		LoadBalancers: fakeLB,
 	}

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/digitalocean/godo"
 )
 
-func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService, fakeCert *fakeCertService) *godo.Client {
+func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService, fakeCert *kvCertService) *godo.Client {
 	return &godo.Client{
 		Certificates:  fakeCert,
 		Droplets:      fakeDroplet,

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strconv"
 	"testing"
@@ -56,6 +57,10 @@ func newFakeResponse(statusCode int) *godo.Response {
 func newFakeNotFoundErrorResponse() *godo.ErrorResponse {
 	return &godo.ErrorResponse{
 		Response: &http.Response{
+			Request: &http.Request{
+				Method: "FAKE",
+				URL:    &url.URL{},
+			},
 			StatusCode: http.StatusNotFound,
 			Body:       ioutil.NopCloser(bytes.NewBufferString("test")),
 		},

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -53,6 +53,15 @@ func newFakeResponse(statusCode int) *godo.Response {
 	}
 }
 
+func newFakeNotFoundErrorResponse() *godo.ErrorResponse {
+	return &godo.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       ioutil.NopCloser(bytes.NewBufferString("test")),
+		},
+	}
+}
+
 func linksForPage(page int) *godo.Links {
 	switch page {
 	case 0, 1:

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -45,6 +45,10 @@ func newFakeNotOKResponse() *godo.Response {
 	return newFakeResponse(http.StatusInternalServerError)
 }
 
+func newFakeNotFoundResponse() *godo.Response {
+	return newFakeResponse(http.StatusNotFound)
+}
+
 func newFakeResponse(statusCode int) *godo.Response {
 	return &godo.Response{
 		Response: &http.Response{

--- a/cloud-controller-manager/do/droplets_test.go
+++ b/cloud-controller-manager/do/droplets_test.go
@@ -94,7 +94,7 @@ func (f *fakeDropletService) Neighbors(ctx context.Context, dropletID int) ([]go
 }
 
 func newFakeDropletClient(fakeDroplet *fakeDropletService) *godo.Client {
-	return newFakeClient(fakeDroplet, nil)
+	return newFakeClient(fakeDroplet, nil, nil)
 }
 
 func newFakeDroplet() *godo.Droplet {

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -229,7 +229,7 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 		// LB existing
 		lb, err = l.updateLoadBalancer(ctx, lb, lbRequest, service)
 		if err != nil {
-			return nil, fmt.Errorf("failed to update load-balancer with ID %s: %s", lb.ID, err)
+			return nil, err
 		}
 
 	case errLBNotFound:

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -274,16 +274,21 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	}, nil
 }
 
-func (l *loadBalancers) updateLoadBalancer(ctx context.Context, lb *godo.LoadBalancer, lbRequest *godo.LoadBalancerRequest, service *v1.Service) (*godo.LoadBalancer, error) {
-	var lbCertID string
+func getCertificateIDFromLB(lb *godo.LoadBalancer) string {
+	var id string
 	for _, rule := range lb.ForwardingRules {
 		if rule.CertificateID != "" {
-			lbCertID = rule.CertificateID
+			id = rule.CertificateID
 			// CCM does not currently support multiple certificates on the
 			// loadbalancers it manages so we only need to grab the first one we find
 			break
 		}
 	}
+	return id
+}
+
+func (l *loadBalancers) updateLoadBalancer(ctx context.Context, lb *godo.LoadBalancer, lbRequest *godo.LoadBalancerRequest, service *v1.Service) (*godo.LoadBalancer, error) {
+	lbCertID := getCertificateIDFromLB(lb)
 
 	checkServiceCertID := true
 	if lbCertID != "" && lbCertID != getCertificateID(service) {

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -188,8 +188,8 @@ func newServicePatcher(kclient kubernetes.Interface, base *v1.Service) servicePa
 	}
 }
 
-// Patch will submit a patch request for the Service if the updated service
-// reference contains the same set of annoations as the base copied during
+// Patch will submit a patch request for the Service unless the updated service
+// reference contains the same set of annotations as the base copied during
 // servicePatcher initialization.
 func (sp *servicePatcher) Patch(err error) error {
 	if reflect.DeepEqual(sp.base.Annotations, sp.updated.Annotations) {

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -293,7 +293,7 @@ func (l *loadBalancers) checkAndUpdateLBAndServiceCerts(ctx context.Context, ser
 		if err != nil {
 			respErr, ok := err.(*godo.ErrorResponse)
 			if ok && respErr.Response.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("the loadbalancer is configured with a nonexistent DO Certificate %q", lbCertID)
+				goto serviceCheck
 			}
 			return fmt.Errorf("failed to get DO certificate for lb: %s", err)
 		}
@@ -302,6 +302,8 @@ func (l *loadBalancers) checkAndUpdateLBAndServiceCerts(ctx context.Context, ser
 			l.ensureCertificateIDAnnot(service, lbCertID)
 		}
 	}
+
+serviceCheck:
 	if serviceCertID != "" {
 		_, _, err := l.resources.gclient.Certificates.Get(ctx, getCertificateID(service))
 		if err != nil {

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -434,6 +434,7 @@ func (l *loadBalancers) ensureServiceAnnotation(service *v1.Service, annotName, 
 	updated := service.DeepCopy()
 	if updated.ObjectMeta.Annotations == nil {
 		updated.ObjectMeta.Annotations = map[string]string{}
+		service.ObjectMeta.Annotations = map[string]string{}
 	}
 	updated.ObjectMeta.Annotations[annotName] = annotValue
 	err := patchService(l.resources.kclient, service, updated)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -325,25 +325,13 @@ func (l *loadBalancers) checkAndUpdateLBAndServiceCerts(ctx context.Context, ser
 		if err != nil {
 			respErr, ok := err.(*godo.ErrorResponse)
 			if ok && respErr.Response.StatusCode == http.StatusNotFound {
-				goto serviceCheck
+				return nil
 			}
 			return fmt.Errorf("failed to get DO certificate for lb: %s", err)
 		}
 
 		if lbCert.Type == certTypeLetsEncrypt {
 			ensureServiceAnnotation(service, annDOCertificateID, lbCertID)
-		}
-	}
-
-serviceCheck:
-	if serviceCertID != "" {
-		_, _, err := l.resources.gclient.Certificates.Get(ctx, getCertificateID(service))
-		if err != nil {
-			respErr, ok := err.(*godo.ErrorResponse)
-			if ok && respErr.Response.StatusCode == http.StatusNotFound {
-				return fmt.Errorf("the %q service annotation refers to nonexistent DO Certificate %q", annDOCertificateID, serviceCertID)
-			}
-			return fmt.Errorf("failed to get DO certificate for service: %s", err)
 		}
 	}
 

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -196,7 +196,7 @@ func (sp *servicePatcher) Patch(err error) error {
 		return err
 	}
 	perr := patchService(sp.kclient, sp.base, sp.updated)
-	return utilerrors.NewAggregate([]err{err, perr})
+	return utilerrors.NewAggregate([]error{err, perr})
 }
 
 // newLoadbalancers returns a cloudprovider.LoadBalancer whose concrete type is a *loadbalancer.

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -302,7 +302,7 @@ func (l *loadBalancers) updateLoadBalancer(ctx context.Context, lb *godo.LoadBal
 		}
 	}
 
-	if checkServiceCertID {
+	if checkServiceCertID && getCertificateID(service) != "" {
 		_, _, err := l.resources.gclient.Certificates.Get(ctx, getCertificateID(service))
 		if err != nil {
 			respErr, ok := err.(*godo.ErrorResponse)

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -100,6 +100,26 @@ func createLB() *godo.LoadBalancer {
 	}
 }
 
+func createHTTPSLB(entryPort, targetPort int, lbID, certID string) *godo.LoadBalancer {
+	return &godo.LoadBalancer{
+		// loadbalancer names are a + service.UID
+		// see cloudprovider.DefaultLoadBalancerName
+		ID:     lbID,
+		Name:   "afoobar123",
+		IP:     "10.0.0.1",
+		Status: lbStatusActive,
+		ForwardingRules: []godo.ForwardingRule{
+			{
+				EntryProtocol:  "https",
+				EntryPort:      entryPort,
+				TargetProtocol: "https",
+				TargetPort:     targetPort,
+				CertificateID:  certID,
+			},
+		},
+	}
+}
+
 func updateLB(lbr *godo.LoadBalancerRequest) *godo.LoadBalancer {
 	lb := createLB()
 	lb.ForwardingRules = lbr.ForwardingRules

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog"
@@ -3828,7 +3829,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				},
 			},
 			lbStatus: nil,
-			err:      fmt.Errorf("load-balancer is not yet active (current status: %s)", lbStatusNew),
+			err:      utilerrors.NewAggregate([]error{fmt.Errorf("load-balancer is not yet active (current status: %s)", lbStatusNew)}),
 		},
 	}
 

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -100,6 +100,20 @@ func createLB() *godo.LoadBalancer {
 	}
 }
 
+func updateLB(lbr *godo.LoadBalancerRequest) *godo.LoadBalancer {
+	lb := createLB()
+	lb.ForwardingRules = lbr.ForwardingRules
+	lb.RedirectHttpToHttps = lbr.RedirectHttpToHttps
+	lb.StickySessions = lbr.StickySessions
+	lb.HealthCheck = lbr.HealthCheck
+	lb.EnableProxyProtocol = lbr.EnableProxyProtocol
+	lb.Name = lbr.Name
+	lb.Tags = lbr.Tags
+	lb.Algorithm = lbr.Algorithm
+
+	return lb
+}
+
 func defaultHealthCheck(proto string, port int, path string) *godo.HealthCheck {
 	svc := &v1.Service{}
 	is, _ := healthCheckIntervalSeconds(svc)

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -3855,13 +3855,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				updateFn: test.updateFn,
 			}
 			certStore := make(map[string]*godo.Certificate)
-			fakeCert := newKVCertService(certStore)
-			fakeCert.getFn = func(ctx context.Context, certID string) (*godo.Certificate, *godo.Response, error) {
-				return &godo.Certificate{
-					ID:   certID,
-					Type: certTypeCustom,
-				}, nil, nil
-			}
+			fakeCert := newKVCertService(certStore, true)
 			fakeClient := newFakeClient(fakeDroplet, fakeLB, &fakeCert)
 			fakeResources := newResources("", "", fakeClient)
 			fakeResources.kclient = fake.NewSimpleClientset()

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -94,12 +94,12 @@ func newKVLBService(store map[string]*godo.LoadBalancer) fakeLBService {
 			if ok {
 				return lb, newFakeOKResponse(), nil
 			}
-			return nil, newFakeNotOKResponse(), newFakeNotFoundErrorResponse()
+			return nil, newFakeNotFoundResponse(), newFakeNotFoundErrorResponse()
 		},
 		updateFn: func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 			lb, ok := store[lbID]
 			if !ok {
-				return nil, newFakeNotOKResponse(), newFakeNotFoundErrorResponse()
+				return nil, newFakeNotFoundResponse(), newFakeNotFoundErrorResponse()
 			}
 
 			lb.ForwardingRules = lbr.ForwardingRules
@@ -131,7 +131,7 @@ func createLB() *godo.LoadBalancer {
 	}
 }
 
-func createHTTPSLB(entryPort, targetPort int, lbID, certID, certType string) (*godo.LoadBalancer, *godo.Certificate) {
+func createHTTPSLB(lbID, certID, certType string) (*godo.LoadBalancer, *godo.Certificate) {
 	lb := &godo.LoadBalancer{
 		// loadbalancer names are a + service.UID
 		// see cloudprovider.DefaultLoadBalancerName
@@ -141,10 +141,10 @@ func createHTTPSLB(entryPort, targetPort int, lbID, certID, certType string) (*g
 		Status: lbStatusActive,
 		ForwardingRules: []godo.ForwardingRule{
 			{
-				EntryProtocol:  "https",
-				EntryPort:      entryPort,
-				TargetProtocol: "https",
-				TargetPort:     targetPort,
+				EntryProtocol:  protocolHTTPS,
+				EntryPort:      443,
+				TargetProtocol: protocolHTTP,
+				TargetPort:     30000,
 				CertificateID:  certID,
 			},
 		},

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -3480,7 +3480,6 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 		listFn            func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
 		createFn          func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
 		updateFn          func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
-		getCertFn         func(context.Context, string) (*godo.Certificate, *godo.Response, error)
 		service           *v1.Service
 		newLoadBalancerID string
 		nodes             []*v1.Node

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -89,18 +89,12 @@ func (f *fakeLBService) RemoveForwardingRules(ctx context.Context, lbID string, 
 func newKVLBService(store map[string]*godo.LoadBalancer) fakeLBService {
 	return fakeLBService{
 		store: store,
-		createFn: func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
-			return nil, newFakeNotOKResponse(), errors.New("create should not have been invoked")
-		},
 		getFn: func(ctx context.Context, lbID string) (*godo.LoadBalancer, *godo.Response, error) {
 			lb, ok := store[lbID]
 			if ok {
 				return lb, newFakeOKResponse(), nil
 			}
 			return nil, newFakeNotOKResponse(), newFakeNotFoundErrorResponse()
-		},
-		listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
-			return []godo.LoadBalancer{*createLB()}, newFakeOKResponse(), nil
 		},
 		updateFn: func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 			lb, ok := store[lbID]

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -117,7 +117,6 @@ func newKVLBService(store map[string]*godo.LoadBalancer) fakeLBService {
 			lb.Tags = lbr.Tags
 			lb.Algorithm = lbr.Algorithm
 
-			store[lbID] = lb
 			return lb, newFakeOKResponse(), nil
 		},
 	}

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -103,7 +103,20 @@ func newKVLBService(store map[string]*godo.LoadBalancer) fakeLBService {
 			return []godo.LoadBalancer{*createLB()}, newFakeOKResponse(), nil
 		},
 		updateFn: func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
-			lb := updateLB(lbr)
+			lb, ok := store[lbID]
+			if !ok {
+				return nil, newFakeNotOKResponse(), newFakeNotFoundErrorResponse()
+			}
+
+			lb.ForwardingRules = lbr.ForwardingRules
+			lb.RedirectHttpToHttps = lbr.RedirectHttpToHttps
+			lb.StickySessions = lbr.StickySessions
+			lb.HealthCheck = lbr.HealthCheck
+			lb.EnableProxyProtocol = lbr.EnableProxyProtocol
+			lb.Name = lbr.Name
+			lb.Tags = lbr.Tags
+			lb.Algorithm = lbr.Algorithm
+
 			store[lbID] = lb
 			return lb, newFakeOKResponse(), nil
 		},
@@ -148,20 +161,6 @@ func createHTTPSLB(entryPort, targetPort int, lbID, certID, certType string) (*g
 		Type: certType,
 	}
 	return lb, cert
-}
-
-func updateLB(lbr *godo.LoadBalancerRequest) *godo.LoadBalancer {
-	lb := createLB()
-	lb.ForwardingRules = lbr.ForwardingRules
-	lb.RedirectHttpToHttps = lbr.RedirectHttpToHttps
-	lb.StickySessions = lbr.StickySessions
-	lb.HealthCheck = lbr.HealthCheck
-	lb.EnableProxyProtocol = lbr.EnableProxyProtocol
-	lb.Name = lbr.Name
-	lb.Tags = lbr.Tags
-	lb.Algorithm = lbr.Algorithm
-
-	return lb
 }
 
 func defaultHealthCheck(proto string, port int, path string) *godo.HealthCheck {

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -104,6 +104,7 @@ func newKVLBService(store map[string]*godo.LoadBalancer) fakeLBService {
 		},
 		updateFn: func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 			lb := updateLB(lbr)
+			store[lbID] = lb
 			return lb, newFakeOKResponse(), nil
 		},
 	}

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -3420,7 +3420,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 		}
 		return f
 	}
-	defaultGetCertFn := getGetCertFnFn("custom")
+	defaultGetCertFn := getGetCertFnFn(certTypeCustom)
 	testcases := []struct {
 		name              string
 		droplets          []godo.Droplet

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -43,6 +43,8 @@ type serviceBuilder struct {
 	idx                int
 	isTypeLoadBalancer bool
 	loadBalancerID     string
+	certificateID      string
+	certificateType    string
 }
 
 func newSvcBuilder(idx int) *serviceBuilder {
@@ -58,6 +60,12 @@ func (sb *serviceBuilder) setTypeLoadBalancer(isTypeLoadBalancer bool) *serviceB
 
 func (sb *serviceBuilder) setLoadBalancerID(id string) *serviceBuilder {
 	sb.loadBalancerID = id
+	return sb
+}
+
+func (sb *serviceBuilder) setCertificateIDAndType(id, certType string) *serviceBuilder {
+	sb.certificateID = id
+	sb.certificateType = certType
 	return sb
 }
 

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -146,6 +146,7 @@ func TestResourcesController_Run(t *testing.T) {
 				return []godo.LoadBalancer{{ID: "2", Name: "two"}}, newFakeOKResponse(), nil
 			},
 		},
+		nil,
 	)
 	fakeResources := newResources(clusterID, "", gclient)
 	kclient := fake.NewSimpleClientset()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -267,6 +267,7 @@ k8s.io/apiextensions-apiserver/pkg/features
 # k8s.io/apimachinery v0.0.0 => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/wait
@@ -284,7 +285,6 @@ k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/api/errors
-k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/runtime/serializer


### PR DESCRIPTION
While DOKS does not officially support Let's Encrypt, it is possible for users to create a DO Let's Encrypt certificate and use that cert UUID for the "service.beta.kubernetes.io/do-loadbalancer-certificate-id" on Services they create in their cluster.

This is problematic because some combination of the Certificates Service and LBaaS will automatically rotate Let's Encrypt certificates which deletes the old Certificate (resulting an invalid UUID on the "service.beta.kubernetes.io/do-loadbalancer-certificate-id" Service annotation) then updates the Loadbalancer to point at a new certificate with CCM none the wiser.

Because of the following facts:

* CCM doesn't "know" about Let's Encrypt certificates
* CCM always attempts to set the cert UUID from the Service on the LoadBalancer when making any kind of update to it
* LBaaS will return HTTP 404 status code when it determines that there is no Certificate pointed to by the given cert UUID

CCM subsequently cannot make any change to LoadBalancers in these scenarios. Actually, this can happen when users specify their own custom Certificate and update a LoadBalancer manually without also updating the Service object, but that is probably more rare than the Let's Encrypt scenario and is arguably the user's responsibility not to shoot themselves in the foot by manual changing a LoadBalancer managed by CCM.

This PR proposes a fix that changes the way CCM behaves when it encounters a Let's Encrypt certificate associated with the LoadBalancer that is different from the one found on the Service annotation; specifically, it makes an effort to update the Service annotation with the correct cert UUID.

Left to do before merging this PR:

* [x] Update broken test cases
* [x] add new test cases to cover the different cert type and existence scenarios
* [x] Consider how to handle the known edge case where the load balancer has a valid LE cert but the user may have specified a new certificate ID manually
  * Internal discussion within the DOKS team has initially proposed that we don't support this use case, but we should consider documenting that a user can't (easily) switch from a lets_encrypt to a user-managed certificate.
  * Use certificate creation datetime to determine precedence when the LB and the service certificate differe and both are valid certs.
* [x] collapse service patching code into single call
* [x] create separate PR for service cert id missing 
* [x] use loadbalancer request creation for validation (use in-memory validation where possible before reaching out to APIs)
* [x] if we can't find the loadbalancer certificate we should not fail immediately but should still attempt to update from service (add test case to validate the correct behavior here)
* [ ] manually create service/lb using k8saas-images PR image

Refs #92 