### PR TITLE
Annote TLS part(s) of building forwarding rules

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -705,7 +705,7 @@ func buildForwardingRule(service *v1.Service, port *v1.ServicePort, protocol, ce
 	if protocol == protocolHTTPS || protocol == protocolHTTP2 {
 		err := buildTLSForwardingRule(&forwardingRule, service, port.Port, certificateID, tlsPassThrough)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to build TLS part(s) of forwarding rule: %s", err)
 		}
 	}
 

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1486,7 +1486,7 @@ func Test_buildForwardingRules(t *testing.T) {
 				},
 			},
 			nil,
-			errors.New("either certificate id should be set or tls pass through enabled, not both"),
+			errors.New("failed to build TLS part(s) of forwarding rule: either certificate id should be set or tls pass through enabled, not both"),
 		},
 		{
 			"invalid TLS config, neither certificate ID is set or tls pass through enabled",
@@ -1517,7 +1517,7 @@ func Test_buildForwardingRules(t *testing.T) {
 				},
 			},
 			nil,
-			errors.New("must set certificate id or enable tls pass through"),
+			errors.New("failed to build TLS part(s) of forwarding rule: must set certificate id or enable tls pass through"),
 		},
 		{
 			"invalid HTTP2 config, neither certificate ID is set or tls pass through enabled",
@@ -1548,7 +1548,7 @@ func Test_buildForwardingRules(t *testing.T) {
 				},
 			},
 			nil,
-			errors.New("must set certificate id or enable tls pass through"),
+			errors.New("failed to build TLS part(s) of forwarding rule: must set certificate id or enable tls pass through"),
 		},
 		{
 			"secure ports shared",


### PR DESCRIPTION
This helps to better identify what part of the forwarding rule building has failed.