### PR TITLE
Add annotation to specify HTTP ports explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Add annotation to specify HTTP ports explicitly (@timoreimann)
 * Build using Go 1.14 (@timoreimann)
 * Add support for enabling backend keepalive feature for load balancers (@anitgandhi)
 * Bump godo dependency to v1.35.1 (@anitgandhi)

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -53,6 +53,12 @@ The number of times a health check must fail for a backend Droplet to be marked 
 
 The number of times a health check must pass for a backend Droplet to be marked "healthy" for the given service and be re-added to the pool. The vaule must be between 2 and 10. If not specified, the default value is 5.
 
+## service.beta.kubernetes.io/do-loadbalancer-http-ports
+
+Specify which ports of the loadbalancer should use the HTTP protocol. This is a comma separated list of ports (e.g. 80,8080).
+
+Ports must not be shared between this annotation, `service.beta.kubernetes.io/do-loadbalancer-tls-ports`, and `service.beta.kubernetes.io/do-loadbalancer-http2-ports`.
+
 ## service.beta.kubernetes.io/do-loadbalancer-tls-ports
 
 Specify which ports of the loadbalancer should use the HTTPS protocol. This is a comma separated list of ports (e.g. 443,6443,7443).
@@ -61,7 +67,7 @@ If specified, exactly one of `service.beta.kubernetes.io/do-loadbalancer-tls-pas
 
 If no HTTPS port is specified but one of `service.beta.kubernetes.io/do-loadbalancer-tls-passthrough` or `service.beta.kubernetes.io/do-loadbalancer-certificate-id` is, then port 443 is assumed to be used for HTTPS. This does not hold if `service.beta.kubernetes.io/do-loadbalancer-http2-ports` already specifies 443.
 
-Ports must not be shared between this annotation and `service.beta.kubernetes.io/do-loadbalancer-http2-ports`.
+Ports must not be shared between this annotation, `service.beta.kubernetes.io/do-loadbalancer-http-ports`, and `service.beta.kubernetes.io/do-loadbalancer-http2-ports`.
 
 ## service.beta.kubernetes.io/do-loadbalancer-http2-ports
 
@@ -71,7 +77,7 @@ If specified, exactly one of `service.beta.kubernetes.io/do-loadbalancer-tls-pas
 
 The annotation is required for implicit HTTP2 usage, i.e., when `service.beta.kubernetes.io/do-loadbalancer-protocol` is not set to `http2`. (Unlike `service.beta.kubernetes.io/do-loadbalancer-tls-ports`, no default port is assumed for HTTP2 in order to retain compatibility with the semantics of implicit HTTPS usage.)
 
-Ports must not be shared between this annotation and `service.beta.kubernetes.io/do-loadbalancer-tls-ports`.
+Ports must not be shared between this annotation, `service.beta.kubernetes.io/do-loadbalancer-http-ports`, and `service.beta.kubernetes.io/do-loadbalancer-tls-ports`.
 
 ## service.beta.kubernetes.io/do-loadbalancer-tls-passthrough
 

--- a/docs/controllers/services/examples/all-protos-nginx.yml
+++ b/docs/controllers/services/examples/all-protos-nginx.yml
@@ -1,0 +1,54 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: http-lb
+  annotations:
+    # service.beta.kubernetes.io/do-loadbalancer-protocol can also be omitted since it defaults to "tcp".
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "tcp"
+    service.beta.kubernetes.io/do-loadbalancer-http-ports: "80"
+    service.beta.kubernetes.io/do-loadbalancer-https-ports: "443"
+    service.beta.kubernetes.io/do-loadbalancer-certificate-id: "c019bbf4-cad2-4884-8a20-410ddad7f54a"
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx-example
+  ports:
+    - name: ssh
+      protocol: TCP
+      port: 22
+      targetPort: 22
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 443
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-example
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx-example
+  template:
+    metadata:
+      labels:
+        app: nginx-example
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 22
+          protocol: TCP
+        - containerPort: 80
+          protocol: TCP
+        - containerPort: 443
+          protocol: TCP


### PR DESCRIPTION
This facilitates concurrent use of all protocols that we support, specifically TCP, HTTP, and at least another secure protocol, by setting the default protocol to TCP and specifying the HTTP* ports through the respective annotations explicitly.

This would not be possible before since we only provided annotations to enforce the HTTPS and HTTP2 protocol on given ports, forcing users to choose between TCP or HTTP through the default protocol annotation without any means to select both for different ports.

Fixes #316