### PR TITLE
Add DO specific health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+* Add `DEBUG_ADDR` env var for configuring the address of a http server serving a `/healthz` health endpoint (@nanzhong)
+
 ## v0.1.21 (beta) - Oct 27th 2019
 
 ### Changed

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/main.go
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/main.go
@@ -18,10 +18,8 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
-	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
@@ -30,10 +28,6 @@ import (
 	"github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do"
 	"github.com/spf13/pflag"
 )
-
-func init() {
-	healthz.InstallHandler(http.DefaultServeMux)
-}
 
 func main() {
 	command := app.NewCloudControllerManagerCommand()
@@ -59,7 +53,6 @@ func main() {
 			// for.
 			err = fl.Value.Set(do.ProviderName)
 		}
-
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to set flag %q: %s\n", fl.Name, err)
 			os.Exit(1)

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -114,6 +114,7 @@ func newCloud() (cloudprovider.Interface, error) {
 	healthz.InstallHandler(debugMux, &godoHealthChecker{client: doClient})
 	debugAddr := defaultDebugAddr
 	if os.Getenv(debugAddrEnv) != "" {
+		debugAddr = os.Getenv(debugAddrEnv)
 	}
 
 	return &cloud{

--- a/cloud-controller-manager/do/health.go
+++ b/cloud-controller-manager/do/health.go
@@ -18,7 +18,6 @@ package do
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -39,8 +38,5 @@ func (c *godoHealthChecker) Check(r *http.Request) error {
 	ctx, cancel := context.WithTimeout(r.Context(), godoHealthTimeout)
 	defer cancel()
 	_, _, err := c.client.Account.Get(ctx)
-	if err != nil {
-		return fmt.Errorf("checking godo health: %w", err)
-	}
-	return nil
+	return err
 }

--- a/cloud-controller-manager/do/health.go
+++ b/cloud-controller-manager/do/health.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+var godoHealthTimeout = 15 * time.Second
+
+type godoHealthChecker struct {
+	client *godo.Client
+}
+
+func (c *godoHealthChecker) Name() string {
+	return "godo"
+}
+
+func (c *godoHealthChecker) Check(r *http.Request) error {
+	ctx, cancel := context.WithTimeout(r.Context(), godoHealthTimeout)
+	defer cancel()
+	_, _, err := c.client.Account.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("checking godo health: %w", err)
+	}
+	return nil
+}

--- a/cloud-controller-manager/do/health_test.go
+++ b/cloud-controller-manager/do/health_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+func TestGodoHealthChecker_Name(t *testing.T) {
+	c := godoHealthChecker{}
+	if want, got := "godo", c.Name(); want != got {
+		t.Errorf("incorrect name\nwant: %#v \n got: %#v", want, got)
+	}
+}
+
+func TestGodoHealthCheker_Check(t *testing.T) {
+	c := godoHealthChecker{}
+
+	t.Run("healthy godo", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"account":null}`))
+		}))
+		defer ts.Close()
+
+		var err error
+		c.client, err = godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = c.Check(req)
+		if err != nil {
+			t.Errorf("expected no error: %s", err)
+		}
+	})
+
+	t.Run("unhealthy godo", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		var err error
+		c.client, err = godo.New(http.DefaultClient, godo.SetBaseURL(ts.URL))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = c.Check(req)
+		if err == nil {
+			t.Error("expected error but got none")
+		}
+	})
+}

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,7 @@ github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/heketi/heketi v9.0.0+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413/go.mod h1:BeS3M108VzVlmAue3lv2WcGuPAX94/KN63MUURzbYSI=
@@ -285,6 +286,7 @@ github.com/lucas-clemente/quic-clients v0.1.0/go.mod h1:y5xVIEoObKqULIKivu+gD/LU
 github.com/lucas-clemente/quic-go v0.10.2/go.mod h1:hvaRS9IHjFLMq76puFJeWNfmn+H70QZ/CXoxqw9bzao=
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
@@ -309,6 +311,7 @@ github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfv
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -344,6 +347,7 @@ github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOl
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
@@ -392,16 +396,19 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
We want to expose a health check endpoint that we can use for monitoring the availability of CCM running in a cluster.

The way DO's CCM is currently implemented, it's configuring a healthz handler against the default serve mux, but actually not serving it anymore.

We re-use the upstream ccm cobra command for starting up CCM, and that [cobra command actually sets up all the health checking on the secure/unsecure bind address that you can configure with the `--address` flag](https://github.com/kubernetes/kubernetes/blob/master/cmd/cloud-controller-manager/app/controllermanager.go#L145-L169), however, due to the way that is implemented, there is no way we can access and and extend it.

Digging through what health checks it actually configures, it seems like it either installs the leader election health check if leader election is configured (which we disable), or it installs the default ping health checker (the empty case).

The health check that we really want to have is to check that the DO API is functional. There are a number of approach we can take here, but the simplest way is to check if a simple request successful (I've chosen the `/v2/account` endpoint).

This PR adds an additional flag/env var that can be used to configure a debug addr that we will be serving the `/healthz` endpoint on. It's intentionally setup to serve the health information insecurely to avoid complexity for now (see future considerations).

Some things to consider in the future:
- tie the DO api health to the actual endpoints that we use
    - we could tie the "health" to a mix of the `/v2/account` endpoint (to handle the empty/initial case) + the past `n` number of droplet/load balancer requests ccm has made.
- revisit the way we start up ccm (ie. do we want to continue using the upstream command directly, or do we want to reimplement the parts of it that are relevant to us)
    - this will influence how we want to support serving the debug handler securely