### PR TITLE
Support specifying a fake region by environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+Support specifying a fake region by environment variable (@timoreimann)
+
 ## v0.1.23 (beta) - Jan 31th 2020
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The solution is to change the service port to a different, non-conlicting one.
 
 ## Development
 
-Requirements:
+### Basics
 
 * Go: min `v1.12.x`
 
@@ -63,16 +63,35 @@ After making your code changes, run the tests and CI checks:
 make ci
 ```
 
-If you want to test your changes, create a new image with the version set to `dev`:
+### Run Locally
+
+If you want to run `digitalocean-cloud-controller-manager` locally against a
+particular cluster, keep your kubeconfig ready and start the binary in the main
+package-hosted directory like this:
+
+```bash
+cd cloud-controller-manager/cmd/digitalocean-cloud-controller-manager
+FAKE_REGION=fra1 go run main.go --kubeconfig <path to your kubeconfig file> --leader-elect=false --v=5 --cloud-provider=digitalocean
+```
+
+The `FAKE_REGION` environment variable takes a (valid) DigitalOcean region. It
+is needed to keep `digitalocean-cloud-controller-manager` from trying to access
+the DigitalOcean metadata service which is only available on droplets. Overall,
+which region you choose should not matter a lot as long as you pick one.
+
+### Run Containerized
+
+If you want to test your changes in a containerized environment, create a new
+image with the version set to `dev`:
 
 ```bash
 VERSION=dev make publish
 ```
 
 This will create a binary with version `dev` and docker image pushed to
-`digitalocean/digitalocean-cloud-controller-manager:dev`
+`digitalocean/digitalocean-cloud-controller-manager:dev`.
 
-### Release a new version
+## Release a new version
 
 To release a new version first bump the version:
 

--- a/cloud-controller-manager/do/metadata.go
+++ b/cloud-controller-manager/do/metadata.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"k8s.io/klog"
 )
 
 const dropletRegionMetadataURL = "http://169.254.169.254/metadata/v1/region"
@@ -29,6 +31,7 @@ const dropletRegionMetadataURL = "http://169.254.169.254/metadata/v1/region"
 func dropletRegion() (string, error) {
 	// FAKE_REGION can be specified for local testing.
 	if region := os.Getenv("FAKE_REGION"); region != "" {
+		klog.Warningf("Using fake region %q from environment variable FAKE_REGION -- this should only be set for testing purposes!", region)
 		return region, nil
 	}
 	return httpGet(dropletRegionMetadataURL)

--- a/cloud-controller-manager/do/metadata.go
+++ b/cloud-controller-manager/do/metadata.go
@@ -20,12 +20,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 )
 
 const dropletRegionMetadataURL = "http://169.254.169.254/metadata/v1/region"
 
 // dropletRegion returns the region of the currently running program.
 func dropletRegion() (string, error) {
+	// FAKE_REGION can be specified for local testing.
+	if region := os.Getenv("FAKE_REGION"); region != "" {
+		return region, nil
+	}
 	return httpGet(dropletRegionMetadataURL)
 }
 


### PR DESCRIPTION
The sole purpose of this change is to enable local testing since CCM depends on the DigitalOcean metadata service to be available, which only exists on droplets.