### PR TITLE
docs: clarify that healthcheck port annotation refers to a service port

### DIFF
--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -25,7 +25,9 @@ If `https` or `http2` is specified, then either `service.beta.kubernetes.io/do-l
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-port
 
-The port used to check if a backend droplet is healthy. Defaults to the first port in a service.
+The service port used to check if a backend droplet is healthy. Defaults to the first port in a service.
+
+**Note:** Users must specify a port exposed by the Service, not the NodePort.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-path
 


### PR DESCRIPTION
In particular, point out that it is not a NodePort that can be referenced.