### PR TITLE
Warn about a bug in service annotations docs

### DIFF
--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -60,7 +60,11 @@ Ports must not be shared between this annotation and `service.beta.kubernetes.io
 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-passthrough
 
-Specify whether the DigitalOcean Load Balancer should pass encrypted data to backend droplets. This is optional. Options are `true` or `false`. Defaults to `false`.
+Specify whether the DigitalOcean Load Balancer should pass encrypted data to backend droplets. This is optional. Options are `"true"` or `"false"`. Defaults to `"false"`.
+
+**Note**
+
+You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).
 
 ## service.beta.kubernetes.io/do-loadbalancer-certificate-id
 
@@ -93,8 +97,16 @@ Specifies the TTL of cookies used for loadbalancer sticky sessions. This annotat
 
 ## service.beta.kubernetes.io/do-loadbalancer-redirect-http-to-https
 
-Indicates whether or not http traffic should be redirected to https. Options are `true` or `false`. Defaults to `false`.
+Indicates whether or not http traffic should be redirected to https. Options are `"true"` or `"false"`. Defaults to `"false"`. 
+
+**Note**
+
+You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).
 
 ## service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol
 
-Indicates whether PROXY protocol should be enabled. Options are `true` or `false`. Defaults to `false`.
+Indicates whether PROXY protocol should be enabled. Options are `"true"` or `"false"`. Defaults to `"false"`.
+
+**Note**
+
+You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).


### PR DESCRIPTION
A [kubernetes bug](https://github.com/kubernetes/kubernetes/issues/59113) caused my external-dns annotation to vanish because I had used a wrong DO service annotation with a boolean value instead of a string by accident. The load balancer annotation documentation suggests using boolean values would work here, my IDE didn't print a warning either, and using any boolean annotation causes **all** annotations on the Service object to vanish on `kubectl apply`.

This PR improves docs so other devs hopefully don't use boolean values in service annotations, possibly saving them some hours of debugging when getting bitten by similar bugs.