### PR TITLE
Fixes v0.1.21.yml manifest to be compatible with apps/v1

### DIFF
--- a/releases/v0.1.21.yml
+++ b/releases/v0.1.21.yml
@@ -7,6 +7,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: digitalocean-cloud-controller-manager
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deployment in apps/v1 requires a selector to be present in the deployment spec. Otherwise applying this manifest fails with:
```
error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec
```