### PR TITLE
Support disowning load-balancers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+
+* Support disowning LBs (@timoreimann)
+
 ## v0.1.24 (beta) - April 28th 2020
 
 * Add annotation to specify HTTP ports explicitly (@timoreimann)

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -125,7 +125,7 @@ func newCloud() (cloudprovider.Interface, error) {
 		client:        doClient,
 		instances:     newInstances(resources, region),
 		zones:         newZones(resources, region),
-		loadbalancers: newLoadBalancers(resources, doClient, region),
+		loadbalancers: newLoadBalancers(resources, region),
 
 		resources: resources,
 

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/digitalocean/godo"
 )
 
+func stringP(s string) *string {
+	return &s
+}
+
 func newFakeClient(fakeDroplet *fakeDropletService, fakeLB *fakeLBService, fakeCert *kvCertService) *godo.Client {
 	return &godo.Client{
 		Certificates:  fakeCert,

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -139,3 +139,15 @@ Indicates whether HTTP keepalive connections should be enabled to backend target
 **Note**
 
 You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).
+
+## service.kubernetes.io/do-loadbalancer-disown
+
+Indicates whether the managed load-balancer should be disowned. Disowned load-balancers are not mutated anymore, including creates, updates, and deletes. This can be employed to manage the load-balancer by a different cluster. Options are `"true"` or `"false"`. Defaults to `"false"`.
+
+**Warning** Disowned load-balancers do not necessarily work correctly anymore because needed load-balancer updates (in terms of target nodes or configuration annotations) stop being propagated to the DigitalOcean load-balancer. Similarly, the Service status field may not reflect the right state anymore. Consequently, users should assign disowned load-balancers to a new Service without much delay.
+
+See also the [elaborate example](/docs/controllers/services/examples/README.md#changing-ownership-of-a-load-balancer-for-migration-purposes).
+
+**Note**
+
+You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,7 +93,7 @@ When a cluster is created in a non-default VPC for the region, the environment v
 
 `digitalocean-cloud-controller-manager` annotates new and existing Services. Note that a load-balancer that is renamed before the annotation is added will be lost, and a new one will be created.
 
-You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. Do not do this while it is being managed by another cluster, or the `digitalocean-cloud-controller-managers` will make conflicting modifications to the load-balancer.
+You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. However, if it is already managed by another Service/cluster, you have to make sure [to disown it properly](/docs/controllers/services/examples/README.md#changing-ownership-of-a-load-balancer-for-migration-purposes) to prevent conflicting modifications to the load-balancer.
 
 ## Deployment
 


### PR DESCRIPTION
Disowning allows to migrate LBs across clusters in a safe manner.

See the included documentation updates for details.