### PR TITLE
Add support for configurable health-check via annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Maintain default protocol when secure protocol override is applied (@timoreimann)
+* Add `service.beta.kubernetes.io/do-loadbalancer-healthcheck-port` annotation to customize DO LB health-check port (@ntate)
 
 ## v0.1.22 (beta) - Jan 15th 2020
 

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -12,6 +12,10 @@ Certain annotations may override the default protocol. See the more specific des
 
 If `https` or `http2` is specified, then either `service.beta.kubernetes.io/do-loadbalancer-certificate-id` or `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` must be specified as well.
 
+## service.beta.kubernetes.io/do-loadbalancer-healthcheck-port
+
+The port used to check if a backend droplet is healthy. Defaults to the first port in a service.
+
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-path
 
 The path used to check if a backend droplet is healthy. Defaults to "/".

--- a/docs/controllers/services/examples/http-nginx-with-healthcheck-port.yml
+++ b/docs/controllers/services/examples/http-nginx-with-healthcheck-port.yml
@@ -1,0 +1,43 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-lb
+  annotations:
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    service.beta.kubernetes.io/do-loadbalancer-healthcheck-port: "55"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: health-check
+      protocol: TCP
+      port: 55
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx-example
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP


### PR DESCRIPTION
## Description

**DO NOT MERGE**
> Need to run some integration tests to verify functionality still

### What does this pull request accomplish

* Adds `service.beta.kubernetes.io/do-loadbalancer-healthcheck-port` annotation for services to specify which port to use for the loadbalancer health check.
* Defaults to existing functionality of choosing the first port in a service