### PR TITLE
Use correct annotation name for invalid health check protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## unreleased
 
+* Use correct annotation name for invalid health check protocol (@timoreimann)
+* Add logging for Create and Update requests to the LB API (@morrislaw)
 * Add support for specifying custom load-balancer names (@grzesiek)
 * Support specifying a fake region by environment variable (@timoreimann)
-* Add logging for Create and Update requests to the LB API (@morrislaw)
 
 ## v0.1.23 (beta) - Jan 31th 2020
 

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -826,7 +826,7 @@ func getProtocol(service *v1.Service) (string, error) {
 	}
 
 	if protocol != protocolTCP && protocol != protocolHTTP && protocol != protocolHTTPS && protocol != protocolHTTP2 {
-		return "", fmt.Errorf("invalid protocol: %q specified in annotation: %q", protocol, annDOProtocol)
+		return "", fmt.Errorf("invalid protocol %q specified in annotation %q", protocol, annDOProtocol)
 	}
 
 	return protocol, nil
@@ -875,7 +875,7 @@ func healthCheckProtocol(service *v1.Service) (string, error) {
 	}
 
 	if protocol != protocolTCP && protocol != protocolHTTP {
-		return "", fmt.Errorf("invalid protocol: %q specified in annotation: %q", protocol, annDOProtocol)
+		return "", fmt.Errorf("invalid protocol %q specified in annotation %q", protocol, annDOHealthCheckProtocol)
 	}
 
 	return protocol, nil

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -543,7 +543,7 @@ func Test_getProtocol(t *testing.T) {
 				},
 			},
 			"",
-			fmt.Errorf("invalid protocol: %q specified in annotation: %q", "invalid", annDOProtocol),
+			fmt.Errorf("invalid protocol %q specified in annotation %q", "invalid", annDOProtocol),
 		},
 	}
 
@@ -1985,7 +1985,7 @@ func Test_buildHealthCheck(t *testing.T) {
 					},
 				},
 			},
-			errMsgPrefix: fmt.Sprintf("invalid protocol: %q specified in annotation: %q", "invalid", annDOProtocol),
+			errMsgPrefix: fmt.Sprintf("invalid protocol %q specified in annotation %q", "invalid", annDOHealthCheckProtocol),
 		},
 		{
 			name: "health check with custom port",


### PR DESCRIPTION
We also use the opportunity to make the error message more readable for invalid health check and payload protocol.