### PR TITLE
Maintain default protocol when secure protocol override is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+### Fixed
+
+* Maintain default protocol when secure protocol override is applied (@timoreimann)
+
 ## v0.1.22 (beta) - Jan 15th 2020
 
 * Add `DEBUG_ADDR` environment variable for configuring the address of an HTTP server serving a `/healthz` health endpoint (@nanzhong)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -632,7 +632,7 @@ func buildHealthCheck(service *v1.Service) (*godo.HealthCheck, error) {
 func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 	var forwardingRules []godo.ForwardingRule
 
-	protocol, err := getProtocol(service)
+	defaultProtocol, err := getProtocol(service)
 	if err != nil {
 		return nil, err
 	}
@@ -670,6 +670,7 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 	}
 
 	for _, port := range service.Spec.Ports {
+		protocol := defaultProtocol
 		// Set secure protocols explicitly if correspondingly configured ports
 		// are found.
 		if httpsPortMap[port.Port] {

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1307,6 +1307,55 @@ func Test_buildForwardingRules(t *testing.T) {
 			nil,
 		},
 		{
+			"default protocol is maintained",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOProtocol:       "http",
+						annDOTLSPassThrough: "true",
+						annDOHTTP2Ports:     "443",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test-http2",
+							Protocol: "TCP",
+							Port:     int32(443),
+							NodePort: int32(40000),
+						},
+						{
+							Name:     "test-http",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			[]godo.ForwardingRule{
+				{
+					EntryProtocol:  "http2",
+					EntryPort:      443,
+					TargetProtocol: "http2",
+					TargetPort:     40000,
+					CertificateID:  "",
+					TlsPassthrough: true,
+				},
+				{
+					EntryProtocol:  "http",
+					EntryPort:      80,
+					TargetProtocol: "http",
+					TargetPort:     30000,
+					CertificateID:  "",
+					TlsPassthrough: false,
+				},
+			},
+			nil,
+		},
+		{
 			"default forwarding rules with sticky sessions no protocol specified",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This fixes a bug where the default protocol set through the corresponding annotation would be overwritten when a secure port (i.e., an HTTPS or HTTP2 port) was discovered.