### PR TITLE
firewalls: add controller to manage worker firewall for public access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 * Support HTTPS as health check protocol (@timoreimann)
+* add controller to manage worker firewall for public access (@MorrisLaw)
 
 ## v0.1.26 (beta) - June 16th 2020
 

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -252,7 +252,7 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 				service := test.setupFn(lbService, certService)
 
 				fakeClient := newFakeClient(&fakeDroplet, &lbService, &certService)
-				fakeResources := newResources("", "", fakeClient)
+				fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 				fakeResources.kclient = fake.NewSimpleClientset()
 				if _, err := fakeResources.kclient.CoreV1().Services(service.Namespace).Create(context.Background(), service, metav1.CreateOptions{}); err != nil {
 					t.Fatalf("failed to add service to fake client: %s", err)

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -61,6 +61,36 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 	return list, nil
 }
 
+func filterFirewallList(ctx context.Context, client *godo.Client, matchExpectedFirewallName func(godo.Firewall) bool) (*godo.Firewall, error) {
+	opt := &godo.ListOptions{Page: 1, PerPage: apiResultsPerPage}
+	for {
+		firewalls, resp, err := client.Firewalls.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, fw := range firewalls {
+			if matchExpectedFirewallName(fw) {
+				return &fw, nil
+			}
+		}
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opt.Page = page + 1
+	}
+
+	return nil, nil
+}
+
 func allLoadBalancerList(ctx context.Context, client *godo.Client) ([]godo.LoadBalancer, error) {
 	list := []godo.LoadBalancer{}
 

--- a/cloud-controller-manager/do/firewall_controller.go
+++ b/cloud-controller-manager/do/firewall_controller.go
@@ -1,0 +1,374 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+const (
+	// Interval of synchronizing service status from apiserver.
+	serviceSyncPeriod = 30 * time.Second
+	// Frequency at which the firewall controller runs.
+	firewallReconcileFrequency = 5 * time.Minute
+)
+
+var (
+	allowAllOutboundRules = []godo.OutboundRule{
+		{
+			Protocol:  "tcp",
+			PortRange: "all",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+		{
+			Protocol:  "udp",
+			PortRange: "all",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+		{
+			Protocol: "icmp",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+	}
+)
+
+// firewallCache stores a cached firewall and mutex to handle concurrent access.
+type firewallCache struct {
+	mu       *sync.RWMutex // protects firewall.
+	firewall *godo.Firewall
+}
+
+// firewallManager manages the interaction with the DO Firewalls API.
+type firewallManager struct {
+	client             *godo.Client
+	fwCache            firewallCache
+	workerFirewallName string
+	workerFirewallTags []string
+}
+
+// FirewallController helps to keep cloud provider service firewalls in sync.
+type FirewallController struct {
+	kubeClient         clientset.Interface
+	client             *godo.Client
+	workerFirewallTags []string
+	workerFirewallName string
+	serviceLister      corelisters.ServiceLister
+	fwManager          firewallManager
+}
+
+// NewFirewallController returns a new firewall controller to reconcile public access firewall state.
+func NewFirewallController(
+	ctx context.Context,
+	kubeClient clientset.Interface,
+	client *godo.Client,
+	serviceInformer coreinformers.ServiceInformer,
+	fwManager firewallManager,
+	workerFirewallTags []string,
+	workerFirewallName string,
+) *FirewallController {
+	fc := &FirewallController{
+		kubeClient:         kubeClient,
+		client:             client,
+		workerFirewallTags: workerFirewallTags,
+		workerFirewallName: workerFirewallName,
+		fwManager:          fwManager,
+	}
+
+	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(cur interface{}) {
+				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+				defer cancel()
+				err := fc.ensureReconciledFirewall(ctx)
+				if err != nil {
+					klog.Errorf("failed to reconcile worker firewall after adding a resource object: %s", err)
+				}
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+				defer cancel()
+				err := fc.ensureReconciledFirewall(ctx)
+				if err != nil {
+					klog.Errorf("failed to reconcile worker firewall after updating a resource object: %s", err)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+				defer cancel()
+				err := fc.ensureReconciledFirewall(ctx)
+				if err != nil {
+					klog.Errorf("failed to reconcile worker firewall after deleting a resource object: %s", err)
+				}
+			},
+		},
+		serviceSyncPeriod,
+	)
+	fc.serviceLister = serviceInformer.Lister()
+
+	return fc
+}
+
+// Run starts the firewall controller loop.
+func (fc *FirewallController) Run(stopCh <-chan struct{}, fwReconcileFrequency time.Duration) {
+	wait.Until(func() {
+		err := fc.actualRun(stopCh, fwReconcileFrequency)
+		if err != nil {
+			klog.Errorf("failed to run firewall controller loop: %v", err)
+		}
+	}, fwReconcileFrequency, stopCh)
+}
+
+func (fc *FirewallController) actualRun(stopCh <-chan struct{}, fwReconcileFrequency time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), fwReconcileFrequency)
+	defer cancel()
+
+	currentFirewall, err := fc.fwManager.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get worker firewall: %s", err)
+	}
+	if currentFirewall != nil {
+		if fc.fwManager.fwCache.isEqual(currentFirewall) {
+			return nil
+		}
+	}
+	fc.fwManager.fwCache.updateCache(currentFirewall)
+	err = fc.ensureReconciledFirewall(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile worker firewall: %s", err)
+	}
+
+	klog.Info("successfully reconciled firewall")
+	return nil
+}
+
+// Get returns the current public access firewall representation.
+func (fm *firewallManager) Get(ctx context.Context) (*godo.Firewall, error) {
+	// check cache and query the API firewall service to get firewall by ID, if it exists. Return it. If not, continue.
+	fw := fm.fwCache.getCachedFirewall()
+	if fw != nil {
+		fw, resp, err := fm.client.Firewalls.Get(ctx, fw.ID)
+		if err != nil && (resp == nil || resp.StatusCode != http.StatusNotFound) {
+			return nil, fmt.Errorf("could not get firewall: %v", err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			klog.Warningf("unable to retrieve firewall by ID because it no longer exists")
+		}
+		if fw != nil {
+			return fw, nil
+		}
+	}
+
+	// iterate through firewall API provided list and return the firewall with the matching firewall name.
+	f := func(fw godo.Firewall) bool {
+		return fw.Name == fm.workerFirewallName
+	}
+	klog.Info("filtering firewall list for the firewall that has the expected firewall name")
+	fw, err := filterFirewallList(ctx, fm.client, f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve list of firewalls from DO API: %v", err)
+	}
+	if fw != nil {
+		klog.Info("found firewall by listing")
+	} else {
+		klog.Info("could not find firewall by listing")
+	}
+	return fw, nil
+}
+
+// Set applies the given firewall request configuration to the public access firewall if there is a delta.
+// Specifically Set will reconcile away any changes to the inbound rules, outbound rules, firewall name and/or tags.
+func (fm *firewallManager) Set(ctx context.Context, fr *godo.FirewallRequest) error {
+	targetFirewall := fm.fwCache.getCachedFirewall()
+
+	if targetFirewall != nil {
+		equal, unequalParts := isEqual(targetFirewall, fr)
+		if equal {
+			// A locally cached firewall with matching rules, correct name and tags means there is nothing to update.
+			return nil
+		}
+		klog.Infof("firewall configuration mismatch: %v", unequalParts)
+		// A locally cached firewall exists, but is does not match the expected
+		// service inbound rules, outbound rules, name or tags. So we need to use the locally
+		// cached firewall ID to attempt to update the firewall APIs representation of the
+		// firewall with the new rules.
+		currentFirewall, resp, err := fm.client.Firewalls.Update(ctx, targetFirewall.ID, fr)
+		if err == nil {
+			klog.Info("successfully updated firewall")
+		} else {
+			if resp == nil || resp.StatusCode != http.StatusNotFound {
+				return fmt.Errorf("could not update firewall: %v", err)
+			}
+			currentFirewall, err = fm.createFirewall(ctx, fr)
+			if err != nil {
+				return fmt.Errorf("could not create firewall: %v", err)
+			}
+			klog.Info("successfully created firewall")
+		}
+		fm.fwCache.updateCache(currentFirewall)
+		return nil
+	}
+
+	// Check if the target firewall ID exists. In the case that CCM first starts up and the
+	// firewall ID does not exist yet, check the API and see if a firewall by the right name
+	// already exists.
+	if targetFirewall == nil {
+		currentFirewall, err := fm.Get(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to check if firewall already exists: %s", err)
+		}
+		if currentFirewall == nil {
+			klog.Info("an existing firewall not found, we need to create one")
+			currentFirewall, err = fm.createFirewall(ctx, fr)
+			if err != nil {
+				return err
+			}
+			klog.Info("successfully created firewall")
+		} else {
+			klog.Info("an existing firewall is found, we need to update it")
+			currentFirewall, err = fm.updateFirewall(ctx, currentFirewall.ID, fr)
+			if err != nil {
+				return fmt.Errorf("could not update firewall: %v", err)
+			}
+			klog.Info("successfully updated firewall")
+		}
+		fm.fwCache.updateCache(currentFirewall)
+	}
+	return nil
+}
+
+func isEqual(targetFirewall *godo.Firewall, fr *godo.FirewallRequest) (bool, []string) {
+	var unequalParts []string
+	if targetFirewall.Name != fr.Name {
+		unequalParts = append(unequalParts, "name")
+	}
+	if !cmp.Equal(targetFirewall.InboundRules, fr.InboundRules) {
+		unequalParts = append(unequalParts, "inboundRules")
+	}
+	if !cmp.Equal(targetFirewall.OutboundRules, fr.OutboundRules) {
+		unequalParts = append(unequalParts, "outboundRules")
+	}
+	if !cmp.Equal(targetFirewall.Tags, fr.Tags) {
+		unequalParts = append(unequalParts, "tags")
+	}
+	return len(unequalParts) == 0, unequalParts
+}
+
+func (fm *firewallManager) createFirewall(ctx context.Context, fr *godo.FirewallRequest) (*godo.Firewall, error) {
+	currentFirewall, _, err := fm.client.Firewalls.Create(ctx, fr)
+	return currentFirewall, err
+}
+
+func (fm *firewallManager) updateFirewall(ctx context.Context, fwID string, fr *godo.FirewallRequest) (*godo.Firewall, error) {
+	currentFirewall, _, err := fm.client.Firewalls.Update(ctx, fwID, fr)
+	return currentFirewall, err
+}
+
+// createReconciledFirewallRequest creates a firewall request that has the correct rules, name and tag
+func (fc *FirewallController) createReconciledFirewallRequest(serviceList []*v1.Service) *godo.FirewallRequest {
+	var nodePortInboundRules []godo.InboundRule
+	for _, svc := range serviceList {
+		if svc.Spec.Type == v1.ServiceTypeNodePort {
+			// this is a nodeport service so we should check for existing inbound rules on all ports.
+			for _, servicePort := range svc.Spec.Ports {
+				// In the odd case that a failure is asynchronous causing the NodePort to be set to zero.
+				if servicePort.NodePort == 0 {
+					klog.Warningf("NodePort on the service is set to zero")
+					continue
+				}
+				var protocol string
+				switch servicePort.Protocol {
+				case v1.ProtocolTCP:
+					protocol = "tcp"
+				case v1.ProtocolUDP:
+					protocol = "udp"
+				default:
+					klog.Warningf("unsupported service protocol %v, skipping service port %v", servicePort.Protocol, servicePort.Name)
+					continue
+				}
+
+				nodePortInboundRules = append(nodePortInboundRules,
+					godo.InboundRule{
+						Protocol:  protocol,
+						PortRange: strconv.Itoa(int(servicePort.NodePort)),
+						Sources: &godo.Sources{
+							Tags: fc.workerFirewallTags,
+						},
+					},
+				)
+			}
+		}
+	}
+	return &godo.FirewallRequest{
+		Name:          fc.workerFirewallName,
+		InboundRules:  nodePortInboundRules,
+		OutboundRules: allowAllOutboundRules,
+		Tags:          fc.workerFirewallTags,
+	}
+}
+
+func (fc *FirewallController) ensureReconciledFirewall(ctx context.Context) error {
+	serviceList, err := fc.serviceLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list services: %v", err)
+	}
+	fr := fc.createReconciledFirewallRequest(serviceList)
+	err = fc.fwManager.Set(ctx, fr)
+	if err != nil {
+		return fmt.Errorf("failed to set reconciled firewall: %v", err)
+	}
+	return nil
+}
+
+func (fc *firewallCache) getCachedFirewall() *godo.Firewall {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.firewall
+}
+
+func (fc *firewallCache) isEqual(fw *godo.Firewall) bool {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return cmp.Equal(fc.firewall, fw)
+}
+
+func (fc *firewallCache) updateCache(currentFirewall *godo.Firewall) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	fc.firewall = currentFirewall
+}

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -1,0 +1,960 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	ctx = context.TODO()
+
+	kclient kubernetes.Interface
+
+	inf = informers.NewSharedInformerFactory(kclient, 0)
+
+	testWorkerFWName  = "k8s-test-firewall"
+	testWorkerFWTags  = []string{"tag1", "tag2"}
+	testOutboundRules = []godo.OutboundRule{
+		{
+			Protocol:  "tcp",
+			PortRange: "all",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+		{
+			Protocol:  "udp",
+			PortRange: "all",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+		{
+			Protocol: "icmp",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+	}
+	testDiffOutboundRules = []godo.OutboundRule{
+		{
+			Protocol:  "udp",
+			PortRange: "all",
+			Destinations: &godo.Destinations{
+				Addresses: []string{"0.0.0.0/0", "::/0"},
+			},
+		},
+	}
+	testInboundRules     = []godo.InboundRule{fakeInboundRule}
+	testDiffInboundRules = []godo.InboundRule{diffFakeInboundRule}
+
+	fakeInboundRule = godo.InboundRule{
+		Protocol:  "tcp",
+		PortRange: "31000",
+		Sources: &godo.Sources{
+			Tags:       []string{"tag"},
+			DropletIDs: []int{1},
+		},
+	}
+	diffFakeInboundRule = godo.InboundRule{
+		Protocol:  "tcp",
+		PortRange: "32000",
+		Sources: &godo.Sources{
+			Tags:       []string{"tag"},
+			DropletIDs: []int{1, 2},
+		},
+	}
+
+	fwManager firewallManager
+)
+
+// fakeFirewallService satisfies the FirewallsService interface.
+type fakeFirewallService struct {
+	getFunc            func(context.Context, string) (*godo.Firewall, *godo.Response, error)
+	createFunc         func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+	updateFunc         func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+	deleteFunc         func(context.Context, string) (*godo.Response, error)
+	listFunc           func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+	listByDropletFunc  func(context.Context, int, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+	addDropletsFunc    func(context.Context, string, ...int) (*godo.Response, error)
+	removeDropletsFunc func(context.Context, string, ...int) (*godo.Response, error)
+	addTagsFunc        func(context.Context, string, ...string) (*godo.Response, error)
+	removeTagsFunc     func(context.Context, string, ...string) (*godo.Response, error)
+	addRulesFunc       func(context.Context, string, *godo.FirewallRulesRequest) (*godo.Response, error)
+	removeRulesFunc    func(context.Context, string, *godo.FirewallRulesRequest) (*godo.Response, error)
+}
+
+// Get an existing Firewall by its identifier.
+func (f *fakeFirewallService) Get(ctx context.Context, fID string) (*godo.Firewall, *godo.Response, error) {
+	return f.getFunc(ctx, fID)
+}
+
+// Create a new Firewall with a given configuration.
+func (f *fakeFirewallService) Create(ctx context.Context, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+	return f.createFunc(ctx, fr)
+}
+
+// Update an existing Firewall with new configuration.
+func (f *fakeFirewallService) Update(ctx context.Context, fID string, fr *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+	return f.updateFunc(ctx, fID, fr)
+}
+
+// Delete a Firewall by its identifier.
+func (f *fakeFirewallService) Delete(ctx context.Context, fID string) (*godo.Response, error) {
+	return f.deleteFunc(ctx, fID)
+}
+
+// List Firewalls.
+func (f *fakeFirewallService) List(ctx context.Context, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+	return f.listFunc(ctx, opt)
+}
+
+// ListByDroplet Firewalls.
+func (f *fakeFirewallService) ListByDroplet(ctx context.Context, dID int, opt *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+	return f.listByDropletFunc(ctx, dID, opt)
+}
+
+// AddDroplets to a Firewall.
+func (f *fakeFirewallService) AddDroplets(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error) {
+	return f.addDropletsFunc(ctx, fID)
+}
+
+// RemoveDroplets from a Firewall.
+func (f *fakeFirewallService) RemoveDroplets(ctx context.Context, fID string, dropletIDs ...int) (*godo.Response, error) {
+	return f.removeDropletsFunc(ctx, fID, dropletIDs...)
+}
+
+// AddTags to a Firewall.
+func (f *fakeFirewallService) AddTags(ctx context.Context, fID string, tags ...string) (*godo.Response, error) {
+	return f.addTagsFunc(ctx, fID, tags...)
+}
+
+// RemoveTags from a Firewall.
+func (f *fakeFirewallService) RemoveTags(ctx context.Context, fID string, tags ...string) (*godo.Response, error) {
+	return f.removeTagsFunc(ctx, fID, tags...)
+}
+
+// AddRules to a Firewall.
+func (f *fakeFirewallService) AddRules(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
+	return f.addRulesFunc(ctx, fID, rr)
+}
+
+// RemoveRules from a Firewall.
+func (f *fakeFirewallService) RemoveRules(ctx context.Context, fID string, rr *godo.FirewallRulesRequest) (*godo.Response, error) {
+	return f.removeRulesFunc(ctx, fID, rr)
+}
+
+func newFakeFirewall() *godo.Firewall {
+	return &godo.Firewall{
+		ID:            "123",
+		Name:          testWorkerFWName,
+		Tags:          testWorkerFWTags,
+		InboundRules:  testInboundRules,
+		OutboundRules: testOutboundRules,
+	}
+}
+
+func newFakeFirewallWithDiffInboundRules() *godo.Firewall {
+	return &godo.Firewall{
+		ID:            "123",
+		Name:          testWorkerFWName,
+		Tags:          testWorkerFWTags,
+		InboundRules:  testDiffInboundRules,
+		OutboundRules: testOutboundRules,
+	}
+}
+
+func newFakeFirewallCache() firewallCache {
+	return firewallCache{
+		mu:       new(sync.RWMutex),
+		firewall: newFakeFirewall(),
+	}
+}
+
+func newFakeFirewallCacheWithDiffInboundRules() firewallCache {
+	return firewallCache{
+		mu:       new(sync.RWMutex),
+		firewall: newFakeFirewallWithDiffInboundRules(),
+	}
+}
+
+func newFakeFirewallCacheEmpty() firewallCache {
+	return firewallCache{
+		mu: new(sync.RWMutex),
+	}
+}
+
+func newFakeFirewallManager(client *godo.Client, cache firewallCache) firewallManager {
+	return firewallManager{
+		client:             client,
+		fwCache:            cache,
+		workerFirewallName: testWorkerFWName,
+		workerFirewallTags: testWorkerFWTags,
+	}
+}
+
+func newFakeGodoClient(fakeFirewall *fakeFirewallService) *godo.Client {
+	return &godo.Client{
+		Firewalls: fakeFirewall,
+	}
+}
+
+func TestFirewallController_Get(t *testing.T) {
+	testcases := []struct {
+		name                         string
+		fwCache                      firewallCache
+		expectedGodoFirewallGetResp  func(context.Context, string) (*godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallListResp func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+		expectedError                error
+		expectedFirewall             *godo.Firewall
+	}{
+		{
+			name:    "return error when error on GET firewall by ID",
+			fwCache: newFakeFirewallCache(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("failed to retrieve firewall by ID")
+			},
+			expectedError: errors.New("failed to retrieve firewall by ID"),
+		},
+		{
+			name:    "return error when error on List firewalls",
+			fwCache: newFakeFirewallCacheEmpty(),
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("failed to retrieve list of firewalls from DO API")
+			},
+			expectedError: errors.New("failed to retrieve list of firewalls from DO API"),
+		},
+		{
+			name:    "firewall does not exist in API",
+			fwCache: newFakeFirewallCache(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotFoundResponse(), errors.New("not found")
+			},
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeOKResponse(), nil
+			},
+		},
+		{
+			name:    "handle 404 response code from GET firewall by ID and instead return firewall from List",
+			fwCache: newFakeFirewallCache(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotFoundResponse(), errors.New("not found")
+			},
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return []godo.Firewall{*newFakeFirewall()}, newFakeOKResponse(), nil
+			},
+			expectedFirewall: newFakeFirewall(),
+		},
+		{
+			name:    "get firewall from API with cached firewall ID",
+			fwCache: newFakeFirewallCache(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+			expectedFirewall: newFakeFirewall(),
+		},
+		{
+			name:    "get firewall from API without cached firewall",
+			fwCache: newFakeFirewallCacheEmpty(),
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeOKResponse(), nil
+			},
+		},
+	}
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			gclient := newFakeGodoClient(
+				&fakeFirewallService{
+					getFunc:  test.expectedGodoFirewallGetResp,
+					listFunc: test.expectedGodoFirewallListResp,
+				},
+			)
+			fwManager = newFakeFirewallManager(gclient, test.fwCache)
+
+			fw, err := fwManager.Get(ctx)
+			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
+				t.Errorf("incorrect firewall config\nwant: %#v\n got: %#v", test.expectedError, err)
+			}
+
+			if diff := cmp.Diff(test.expectedFirewall, fw); diff != "" {
+				t.Errorf("Get() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFirewallController_Set(t *testing.T) {
+	testcases := []struct {
+		name                           string
+		fwCache                        firewallCache
+		firewallRequest                *godo.FirewallRequest
+		expectedGodoFirewallCreateResp func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallGetResp    func(context.Context, string) (*godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallListResp   func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallUpdateResp func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+		expectedError                  error
+		expectedFirewall               *godo.Firewall
+	}{
+		{
+			name:    "do nothing when firewall is already properly configured",
+			fwCache: newFakeFirewallCache(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+		},
+		{
+			name:    "update firewall when rule parts are improperly configured",
+			fwCache: newFakeFirewallCache(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          "wrong name",
+				InboundRules:  testDiffInboundRules,
+				OutboundRules: testDiffOutboundRules,
+				Tags:          []string{"wrong-tag"},
+			},
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+		},
+		{
+			name:    "create firewall when cache does not exist (i.e. initial startup)",
+			fwCache: newFakeFirewallCacheEmpty(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return []godo.Firewall{}, newFakeOKResponse(), nil
+			},
+			expectedGodoFirewallCreateResp: func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+		},
+		{
+			name:    "failing to create the firewall because of an unexpected error",
+			fwCache: newFakeFirewallCacheWithDiffInboundRules(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotFoundResponse(), errors.New("not found")
+			},
+			expectedGodoFirewallCreateResp: func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("unexpected error")
+			},
+			expectedError: errors.New("failed to create firewall"),
+		},
+		{
+			name:    "failing to get the firewall",
+			fwCache: newFakeFirewallCacheEmpty(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("unexpected error")
+			},
+			expectedError: errors.New("failed to create firewall"),
+		},
+		{
+			name:    "failing to update the firewall because of an unexpected error",
+			fwCache: newFakeFirewallCacheWithDiffInboundRules(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("unexpected error")
+			},
+			expectedError: errors.New("unexpected error"),
+		},
+		{
+			name:    "when the firewall cache is nil return existing firewall from API then update cache",
+			fwCache: newFakeFirewallCacheEmpty(),
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return []godo.Firewall{*newFakeFirewall()}, newFakeOKResponse(), nil
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			gclient := newFakeGodoClient(
+				&fakeFirewallService{
+					listFunc:   test.expectedGodoFirewallListResp,
+					updateFunc: test.expectedGodoFirewallUpdateResp,
+					createFunc: test.expectedGodoFirewallCreateResp,
+					getFunc:    test.expectedGodoFirewallGetResp,
+				},
+			)
+			fwManager = newFakeFirewallManager(gclient, test.fwCache)
+			fc := NewFirewallController(ctx, kclient, gclient, inf.Core().V1().Services(), fwManager, testWorkerFWTags, testWorkerFWName)
+
+			err := fc.fwManager.Set(ctx, test.firewallRequest)
+			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
+				t.Errorf("incorrect firewall config\nwant: %#v\n got: %#v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestFirewallController_NoDataRace(t *testing.T) {
+	// setup
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	var wg sync.WaitGroup
+
+	gclient := newFakeGodoClient(
+		&fakeFirewallService{
+			listFunc: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeOKResponse(), nil
+			},
+			updateFunc: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+			createFunc: func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeOKResponse(), nil
+			},
+			getFunc: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+		},
+	)
+	fwManager := newFakeFirewallManager(gclient, newFakeFirewallCache())
+	fc := NewFirewallController(ctx, kclient, gclient, inf.Core().V1().Services(), fwManager, testWorkerFWTags, testWorkerFWName)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil { // context has not been terminated
+			if err := fc.ensureReconciledFirewall(ctx); err != nil && err != context.Canceled {
+				t.Errorf("ensureReconciledFirewall failed: %s", err)
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fc.Run(ctx.Done(), time.Duration(0))
+	}()
+
+	wg.Wait()
+	// We do not assert on anything because the goal of this test is to catch data races.
+}
+
+func TestFirewallController_actualRun(t *testing.T) {
+	testcases := []struct {
+		name                           string
+		fwCache                        firewallCache
+		expectedGodoFirewallCreateResp func(context.Context, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallGetResp    func(context.Context, string) (*godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallListResp   func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
+		expectedGodoFirewallUpdateResp func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
+		expectedError                  error
+	}{
+		{
+			name:    "error returns when we fail to get firewall from firewall api",
+			fwCache: newFakeFirewallCacheEmpty(),
+			expectedGodoFirewallListResp: func(context.Context, *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("unexpected error")
+			},
+			expectedError: errors.New("failed to get worker firewall: failed to retrieve list of firewalls from DO API"),
+		},
+		{
+			name:    "when firewall matches what we expect there is nothing to reconcile",
+			fwCache: newFakeFirewallCache(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+		},
+		{
+			name:    "when firewall needs to be reconciled an update call is made",
+			fwCache: newFakeFirewallCacheWithDiffInboundRules(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewallWithDiffInboundRules(), newFakeOKResponse(), nil
+			},
+		},
+		{
+			name:    "error is returned when firewall cache exists but needs to be reconciled and update call fails",
+			fwCache: newFakeFirewallCacheWithDiffInboundRules(),
+			expectedGodoFirewallGetResp: func(context.Context, string) (*godo.Firewall, *godo.Response, error) {
+				return newFakeFirewall(), newFakeOKResponse(), nil
+			},
+			expectedGodoFirewallUpdateResp: func(context.Context, string, *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("unexpected error")
+			},
+			expectedError: errors.New("failed to reconcile worker firewall: failed to set reconciled firewall: could not update firewall: unexpected error"),
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			// setup
+			gclient := newFakeGodoClient(
+				&fakeFirewallService{
+					listFunc:   test.expectedGodoFirewallListResp,
+					updateFunc: test.expectedGodoFirewallUpdateResp,
+					createFunc: test.expectedGodoFirewallCreateResp,
+					getFunc:    test.expectedGodoFirewallGetResp,
+				},
+			)
+			fwManager := newFakeFirewallManager(gclient, test.fwCache)
+			fc := NewFirewallController(ctx, kclient, gclient, inf.Core().V1().Services(), fwManager, testWorkerFWTags, testWorkerFWName)
+
+			err := fc.actualRun(ctx.Done(), time.Duration(0))
+			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
+				t.Errorf("error with firewall controller run\nwant: %#v\n got: %#v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestFirewallController_isEqualCheckForFirewallRequest(t *testing.T) {
+	testcases := []struct {
+		name            string
+		firewall        *godo.Firewall
+		firewallRequest *godo.FirewallRequest
+		unequalParts    []string
+		equal           bool
+	}{
+		{
+			name: "detects when firewall request fields and firewall fields are equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			equal: true,
+		},
+		{
+			name: "detects when name is not equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          "diff firewall name",
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"name"},
+			equal:        false,
+		},
+		{
+			name: "detects when inboundRules are not equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          testWorkerFWName,
+				InboundRules:  testDiffInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"inboundRules"},
+			equal:        false,
+		},
+		{
+			name: "detects when outboundRules are not equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testDiffOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"outboundRules"},
+			equal:        false,
+		},
+		{
+			name: "detects when tags are not equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          []string{"rick", "and", "morty"},
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"tags"},
+			equal:        false,
+		},
+		{
+			name: "detects when more then one property is not equal",
+			firewall: &godo.Firewall{
+				ID:            "123",
+				Name:          testWorkerFWName,
+				InboundRules:  testDiffInboundRules,
+				OutboundRules: testDiffOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"inboundRules", "outboundRules"},
+			equal:        false,
+		},
+		{
+			name: "detects when all properties are not equal",
+			firewall: &godo.Firewall{
+				Name:          "different name",
+				InboundRules:  testDiffInboundRules,
+				OutboundRules: testDiffOutboundRules,
+				Tags:          []string{"rick", "and", "morty"},
+			},
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				InboundRules:  testInboundRules,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			unequalParts: []string{"name", "inboundRules", "outboundRules", "tags"},
+			equal:        false,
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			equal, unequalParts := isEqual(test.firewall, test.firewallRequest)
+			if test.equal != equal {
+				t.Errorf("isEqual() returned unexpected equal bool value (want: %v, got: %v)", test.equal, equal)
+			}
+			if diff := cmp.Diff(test.unequalParts, unequalParts); diff != "" {
+				t.Errorf("isEqual() returned unexpected unequalParts value (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
+	testcases := []struct {
+		name               string
+		firewallRequest    *godo.FirewallRequest
+		firewallController FirewallController
+		serviceList        []*v1.Service
+	}{
+		{
+			name: "nothing to reconcile when there are no changes",
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+		},
+		{
+			name: "reconcile firewall when nodeport service has sctp",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						UID:  "abc123",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port1",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(31000),
+							},
+							{
+								Name:     "port2",
+								Protocol: v1.ProtocolSCTP,
+								NodePort: int32(31000),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nothing to reconcile when service type is not of type NodePort",
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "lbServiceType",
+						UID:  "abc12345",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeLoadBalancer,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port",
+								Protocol: v1.ProtocolTCP,
+								Port:     int32(80),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reconcile firewall based on added nodeport service",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test",
+						UID:  "abc123",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port1",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(31000),
+							},
+							{
+								Name:     "port2",
+								Protocol: v1.ProtocolUDP,
+								NodePort: int32(31000),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "reconcile firewall based on multiple added services",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: "30000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "30000",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: "32727",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "32727",
+						Sources: &godo.Sources{
+							Tags: testWorkerFWTags,
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "singleNodePort",
+						UID:  "abc123",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port1",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(31000),
+							},
+							{
+								Name:     "port2",
+								Protocol: v1.ProtocolUDP,
+								NodePort: int32(31000),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "multipleNodePorts",
+						UID:  "abc1234",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port1",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(30000),
+							},
+							{
+								Name:     "port2",
+								Protocol: v1.ProtocolUDP,
+								NodePort: int32(30000),
+							},
+							{
+								Name:     "port3",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(32727),
+							},
+							{
+								Name:     "port4",
+								Protocol: v1.ProtocolUDP,
+								NodePort: int32(32727),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			fc := FirewallController{
+				workerFirewallTags: testWorkerFWTags,
+				workerFirewallName: testWorkerFWName,
+			}
+			fwReq := fc.createReconciledFirewallRequest(test.serviceList)
+			if diff := cmp.Diff(test.firewallRequest, fwReq); diff != "" {
+				t.Errorf("createReconciledFirewallRequest() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -3363,7 +3363,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					},
 				},
 			)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 
 			lb := &loadBalancers{
 				resources:         fakeResources,
@@ -3449,7 +3449,7 @@ func Test_buildLoadBalancerRequestWithClusterID(t *testing.T) {
 					},
 				},
 			)
-			fakeResources := newResources(test.clusterID, test.vpcID, fakeClient)
+			fakeResources := newResources(test.clusterID, test.vpcID, publicAccessFirewall{}, fakeClient)
 			fakeResources.clusterVPCID = test.vpcID
 
 			lb := &loadBalancers{
@@ -3655,7 +3655,7 @@ func Test_nodeToDropletIDs(t *testing.T) {
 					},
 				},
 			)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 
 			lb := &loadBalancers{
 				resources:         fakeResources,
@@ -3901,7 +3901,7 @@ func Test_GetLoadBalancer(t *testing.T) {
 				listFn: test.listFn,
 			}
 			fakeClient := newFakeLBClient(fakeLB)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 			fakeResources.kclient = fake.NewSimpleClientset()
 			if _, err := fakeResources.kclient.CoreV1().Services(test.service.Namespace).Create(context.Background(), test.service, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to add service to fake client: %s", err)
@@ -4376,7 +4376,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 			certStore := make(map[string]*godo.Certificate)
 			fakeCert := newKVCertService(certStore, true)
 			fakeClient := newFakeClient(fakeDroplet, fakeLB, &fakeCert)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 			fakeResources.kclient = fake.NewSimpleClientset()
 			if _, err := fakeResources.kclient.CoreV1().Services(test.service.Namespace).Create(context.Background(), test.service, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to add service to fake client: %s", err)
@@ -4535,7 +4535,7 @@ func Test_EnsureLoadBalancerDeleted(t *testing.T) {
 				deleteFn: test.deleteFn,
 			}
 			fakeClient := newFakeLBClient(fakeLB)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 
 			lb := &loadBalancers{
 				resources:         fakeResources,
@@ -4627,7 +4627,7 @@ func TestEnsureLoadBalancerIDAnnotation(t *testing.T) {
 				},
 			}
 			fakeClient := newFakeLBClient(fakeLB)
-			fakeResources := newResources("", "", fakeClient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, fakeClient)
 			// fakeResources.kclient = fake.NewSimpleClientset(svc)
 			fakeResources.kclient = fake.NewSimpleClientset()
 			if _, err := fakeResources.kclient.CoreV1().Services(v1.NamespaceDefault).Create(context.Background(), svc, metav1.CreateOptions{}); err != nil {

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -42,9 +42,15 @@ type tagMissingError struct {
 	error
 }
 
+type publicAccessFirewall struct {
+	name string
+	tags []string
+}
+
 type resources struct {
 	clusterID    string
 	clusterVPCID string
+	firewall     publicAccessFirewall
 
 	gclient *godo.Client
 	kclient kubernetes.Interface
@@ -57,10 +63,11 @@ type resources struct {
 // the cloud provider framework provides us with a clientset. Fortunately, the
 // initialization order guarantees that kclient won't be consumed prior to it
 // being set.
-func newResources(clusterID, clusterVPCID string, gclient *godo.Client) *resources {
+func newResources(clusterID, clusterVPCID string, publicAccessFW publicAccessFirewall, gclient *godo.Client) *resources {
 	return &resources{
 		clusterID:    clusterID,
 		clusterVPCID: clusterVPCID,
+		firewall:     publicAccessFW,
 
 		gclient: gclient,
 	}

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -162,7 +162,7 @@ func TestResourcesController_Run(t *testing.T) {
 		},
 		nil,
 	)
-	fakeResources := newResources(clusterID, "", gclient)
+	fakeResources := newResources(clusterID, "", publicAccessFirewall{}, gclient)
 	kclient := fake.NewSimpleClientset()
 	inf := informers.NewSharedInformerFactory(kclient, 0)
 
@@ -342,7 +342,7 @@ func TestResourcesController_SyncTags(t *testing.T) {
 				},
 			)
 
-			fakeResources := newResources("", "", gclient)
+			fakeResources := newResources("", "", publicAccessFirewall{}, gclient)
 			fakeTagsService := test.tagSvc
 			if fakeTagsService == nil {
 				fakeTagsService = newFakeTagsServiceWithFailure(0, errors.New("tags service not configured, should probably not have been called"))

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,6 +36,19 @@ A solution to the problem is to pass the provider ID (aka droplet ID) via the ku
 
 DigitalOcean's managed Kubernetes offering DOKS sets the provider ID on each worker node kubelet instance.
 
+### Managed firewall handling for public access
+
+`digitalocean-cloud-controller-manager` can manage a dedicated [DigitalOcean Cloud Firewall](https://www.digitalocean.com/docs/networking/firewalls/) to dynamically allow access to NodePorts. A controller watches over Services and modifies the inbound rules of a firewall to permit access to the target NodePorts, and likewise close down access again if a Service is deleted or its type changed to something other than `NodePort`. (Note that DigitalOcean Load-Balancers access the cluster over the VPC interface and as such are not managed by this particular firewall for now.)
+
+By default, no firewall will be managed. To enable firewall management, the following environment variables need to be defined:
+
+* `PUBLIC_ACCESS_FIREWALL_NAME`: the name of the firewall to use.
+* `PUBLIC_ACCESS_FIREWALL_TAGS`: a comma-separated list of tags that match the worker droplets the firewall should target.
+
+Managed firewalls should **not** be modified directly as such changes will be reverted eventually, including re-creation of the firewall should it ever be found missing.
+
+If management of the firewall is not desired anymore, the environment variables must be unset before the firewall can be deleted by the user manually.
+
 ### DEBUG_ADDR environment variable
 
 If the `DEBUG_ADDR` environment variable is specified, then an HTTP server is started on the given address (e.g., `:12301`). It serves on `/healthz` and queries the `/v2/account` path of the DigitalOcean API on request.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/digitalocean/godo v1.35.1
 	github.com/go-ini/ini v1.39.0 // indirect
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
+	github.com/google/go-cmp v0.5.0
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/minio/minio-go v6.0.10+incompatible
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/google/cadvisor v0.35.0/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -743,6 +745,8 @@ golang.org/x/tools v0.0.0-20190909030654-5b82db07426d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh338oozWyiFsBRHtrflcws=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/gonum v0.6.2/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=

--- a/vendor/github.com/google/go-cmp/cmp/compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare.go
@@ -6,6 +6,10 @@
 //
 // This package is intended to be a more powerful and safer alternative to
 // reflect.DeepEqual for comparing whether two values are semantically equal.
+// It is intended to only be used in tests, as performance is not a goal and
+// it may panic if it cannot compare the values. Its propensity towards
+// panicking means that its unsuitable for production environments where a
+// spurious panic may be fatal.
 //
 // The primary features of cmp are:
 //
@@ -22,8 +26,8 @@
 // equality is determined by recursively comparing the primitive kinds on both
 // values, much like reflect.DeepEqual. Unlike reflect.DeepEqual, unexported
 // fields are not compared by default; they result in panics unless suppressed
-// by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly compared
-// using the AllowUnexported option.
+// by using an Ignore option (see cmpopts.IgnoreUnexported) or explicitly
+// compared using the Exporter option.
 package cmp
 
 import (
@@ -62,8 +66,8 @@ import (
 //
 // Structs are equal if recursively calling Equal on all fields report equal.
 // If a struct contains unexported fields, Equal panics unless an Ignore option
-// (e.g., cmpopts.IgnoreUnexported) ignores that field or the AllowUnexported
-// option explicitly permits comparing the unexported field.
+// (e.g., cmpopts.IgnoreUnexported) ignores that field or the Exporter option
+// explicitly permits comparing the unexported field.
 //
 // Slices are equal if they are both nil or both non-nil, where recursively
 // calling Equal on all non-ignored slice or array elements report equal.
@@ -80,7 +84,58 @@ import (
 // Pointers and interfaces are equal if they are both nil or both non-nil,
 // where they have the same underlying concrete type and recursively
 // calling Equal on the underlying values reports equal.
+//
+// Before recursing into a pointer, slice element, or map, the current path
+// is checked to detect whether the address has already been visited.
+// If there is a cycle, then the pointed at values are considered equal
+// only if both addresses were previously visited in the same path step.
 func Equal(x, y interface{}, opts ...Option) bool {
+	s := newState(opts)
+	s.compareAny(rootStep(x, y))
+	return s.result.Equal()
+}
+
+// Diff returns a human-readable report of the differences between two values.
+// It returns an empty string if and only if Equal returns true for the same
+// input values and options.
+//
+// The output is displayed as a literal in pseudo-Go syntax.
+// At the start of each line, a "-" prefix indicates an element removed from x,
+// a "+" prefix to indicates an element added to y, and the lack of a prefix
+// indicates an element common to both x and y. If possible, the output
+// uses fmt.Stringer.String or error.Error methods to produce more humanly
+// readable outputs. In such cases, the string is prefixed with either an
+// 's' or 'e' character, respectively, to indicate that the method was called.
+//
+// Do not depend on this output being stable. If you need the ability to
+// programmatically interpret the difference, consider using a custom Reporter.
+func Diff(x, y interface{}, opts ...Option) string {
+	s := newState(opts)
+
+	// Optimization: If there are no other reporters, we can optimize for the
+	// common case where the result is equal (and thus no reported difference).
+	// This avoids the expensive construction of a difference tree.
+	if len(s.reporters) == 0 {
+		s.compareAny(rootStep(x, y))
+		if s.result.Equal() {
+			return ""
+		}
+		s.result = diff.Result{} // Reset results
+	}
+
+	r := new(defaultReporter)
+	s.reporters = append(s.reporters, reporter{r})
+	s.compareAny(rootStep(x, y))
+	d := r.String()
+	if (d == "") != s.result.Equal() {
+		panic("inconsistent difference and equality results")
+	}
+	return d
+}
+
+// rootStep constructs the first path step. If x and y have differing types,
+// then they are stored within an empty interface type.
+func rootStep(x, y interface{}) PathStep {
 	vx := reflect.ValueOf(x)
 	vy := reflect.ValueOf(y)
 
@@ -103,33 +158,7 @@ func Equal(x, y interface{}, opts ...Option) bool {
 		t = vx.Type()
 	}
 
-	s := newState(opts)
-	s.compareAny(&pathStep{t, vx, vy})
-	return s.result.Equal()
-}
-
-// Diff returns a human-readable report of the differences between two values.
-// It returns an empty string if and only if Equal returns true for the same
-// input values and options.
-//
-// The output is displayed as a literal in pseudo-Go syntax.
-// At the start of each line, a "-" prefix indicates an element removed from x,
-// a "+" prefix to indicates an element added to y, and the lack of a prefix
-// indicates an element common to both x and y. If possible, the output
-// uses fmt.Stringer.String or error.Error methods to produce more humanly
-// readable outputs. In such cases, the string is prefixed with either an
-// 's' or 'e' character, respectively, to indicate that the method was called.
-//
-// Do not depend on this output being stable. If you need the ability to
-// programmatically interpret the difference, consider using a custom Reporter.
-func Diff(x, y interface{}, opts ...Option) string {
-	r := new(defaultReporter)
-	eq := Equal(x, y, Options(opts), Reporter(r))
-	d := r.String()
-	if (d == "") != eq {
-		panic("inconsistent difference and equality results")
-	}
-	return d
+	return &pathStep{t, vx, vy}
 }
 
 type state struct {
@@ -137,6 +166,7 @@ type state struct {
 	// Calling statelessCompare must not result in observable changes to these.
 	result    diff.Result // The current result of comparison
 	curPath   Path        // The current path in the value tree
+	curPtrs   pointerPath // The current set of visited pointers
 	reporters []reporter  // Optional reporters
 
 	// recChecker checks for infinite cycles applying the same set of
@@ -148,13 +178,14 @@ type state struct {
 	dynChecker dynChecker
 
 	// These fields, once set by processOption, will not change.
-	exporters map[reflect.Type]bool // Set of structs with unexported field visibility
-	opts      Options               // List of all fundamental and filter options
+	exporters []exporter // List of exporters for structs with unexported fields
+	opts      Options    // List of all fundamental and filter options
 }
 
 func newState(opts []Option) *state {
 	// Always ensure a validator option exists to validate the inputs.
 	s := &state{opts: Options{validator{}}}
+	s.curPtrs.Init()
 	s.processOption(Options(opts))
 	return s
 }
@@ -174,13 +205,8 @@ func (s *state) processOption(opt Option) {
 			panic(fmt.Sprintf("cannot use an unfiltered option: %v", opt))
 		}
 		s.opts = append(s.opts, opt)
-	case visibleStructs:
-		if s.exporters == nil {
-			s.exporters = make(map[reflect.Type]bool)
-		}
-		for t := range opt {
-			s.exporters[t] = true
-		}
+	case exporter:
+		s.exporters = append(s.exporters, opt)
 	case reporter:
 		s.reporters = append(s.reporters, opt)
 	default:
@@ -192,9 +218,9 @@ func (s *state) processOption(opt Option) {
 // This function is stateless in that it does not alter the current result,
 // or output to any registered reporters.
 func (s *state) statelessCompare(step PathStep) diff.Result {
-	// We do not save and restore the curPath because all of the compareX
-	// methods should properly push and pop from the path.
-	// It is an implementation bug if the contents of curPath differs from
+	// We do not save and restore curPath and curPtrs because all of the
+	// compareX methods should properly push and pop from them.
+	// It is an implementation bug if the contents of the paths differ from
 	// when calling this function to when returning from it.
 
 	oldResult, oldReporters := s.result, s.reporters
@@ -216,9 +242,17 @@ func (s *state) compareAny(step PathStep) {
 	}
 	s.recChecker.Check(s.curPath)
 
-	// Obtain the current type and values.
+	// Cycle-detection for slice elements (see NOTE in compareSlice).
 	t := step.Type()
 	vx, vy := step.Values()
+	if si, ok := step.(SliceIndex); ok && si.isSlice && vx.IsValid() && vy.IsValid() {
+		px, py := vx.Addr(), vy.Addr()
+		if eq, visited := s.curPtrs.Push(px, py); visited {
+			s.report(eq, reportByCycle)
+			return
+		}
+		defer s.curPtrs.Pop(px, py)
+	}
 
 	// Rule 1: Check whether an option applies on this node in the value tree.
 	if s.tryOptions(t, vx, vy) {
@@ -342,7 +376,7 @@ func detectRaces(c chan<- reflect.Value, f reflect.Value, vs ...reflect.Value) {
 // assuming that T is assignable to R.
 // Otherwise, it returns the input value as is.
 func sanitizeValue(v reflect.Value, t reflect.Type) reflect.Value {
-	// TODO(dsnet): Workaround for reflect bug (https://golang.org/issue/22143).
+	// TODO(≥go1.10): Workaround for reflect bug (https://golang.org/issue/22143).
 	if !flags.AtLeastGo110 {
 		if v.Kind() == reflect.Interface && v.IsNil() && v.Type() != t {
 			return reflect.New(t).Elem()
@@ -352,8 +386,10 @@ func sanitizeValue(v reflect.Value, t reflect.Type) reflect.Value {
 }
 
 func (s *state) compareStruct(t reflect.Type, vx, vy reflect.Value) {
+	var addr bool
 	var vax, vay reflect.Value // Addressable versions of vx and vy
 
+	var mayForce, mayForceInit bool
 	step := StructField{&structField{}}
 	for i := 0; i < t.NumField(); i++ {
 		step.typ = t.Field(i).Type
@@ -372,10 +408,18 @@ func (s *state) compareStruct(t reflect.Type, vx, vy reflect.Value) {
 				// For retrieveUnexportedField to work, the parent struct must
 				// be addressable. Create a new copy of the values if
 				// necessary to make them addressable.
+				addr = vx.CanAddr() || vy.CanAddr()
 				vax = makeAddressable(vx)
 				vay = makeAddressable(vy)
 			}
-			step.mayForce = s.exporters[t]
+			if !mayForceInit {
+				for _, xf := range s.exporters {
+					mayForce = mayForce || xf(t)
+				}
+				mayForceInit = true
+			}
+			step.mayForce = mayForce
+			step.paddr = addr
 			step.pvx = vax
 			step.pvy = vay
 			step.field = t.Field(i)
@@ -391,9 +435,21 @@ func (s *state) compareSlice(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// NOTE: It is incorrect to call curPtrs.Push on the slice header pointer
+	// since slices represents a list of pointers, rather than a single pointer.
+	// The pointer checking logic must be handled on a per-element basis
+	// in compareAny.
+	//
+	// A slice header (see reflect.SliceHeader) in Go is a tuple of a starting
+	// pointer P, a length N, and a capacity C. Supposing each slice element has
+	// a memory size of M, then the slice is equivalent to the list of pointers:
+	//	[P+i*M for i in range(N)]
+	//
+	// For example, v[:0] and v[:1] are slices with the same starting pointer,
+	// but they are clearly different values. Using the slice pointer alone
+	// violates the assumption that equal pointers implies equal values.
 
-	step := SliceIndex{&sliceIndex{pathStep: pathStep{typ: t.Elem()}}}
+	step := SliceIndex{&sliceIndex{pathStep: pathStep{typ: t.Elem()}, isSlice: isSlice}}
 	withIndexes := func(ix, iy int) SliceIndex {
 		if ix >= 0 {
 			step.vx, step.xkey = vx.Index(ix), ix
@@ -470,7 +526,12 @@ func (s *state) compareMap(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// Cycle-detection for maps.
+	if eq, visited := s.curPtrs.Push(vx, vy); visited {
+		s.report(eq, reportByCycle)
+		return
+	}
+	defer s.curPtrs.Pop(vx, vy)
 
 	// We combine and sort the two map keys so that we can perform the
 	// comparisons in a deterministic order.
@@ -507,7 +568,12 @@ func (s *state) comparePtr(t reflect.Type, vx, vy reflect.Value) {
 		return
 	}
 
-	// TODO: Support cyclic data structures.
+	// Cycle-detection for pointers.
+	if eq, visited := s.curPtrs.Push(vx, vy); visited {
+		s.report(eq, reportByCycle)
+		return
+	}
+	defer s.curPtrs.Pop(vx, vy)
 
 	vx, vy = vx.Elem(), vy.Elem()
 	s.compareAny(Indirect{&indirect{pathStep{t.Elem(), vx, vy}}})

--- a/vendor/github.com/google/go-cmp/cmp/export_panic.go
+++ b/vendor/github.com/google/go-cmp/cmp/export_panic.go
@@ -8,8 +8,8 @@ package cmp
 
 import "reflect"
 
-const supportAllowUnexported = false
+const supportExporters = false
 
-func retrieveUnexportedField(reflect.Value, reflect.StructField) reflect.Value {
-	panic("retrieveUnexportedField is not implemented")
+func retrieveUnexportedField(reflect.Value, reflect.StructField, bool) reflect.Value {
+	panic("no support for forcibly accessing unexported fields")
 }

--- a/vendor/github.com/google/go-cmp/cmp/export_unsafe.go
+++ b/vendor/github.com/google/go-cmp/cmp/export_unsafe.go
@@ -11,13 +11,25 @@ import (
 	"unsafe"
 )
 
-const supportAllowUnexported = true
+const supportExporters = true
 
 // retrieveUnexportedField uses unsafe to forcibly retrieve any field from
 // a struct such that the value has read-write permissions.
 //
 // The parent struct, v, must be addressable, while f must be a StructField
-// describing the field to retrieve.
-func retrieveUnexportedField(v reflect.Value, f reflect.StructField) reflect.Value {
-	return reflect.NewAt(f.Type, unsafe.Pointer(v.UnsafeAddr()+f.Offset)).Elem()
+// describing the field to retrieve. If addr is false,
+// then the returned value will be shallowed copied to be non-addressable.
+func retrieveUnexportedField(v reflect.Value, f reflect.StructField, addr bool) reflect.Value {
+	ve := reflect.NewAt(f.Type, unsafe.Pointer(uintptr(unsafe.Pointer(v.UnsafeAddr()))+f.Offset)).Elem()
+	if !addr {
+		// A field is addressable if and only if the struct is addressable.
+		// If the original parent value was not addressable, shallow copy the
+		// value to make it non-addressable to avoid leaking an implementation
+		// detail of how forcibly exporting a field works.
+		if ve.Kind() == reflect.Interface && ve.IsNil() {
+			return reflect.Zero(f.Type)
+		}
+		return reflect.ValueOf(ve.Interface()).Convert(f.Type)
+	}
+	return ve
 }

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/name.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/name.go
@@ -1,0 +1,157 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package value
+
+import (
+	"reflect"
+	"strconv"
+)
+
+// TypeString is nearly identical to reflect.Type.String,
+// but has an additional option to specify that full type names be used.
+func TypeString(t reflect.Type, qualified bool) string {
+	return string(appendTypeName(nil, t, qualified, false))
+}
+
+func appendTypeName(b []byte, t reflect.Type, qualified, elideFunc bool) []byte {
+	// BUG: Go reflection provides no way to disambiguate two named types
+	// of the same name and within the same package,
+	// but declared within the namespace of different functions.
+
+	// Named type.
+	if t.Name() != "" {
+		if qualified && t.PkgPath() != "" {
+			b = append(b, '"')
+			b = append(b, t.PkgPath()...)
+			b = append(b, '"')
+			b = append(b, '.')
+			b = append(b, t.Name()...)
+		} else {
+			b = append(b, t.String()...)
+		}
+		return b
+	}
+
+	// Unnamed type.
+	switch k := t.Kind(); k {
+	case reflect.Bool, reflect.String, reflect.UnsafePointer,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
+		b = append(b, k.String()...)
+	case reflect.Chan:
+		if t.ChanDir() == reflect.RecvDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, "chan"...)
+		if t.ChanDir() == reflect.SendDir {
+			b = append(b, "<-"...)
+		}
+		b = append(b, ' ')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Func:
+		if !elideFunc {
+			b = append(b, "func"...)
+		}
+		b = append(b, '(')
+		for i := 0; i < t.NumIn(); i++ {
+			if i > 0 {
+				b = append(b, ", "...)
+			}
+			if i == t.NumIn()-1 && t.IsVariadic() {
+				b = append(b, "..."...)
+				b = appendTypeName(b, t.In(i).Elem(), qualified, false)
+			} else {
+				b = appendTypeName(b, t.In(i), qualified, false)
+			}
+		}
+		b = append(b, ')')
+		switch t.NumOut() {
+		case 0:
+			// Do nothing
+		case 1:
+			b = append(b, ' ')
+			b = appendTypeName(b, t.Out(0), qualified, false)
+		default:
+			b = append(b, " ("...)
+			for i := 0; i < t.NumOut(); i++ {
+				if i > 0 {
+					b = append(b, ", "...)
+				}
+				b = appendTypeName(b, t.Out(i), qualified, false)
+			}
+			b = append(b, ')')
+		}
+	case reflect.Struct:
+		b = append(b, "struct{ "...)
+		for i := 0; i < t.NumField(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			sf := t.Field(i)
+			if !sf.Anonymous {
+				if qualified && sf.PkgPath != "" {
+					b = append(b, '"')
+					b = append(b, sf.PkgPath...)
+					b = append(b, '"')
+					b = append(b, '.')
+				}
+				b = append(b, sf.Name...)
+				b = append(b, ' ')
+			}
+			b = appendTypeName(b, sf.Type, qualified, false)
+			if sf.Tag != "" {
+				b = append(b, ' ')
+				b = strconv.AppendQuote(b, string(sf.Tag))
+			}
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	case reflect.Slice, reflect.Array:
+		b = append(b, '[')
+		if k == reflect.Array {
+			b = strconv.AppendUint(b, uint64(t.Len()), 10)
+		}
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Map:
+		b = append(b, "map["...)
+		b = appendTypeName(b, t.Key(), qualified, false)
+		b = append(b, ']')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Ptr:
+		b = append(b, '*')
+		b = appendTypeName(b, t.Elem(), qualified, false)
+	case reflect.Interface:
+		b = append(b, "interface{ "...)
+		for i := 0; i < t.NumMethod(); i++ {
+			if i > 0 {
+				b = append(b, "; "...)
+			}
+			m := t.Method(i)
+			if qualified && m.PkgPath != "" {
+				b = append(b, '"')
+				b = append(b, m.PkgPath...)
+				b = append(b, '"')
+				b = append(b, '.')
+			}
+			b = append(b, m.Name...)
+			b = appendTypeName(b, m.Type, qualified, true)
+		}
+		if b[len(b)-1] == ' ' {
+			b = b[:len(b)-1]
+		} else {
+			b = append(b, ' ')
+		}
+		b = append(b, '}')
+	default:
+		panic("invalid kind: " + k.String())
+	}
+	return b
+}

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_purego.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_purego.go
@@ -21,3 +21,13 @@ func PointerOf(v reflect.Value) Pointer {
 	// assumes that the GC implementation does not use a moving collector.
 	return Pointer{v.Pointer(), v.Type()}
 }
+
+// IsNil reports whether the pointer is nil.
+func (p Pointer) IsNil() bool {
+	return p.p == 0
+}
+
+// Uintptr returns the pointer as a uintptr.
+func (p Pointer) Uintptr() uintptr {
+	return p.p
+}

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_unsafe.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/pointer_unsafe.go
@@ -24,3 +24,13 @@ func PointerOf(v reflect.Value) Pointer {
 	// which is necessary if the GC ever uses a moving collector.
 	return Pointer{unsafe.Pointer(v.Pointer()), v.Type()}
 }
+
+// IsNil reports whether the pointer is nil.
+func (p Pointer) IsNil() bool {
+	return p.p == nil
+}
+
+// Uintptr returns the pointer as a uintptr.
+func (p Pointer) Uintptr() uintptr {
+	return uintptr(p.p)
+}

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/sort.go
@@ -19,7 +19,7 @@ func SortKeys(vs []reflect.Value) []reflect.Value {
 	}
 
 	// Sort the map keys.
-	sort.Slice(vs, func(i, j int) bool { return isLess(vs[i], vs[j]) })
+	sort.SliceStable(vs, func(i, j int) bool { return isLess(vs[i], vs[j]) })
 
 	// Deduplicate keys (fails for NaNs).
 	vs2 := vs[:1]
@@ -42,6 +42,8 @@ func isLess(x, y reflect.Value) bool {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return x.Uint() < y.Uint()
 	case reflect.Float32, reflect.Float64:
+		// NOTE: This does not sort -0 as less than +0
+		// since Go maps treat -0 and +0 as equal keys.
 		fx, fy := x.Float(), y.Float()
 		return fx < fy || math.IsNaN(fx) && !math.IsNaN(fy)
 	case reflect.Complex64, reflect.Complex128:

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/zero.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/zero.go
@@ -4,7 +4,10 @@
 
 package value
 
-import "reflect"
+import (
+	"math"
+	"reflect"
+)
 
 // IsZero reports whether v is the zero value.
 // This does not rely on Interface and so can be used on unexported fields.
@@ -17,9 +20,9 @@ func IsZero(v reflect.Value) bool {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
+		return math.Float64bits(v.Float()) == 0
 	case reflect.Complex64, reflect.Complex128:
-		return v.Complex() == 0
+		return math.Float64bits(real(v.Complex())) == 0 && math.Float64bits(imag(v.Complex())) == 0
 	case reflect.String:
 		return v.String() == ""
 	case reflect.UnsafePointer:

--- a/vendor/github.com/google/go-cmp/cmp/path.go
+++ b/vendor/github.com/google/go-cmp/cmp/path.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp/internal/value"
 )
 
 // Path is a list of PathSteps describing the sequence of operations to get
@@ -41,7 +43,7 @@ type PathStep interface {
 	// In some cases, one or both may be invalid or have restrictions:
 	//	• For StructField, both are not interface-able if the current field
 	//	is unexported and the struct type is not explicitly permitted by
-	//	AllowUnexported to traverse unexported fields.
+	//	an Exporter to traverse unexported fields.
 	//	• For SliceIndex, one may be invalid if an element is missing from
 	//	either the x or y slice.
 	//	• For MapIndex, one may be invalid if an entry is missing from
@@ -175,7 +177,8 @@ type structField struct {
 	// pvx, pvy, and field are only valid if unexported is true.
 	unexported bool
 	mayForce   bool                // Forcibly allow visibility
-	pvx, pvy   reflect.Value       // Parent values
+	paddr      bool                // Was parent addressable?
+	pvx, pvy   reflect.Value       // Parent values (always addressible)
 	field      reflect.StructField // Field information
 }
 
@@ -187,8 +190,8 @@ func (sf StructField) Values() (vx, vy reflect.Value) {
 
 	// Forcibly obtain read-write access to an unexported struct field.
 	if sf.mayForce {
-		vx = retrieveUnexportedField(sf.pvx, sf.field)
-		vy = retrieveUnexportedField(sf.pvy, sf.field)
+		vx = retrieveUnexportedField(sf.pvx, sf.field, sf.paddr)
+		vy = retrieveUnexportedField(sf.pvy, sf.field, sf.paddr)
 		return vx, vy // CanInterface reports true
 	}
 	return sf.vx, sf.vy // CanInterface reports false
@@ -207,6 +210,7 @@ type SliceIndex struct{ *sliceIndex }
 type sliceIndex struct {
 	pathStep
 	xkey, ykey int
+	isSlice    bool // False for reflect.Array
 }
 
 func (si SliceIndex) Type() reflect.Type             { return si.typ }
@@ -300,6 +304,72 @@ func (tf Transform) Func() reflect.Value { return tf.trans.fnc }
 // Option returns the originally constructed Transformer option.
 // The == operator can be used to detect the exact option used.
 func (tf Transform) Option() Option { return tf.trans }
+
+// pointerPath represents a dual-stack of pointers encountered when
+// recursively traversing the x and y values. This data structure supports
+// detection of cycles and determining whether the cycles are equal.
+// In Go, cycles can occur via pointers, slices, and maps.
+//
+// The pointerPath uses a map to represent a stack; where descension into a
+// pointer pushes the address onto the stack, and ascension from a pointer
+// pops the address from the stack. Thus, when traversing into a pointer from
+// reflect.Ptr, reflect.Slice element, or reflect.Map, we can detect cycles
+// by checking whether the pointer has already been visited. The cycle detection
+// uses a seperate stack for the x and y values.
+//
+// If a cycle is detected we need to determine whether the two pointers
+// should be considered equal. The definition of equality chosen by Equal
+// requires two graphs to have the same structure. To determine this, both the
+// x and y values must have a cycle where the previous pointers were also
+// encountered together as a pair.
+//
+// Semantically, this is equivalent to augmenting Indirect, SliceIndex, and
+// MapIndex with pointer information for the x and y values.
+// Suppose px and py are two pointers to compare, we then search the
+// Path for whether px was ever encountered in the Path history of x, and
+// similarly so with py. If either side has a cycle, the comparison is only
+// equal if both px and py have a cycle resulting from the same PathStep.
+//
+// Using a map as a stack is more performant as we can perform cycle detection
+// in O(1) instead of O(N) where N is len(Path).
+type pointerPath struct {
+	// mx is keyed by x pointers, where the value is the associated y pointer.
+	mx map[value.Pointer]value.Pointer
+	// my is keyed by y pointers, where the value is the associated x pointer.
+	my map[value.Pointer]value.Pointer
+}
+
+func (p *pointerPath) Init() {
+	p.mx = make(map[value.Pointer]value.Pointer)
+	p.my = make(map[value.Pointer]value.Pointer)
+}
+
+// Push indicates intent to descend into pointers vx and vy where
+// visited reports whether either has been seen before. If visited before,
+// equal reports whether both pointers were encountered together.
+// Pop must be called if and only if the pointers were never visited.
+//
+// The pointers vx and vy must be a reflect.Ptr, reflect.Slice, or reflect.Map
+// and be non-nil.
+func (p pointerPath) Push(vx, vy reflect.Value) (equal, visited bool) {
+	px := value.PointerOf(vx)
+	py := value.PointerOf(vy)
+	_, ok1 := p.mx[px]
+	_, ok2 := p.my[py]
+	if ok1 || ok2 {
+		equal = p.mx[px] == py && p.my[py] == px // Pointers paired together
+		return equal, true
+	}
+	p.mx[px] = py
+	p.my[py] = px
+	return false, false
+}
+
+// Pop ascends from pointers vx and vy.
+func (p pointerPath) Pop(vx, vy reflect.Value) {
+	delete(p.mx, value.PointerOf(vx))
+	delete(p.my, value.PointerOf(vy))
+}
 
 // isExported reports whether the identifier is exported.
 func isExported(id string) bool {

--- a/vendor/github.com/google/go-cmp/cmp/report.go
+++ b/vendor/github.com/google/go-cmp/cmp/report.go
@@ -41,7 +41,10 @@ func (r *defaultReporter) String() string {
 	if r.root.NumDiff == 0 {
 		return ""
 	}
-	return formatOptions{}.FormatDiff(r.root).String()
+	ptrs := new(pointerReferences)
+	text := formatOptions{}.FormatDiff(r.root, ptrs)
+	resolveReferences(text)
+	return text.String()
 }
 
 func assert(ok bool) {

--- a/vendor/github.com/google/go-cmp/cmp/report_compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_compare.go
@@ -11,14 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp/internal/value"
 )
 
-// TODO: Enforce limits?
-//	* Enforce maximum number of records to print per node?
-//	* Enforce maximum size in bytes allowed?
-//	* As a heuristic, use less verbosity for equal nodes than unequal nodes.
-// TODO: Enforce unique outputs?
-//	* Avoid Stringer methods if it results in same output?
-//	* Print pointer address if outputs still equal?
-
 // numContextRecords is the number of surrounding equal records to print.
 const numContextRecords = 2
 
@@ -71,14 +63,56 @@ func (opts formatOptions) WithTypeMode(t typeMode) formatOptions {
 	opts.TypeMode = t
 	return opts
 }
+func (opts formatOptions) WithVerbosity(level int) formatOptions {
+	opts.VerbosityLevel = level
+	opts.LimitVerbosity = true
+	return opts
+}
+func (opts formatOptions) verbosity() uint {
+	switch {
+	case opts.VerbosityLevel < 0:
+		return 0
+	case opts.VerbosityLevel > 16:
+		return 16 // some reasonable maximum to avoid shift overflow
+	default:
+		return uint(opts.VerbosityLevel)
+	}
+}
+
+const maxVerbosityPreset = 3
+
+// verbosityPreset modifies the verbosity settings given an index
+// between 0 and maxVerbosityPreset, inclusive.
+func verbosityPreset(opts formatOptions, i int) formatOptions {
+	opts.VerbosityLevel = int(opts.verbosity()) + 2*i
+	if i > 0 {
+		opts.AvoidStringer = true
+	}
+	if i >= maxVerbosityPreset {
+		opts.PrintAddresses = true
+		opts.QualifiedNames = true
+	}
+	return opts
+}
 
 // FormatDiff converts a valueNode tree into a textNode tree, where the later
 // is a textual representation of the differences detected in the former.
-func (opts formatOptions) FormatDiff(v *valueNode) textNode {
+func (opts formatOptions) FormatDiff(v *valueNode, ptrs *pointerReferences) (out textNode) {
+	if opts.DiffMode == diffIdentical {
+		opts = opts.WithVerbosity(1)
+	} else {
+		opts = opts.WithVerbosity(3)
+	}
+
 	// Check whether we have specialized formatting for this node.
 	// This is not necessary, but helpful for producing more readable outputs.
 	if opts.CanFormatDiffSlice(v) {
 		return opts.FormatDiffSlice(v)
+	}
+
+	var parentKind reflect.Kind
+	if v.parent != nil && v.parent.TransformerName == "" {
+		parentKind = v.parent.Type.Kind()
 	}
 
 	// For leaf nodes, format the value based on the reflect.Values alone.
@@ -87,8 +121,8 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 		case diffUnknown, diffIdentical:
 			// Format Equal.
 			if v.NumDiff == 0 {
-				outx := opts.FormatValue(v.ValueX, visitedPointers{})
-				outy := opts.FormatValue(v.ValueY, visitedPointers{})
+				outx := opts.FormatValue(v.ValueX, parentKind, ptrs)
+				outy := opts.FormatValue(v.ValueY, parentKind, ptrs)
 				if v.NumIgnored > 0 && v.NumSame == 0 {
 					return textEllipsis
 				} else if outx.Len() < outy.Len() {
@@ -101,8 +135,13 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 			// Format unequal.
 			assert(opts.DiffMode == diffUnknown)
 			var list textList
-			outx := opts.WithTypeMode(elideType).FormatValue(v.ValueX, visitedPointers{})
-			outy := opts.WithTypeMode(elideType).FormatValue(v.ValueY, visitedPointers{})
+			outx := opts.WithTypeMode(elideType).FormatValue(v.ValueX, parentKind, ptrs)
+			outy := opts.WithTypeMode(elideType).FormatValue(v.ValueY, parentKind, ptrs)
+			for i := 0; i <= maxVerbosityPreset && outx != nil && outy != nil && outx.Equal(outy); i++ {
+				opts2 := verbosityPreset(opts, i).WithTypeMode(elideType)
+				outx = opts2.FormatValue(v.ValueX, parentKind, ptrs)
+				outy = opts2.FormatValue(v.ValueY, parentKind, ptrs)
+			}
 			if outx != nil {
 				list = append(list, textRecord{Diff: '-', Value: outx})
 			}
@@ -111,34 +150,57 @@ func (opts formatOptions) FormatDiff(v *valueNode) textNode {
 			}
 			return opts.WithTypeMode(emitType).FormatType(v.Type, list)
 		case diffRemoved:
-			return opts.FormatValue(v.ValueX, visitedPointers{})
+			return opts.FormatValue(v.ValueX, parentKind, ptrs)
 		case diffInserted:
-			return opts.FormatValue(v.ValueY, visitedPointers{})
+			return opts.FormatValue(v.ValueY, parentKind, ptrs)
 		default:
 			panic("invalid diff mode")
 		}
 	}
 
+	// Register slice element to support cycle detection.
+	if parentKind == reflect.Slice {
+		ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, true)
+		defer ptrs.Pop()
+		defer func() { out = wrapTrunkReferences(ptrRefs, out) }()
+	}
+
 	// Descend into the child value node.
 	if v.TransformerName != "" {
-		out := opts.WithTypeMode(emitType).FormatDiff(v.Value)
-		out = textWrap{"Inverse(" + v.TransformerName + ", ", out, ")"}
+		out := opts.WithTypeMode(emitType).FormatDiff(v.Value, ptrs)
+		out = &textWrap{Prefix: "Inverse(" + v.TransformerName + ", ", Value: out, Suffix: ")"}
 		return opts.FormatType(v.Type, out)
 	} else {
 		switch k := v.Type.Kind(); k {
-		case reflect.Struct, reflect.Array, reflect.Slice, reflect.Map:
-			return opts.FormatType(v.Type, opts.formatDiffList(v.Records, k))
+		case reflect.Struct, reflect.Array, reflect.Slice:
+			out = opts.formatDiffList(v.Records, k, ptrs)
+			out = opts.FormatType(v.Type, out)
+		case reflect.Map:
+			// Register map to support cycle detection.
+			ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, false)
+			defer ptrs.Pop()
+
+			out = opts.formatDiffList(v.Records, k, ptrs)
+			out = wrapTrunkReferences(ptrRefs, out)
+			out = opts.FormatType(v.Type, out)
 		case reflect.Ptr:
-			return textWrap{"&", opts.FormatDiff(v.Value), ""}
+			// Register pointer to support cycle detection.
+			ptrRefs := ptrs.PushPair(v.ValueX, v.ValueY, opts.DiffMode, false)
+			defer ptrs.Pop()
+
+			out = opts.FormatDiff(v.Value, ptrs)
+			out = wrapTrunkReferences(ptrRefs, out)
+			out = &textWrap{Prefix: "&", Value: out}
 		case reflect.Interface:
-			return opts.WithTypeMode(emitType).FormatDiff(v.Value)
+			out = opts.WithTypeMode(emitType).FormatDiff(v.Value, ptrs)
 		default:
 			panic(fmt.Sprintf("%v cannot have children", k))
 		}
+		return out
 	}
 }
 
-func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) textNode {
+func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind, ptrs *pointerReferences) textNode {
 	// Derive record name based on the data structure kind.
 	var name string
 	var formatKey func(reflect.Value) string
@@ -154,7 +216,17 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 	case reflect.Map:
 		name = "entry"
 		opts = opts.WithTypeMode(elideType)
-		formatKey = formatMapKey
+		formatKey = func(v reflect.Value) string { return formatMapKey(v, false, ptrs) }
+	}
+
+	maxLen := -1
+	if opts.LimitVerbosity {
+		if opts.DiffMode == diffIdentical {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+		} else {
+			maxLen = (1 << opts.verbosity()) << 1 // 2, 4, 8, 16, 32, 64, etc...
+		}
+		opts.VerbosityLevel--
 	}
 
 	// Handle unification.
@@ -163,12 +235,17 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 		var list textList
 		var deferredEllipsis bool // Add final "..." to indicate records were dropped
 		for _, r := range recs {
+			if len(list) == maxLen {
+				deferredEllipsis = true
+				break
+			}
+
 			// Elide struct fields that are zero value.
 			if k == reflect.Struct {
 				var isZero bool
 				switch opts.DiffMode {
 				case diffIdentical:
-					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueX)
+					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueY)
 				case diffRemoved:
 					isZero = value.IsZero(r.Value.ValueX)
 				case diffInserted:
@@ -186,23 +263,31 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 				}
 				continue
 			}
-			if out := opts.FormatDiff(r.Value); out != nil {
+			if out := opts.FormatDiff(r.Value, ptrs); out != nil {
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
 			}
 		}
 		if deferredEllipsis {
 			list.AppendEllipsis(diffStats{})
 		}
-		return textWrap{"{", list, "}"}
+		return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 	case diffUnknown:
 	default:
 		panic("invalid diff mode")
 	}
 
 	// Handle differencing.
+	var numDiffs int
 	var list textList
+	var keys []reflect.Value // invariant: len(list) == len(keys)
 	groups := coalesceAdjacentRecords(name, recs)
+	maxGroup := diffStats{Name: name}
 	for i, ds := range groups {
+		if maxLen >= 0 && numDiffs >= maxLen {
+			maxGroup = maxGroup.Append(ds)
+			continue
+		}
+
 		// Handle equal records.
 		if ds.NumDiff() == 0 {
 			// Compute the number of leading and trailing records to print.
@@ -226,16 +311,21 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 
 			// Format the equal values.
 			for _, r := range recs[:numLo] {
-				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value)
+				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 			if numEqual > numLo+numHi {
 				ds.NumIdentical -= numLo + numHi
 				list.AppendEllipsis(ds)
+				for len(keys) < len(list) {
+					keys = append(keys, reflect.Value{})
+				}
 			}
 			for _, r := range recs[numEqual-numHi : numEqual] {
-				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value)
+				out := opts.WithDiffMode(diffIdentical).FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 			recs = recs[numEqual:]
 			continue
@@ -247,24 +337,70 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 			case opts.CanFormatDiffSlice(r.Value):
 				out := opts.FormatDiffSlice(r.Value)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			case r.Value.NumChildren == r.Value.MaxDepth:
-				outx := opts.WithDiffMode(diffRemoved).FormatDiff(r.Value)
-				outy := opts.WithDiffMode(diffInserted).FormatDiff(r.Value)
+				outx := opts.WithDiffMode(diffRemoved).FormatDiff(r.Value, ptrs)
+				outy := opts.WithDiffMode(diffInserted).FormatDiff(r.Value, ptrs)
+				for i := 0; i <= maxVerbosityPreset && outx != nil && outy != nil && outx.Equal(outy); i++ {
+					opts2 := verbosityPreset(opts, i)
+					outx = opts2.WithDiffMode(diffRemoved).FormatDiff(r.Value, ptrs)
+					outy = opts2.WithDiffMode(diffInserted).FormatDiff(r.Value, ptrs)
+				}
 				if outx != nil {
 					list = append(list, textRecord{Diff: diffRemoved, Key: formatKey(r.Key), Value: outx})
+					keys = append(keys, r.Key)
 				}
 				if outy != nil {
 					list = append(list, textRecord{Diff: diffInserted, Key: formatKey(r.Key), Value: outy})
+					keys = append(keys, r.Key)
 				}
 			default:
-				out := opts.FormatDiff(r.Value)
+				out := opts.FormatDiff(r.Value, ptrs)
 				list = append(list, textRecord{Key: formatKey(r.Key), Value: out})
+				keys = append(keys, r.Key)
 			}
 		}
 		recs = recs[ds.NumDiff():]
+		numDiffs += ds.NumDiff()
 	}
-	assert(len(recs) == 0)
-	return textWrap{"{", list, "}"}
+	if maxGroup.IsZero() {
+		assert(len(recs) == 0)
+	} else {
+		list.AppendEllipsis(maxGroup)
+		for len(keys) < len(list) {
+			keys = append(keys, reflect.Value{})
+		}
+	}
+	assert(len(list) == len(keys))
+
+	// For maps, the default formatting logic uses fmt.Stringer which may
+	// produce ambiguous output. Avoid calling String to disambiguate.
+	if k == reflect.Map {
+		var ambiguous bool
+		seenKeys := map[string]reflect.Value{}
+		for i, currKey := range keys {
+			if currKey.IsValid() {
+				strKey := list[i].Key
+				prevKey, seen := seenKeys[strKey]
+				if seen && prevKey.CanInterface() && currKey.CanInterface() {
+					ambiguous = prevKey.Interface() != currKey.Interface()
+					if ambiguous {
+						break
+					}
+				}
+				seenKeys[strKey] = currKey
+			}
+		}
+		if ambiguous {
+			for i, k := range keys {
+				if k.IsValid() {
+					list[i].Key = formatMapKey(k, true, ptrs)
+				}
+			}
+		}
+	}
+
+	return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 }
 
 // coalesceAdjacentRecords coalesces the list of records into groups of

--- a/vendor/github.com/google/go-cmp/cmp/report_references.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_references.go
@@ -1,0 +1,264 @@
+// Copyright 2020, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp/internal/flags"
+	"github.com/google/go-cmp/cmp/internal/value"
+)
+
+const (
+	pointerDelimPrefix = "⟪"
+	pointerDelimSuffix = "⟫"
+)
+
+// formatPointer prints the address of the pointer.
+func formatPointer(p value.Pointer, withDelims bool) string {
+	v := p.Uintptr()
+	if flags.Deterministic {
+		v = 0xdeadf00f // Only used for stable testing purposes
+	}
+	if withDelims {
+		return pointerDelimPrefix + formatHex(uint64(v)) + pointerDelimSuffix
+	}
+	return formatHex(uint64(v))
+}
+
+// pointerReferences is a stack of pointers visited so far.
+type pointerReferences [][2]value.Pointer
+
+func (ps *pointerReferences) PushPair(vx, vy reflect.Value, d diffMode, deref bool) (pp [2]value.Pointer) {
+	if deref && vx.IsValid() {
+		vx = vx.Addr()
+	}
+	if deref && vy.IsValid() {
+		vy = vy.Addr()
+	}
+	switch d {
+	case diffUnknown, diffIdentical:
+		pp = [2]value.Pointer{value.PointerOf(vx), value.PointerOf(vy)}
+	case diffRemoved:
+		pp = [2]value.Pointer{value.PointerOf(vx), value.Pointer{}}
+	case diffInserted:
+		pp = [2]value.Pointer{value.Pointer{}, value.PointerOf(vy)}
+	}
+	*ps = append(*ps, pp)
+	return pp
+}
+
+func (ps *pointerReferences) Push(v reflect.Value) (p value.Pointer, seen bool) {
+	p = value.PointerOf(v)
+	for _, pp := range *ps {
+		if p == pp[0] || p == pp[1] {
+			return p, true
+		}
+	}
+	*ps = append(*ps, [2]value.Pointer{p, p})
+	return p, false
+}
+
+func (ps *pointerReferences) Pop() {
+	*ps = (*ps)[:len(*ps)-1]
+}
+
+// trunkReferences is metadata for a textNode indicating that the sub-tree
+// represents the value for either pointer in a pair of references.
+type trunkReferences struct{ pp [2]value.Pointer }
+
+// trunkReference is metadata for a textNode indicating that the sub-tree
+// represents the value for the given pointer reference.
+type trunkReference struct{ p value.Pointer }
+
+// leafReference is metadata for a textNode indicating that the value is
+// truncated as it refers to another part of the tree (i.e., a trunk).
+type leafReference struct{ p value.Pointer }
+
+func wrapTrunkReferences(pp [2]value.Pointer, s textNode) textNode {
+	switch {
+	case pp[0].IsNil():
+		return &textWrap{Value: s, Metadata: trunkReference{pp[1]}}
+	case pp[1].IsNil():
+		return &textWrap{Value: s, Metadata: trunkReference{pp[0]}}
+	case pp[0] == pp[1]:
+		return &textWrap{Value: s, Metadata: trunkReference{pp[0]}}
+	default:
+		return &textWrap{Value: s, Metadata: trunkReferences{pp}}
+	}
+}
+func wrapTrunkReference(p value.Pointer, printAddress bool, s textNode) textNode {
+	var prefix string
+	if printAddress {
+		prefix = formatPointer(p, true)
+	}
+	return &textWrap{Prefix: prefix, Value: s, Metadata: trunkReference{p}}
+}
+func makeLeafReference(p value.Pointer, printAddress bool) textNode {
+	out := &textWrap{Prefix: "(", Value: textEllipsis, Suffix: ")"}
+	var prefix string
+	if printAddress {
+		prefix = formatPointer(p, true)
+	}
+	return &textWrap{Prefix: prefix, Value: out, Metadata: leafReference{p}}
+}
+
+// resolveReferences walks the textNode tree searching for any leaf reference
+// metadata and resolves each against the corresponding trunk references.
+// Since pointer addresses in memory are not particularly readable to the user,
+// it replaces each pointer value with an arbitrary and unique reference ID.
+func resolveReferences(s textNode) {
+	var walkNodes func(textNode, func(textNode))
+	walkNodes = func(s textNode, f func(textNode)) {
+		f(s)
+		switch s := s.(type) {
+		case *textWrap:
+			walkNodes(s.Value, f)
+		case textList:
+			for _, r := range s {
+				walkNodes(r.Value, f)
+			}
+		}
+	}
+
+	// Collect all trunks and leaves with reference metadata.
+	var trunks, leaves []*textWrap
+	walkNodes(s, func(s textNode) {
+		if s, ok := s.(*textWrap); ok {
+			switch s.Metadata.(type) {
+			case leafReference:
+				leaves = append(leaves, s)
+			case trunkReference, trunkReferences:
+				trunks = append(trunks, s)
+			}
+		}
+	})
+
+	// No leaf references to resolve.
+	if len(leaves) == 0 {
+		return
+	}
+
+	// Collect the set of all leaf references to resolve.
+	leafPtrs := make(map[value.Pointer]bool)
+	for _, leaf := range leaves {
+		leafPtrs[leaf.Metadata.(leafReference).p] = true
+	}
+
+	// Collect the set of trunk pointers that are always paired together.
+	// This allows us to assign a single ID to both pointers for brevity.
+	// If a pointer in a pair ever occurs by itself or as a different pair,
+	// then the pair is broken.
+	pairedTrunkPtrs := make(map[value.Pointer]value.Pointer)
+	unpair := func(p value.Pointer) {
+		if !pairedTrunkPtrs[p].IsNil() {
+			pairedTrunkPtrs[pairedTrunkPtrs[p]] = value.Pointer{} // invalidate other half
+		}
+		pairedTrunkPtrs[p] = value.Pointer{} // invalidate this half
+	}
+	for _, trunk := range trunks {
+		switch p := trunk.Metadata.(type) {
+		case trunkReference:
+			unpair(p.p) // standalone pointer cannot be part of a pair
+		case trunkReferences:
+			p0, ok0 := pairedTrunkPtrs[p.pp[0]]
+			p1, ok1 := pairedTrunkPtrs[p.pp[1]]
+			switch {
+			case !ok0 && !ok1:
+				// Register the newly seen pair.
+				pairedTrunkPtrs[p.pp[0]] = p.pp[1]
+				pairedTrunkPtrs[p.pp[1]] = p.pp[0]
+			case ok0 && ok1 && p0 == p.pp[1] && p1 == p.pp[0]:
+				// Exact pair already seen; do nothing.
+			default:
+				// Pair conflicts with some other pair; break all pairs.
+				unpair(p.pp[0])
+				unpair(p.pp[1])
+			}
+		}
+	}
+
+	// Correlate each pointer referenced by leaves to a unique identifier,
+	// and print the IDs for each trunk that matches those pointers.
+	var nextID uint
+	ptrIDs := make(map[value.Pointer]uint)
+	newID := func() uint {
+		id := nextID
+		nextID++
+		return id
+	}
+	for _, trunk := range trunks {
+		switch p := trunk.Metadata.(type) {
+		case trunkReference:
+			if print := leafPtrs[p.p]; print {
+				id, ok := ptrIDs[p.p]
+				if !ok {
+					id = newID()
+					ptrIDs[p.p] = id
+				}
+				trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id))
+			}
+		case trunkReferences:
+			print0 := leafPtrs[p.pp[0]]
+			print1 := leafPtrs[p.pp[1]]
+			if print0 || print1 {
+				id0, ok0 := ptrIDs[p.pp[0]]
+				id1, ok1 := ptrIDs[p.pp[1]]
+				isPair := pairedTrunkPtrs[p.pp[0]] == p.pp[1] && pairedTrunkPtrs[p.pp[1]] == p.pp[0]
+				if isPair {
+					var id uint
+					assert(ok0 == ok1) // must be seen together or not at all
+					if ok0 {
+						assert(id0 == id1) // must have the same ID
+						id = id0
+					} else {
+						id = newID()
+						ptrIDs[p.pp[0]] = id
+						ptrIDs[p.pp[1]] = id
+					}
+					trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id))
+				} else {
+					if print0 && !ok0 {
+						id0 = newID()
+						ptrIDs[p.pp[0]] = id0
+					}
+					if print1 && !ok1 {
+						id1 = newID()
+						ptrIDs[p.pp[1]] = id1
+					}
+					switch {
+					case print0 && print1:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id0)+","+formatReference(id1))
+					case print0:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id0))
+					case print1:
+						trunk.Prefix = updateReferencePrefix(trunk.Prefix, formatReference(id1))
+					}
+				}
+			}
+		}
+	}
+
+	// Update all leaf references with the unique identifier.
+	for _, leaf := range leaves {
+		if id, ok := ptrIDs[leaf.Metadata.(leafReference).p]; ok {
+			leaf.Prefix = updateReferencePrefix(leaf.Prefix, formatReference(id))
+		}
+	}
+}
+
+func formatReference(id uint) string {
+	return fmt.Sprintf("ref#%d", id)
+}
+
+func updateReferencePrefix(prefix, ref string) string {
+	if prefix == "" {
+		return pointerDelimPrefix + ref + pointerDelimSuffix
+	}
+	suffix := strings.TrimPrefix(prefix, pointerDelimPrefix)
+	return pointerDelimPrefix + ref + ": " + suffix
+}

--- a/vendor/github.com/google/go-cmp/cmp/report_reflect.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_reflect.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
-	"github.com/google/go-cmp/cmp/internal/flags"
 	"github.com/google/go-cmp/cmp/internal/value"
 )
 
@@ -20,14 +20,22 @@ type formatValueOptions struct {
 	// methods like error.Error or fmt.Stringer.String.
 	AvoidStringer bool
 
-	// ShallowPointers controls whether to avoid descending into pointers.
-	// Useful when printing map keys, where pointer comparison is performed
-	// on the pointer address rather than the pointed-at value.
-	ShallowPointers bool
-
 	// PrintAddresses controls whether to print the address of all pointers,
 	// slice elements, and maps.
 	PrintAddresses bool
+
+	// QualifiedNames controls whether FormatType uses the fully qualified name
+	// (including the full package path as opposed to just the package name).
+	QualifiedNames bool
+
+	// VerbosityLevel controls the amount of output to produce.
+	// A higher value produces more output. A value of zero or lower produces
+	// no output (represented using an ellipsis).
+	// If LimitVerbosity is false, then the level is treated as infinite.
+	VerbosityLevel int
+
+	// LimitVerbosity specifies that formatting should respect VerbosityLevel.
+	LimitVerbosity bool
 }
 
 // FormatType prints the type as if it were wrapping s.
@@ -44,12 +52,15 @@ func (opts formatOptions) FormatType(t reflect.Type, s textNode) textNode {
 		default:
 			return s
 		}
+		if opts.DiffMode == diffIdentical {
+			return s // elide type for identical nodes
+		}
 	case elideType:
 		return s
 	}
 
 	// Determine the type label, applying special handling for unnamed types.
-	typeName := t.String()
+	typeName := value.TypeString(t, opts.QualifiedNames)
 	if t.Name() == "" {
 		// According to Go grammar, certain type literals contain symbols that
 		// do not strongly bind to the next lexicographical token (e.g., *T).
@@ -57,39 +68,78 @@ func (opts formatOptions) FormatType(t reflect.Type, s textNode) textNode {
 		case reflect.Chan, reflect.Func, reflect.Ptr:
 			typeName = "(" + typeName + ")"
 		}
-		typeName = strings.Replace(typeName, "struct {", "struct{", -1)
-		typeName = strings.Replace(typeName, "interface {", "interface{", -1)
 	}
+	return &textWrap{Prefix: typeName, Value: wrapParens(s)}
+}
 
-	// Avoid wrap the value in parenthesis if unnecessary.
-	if s, ok := s.(textWrap); ok {
-		hasParens := strings.HasPrefix(s.Prefix, "(") && strings.HasSuffix(s.Suffix, ")")
-		hasBraces := strings.HasPrefix(s.Prefix, "{") && strings.HasSuffix(s.Suffix, "}")
+// wrapParens wraps s with a set of parenthesis, but avoids it if the
+// wrapped node itself is already surrounded by a pair of parenthesis or braces.
+// It handles unwrapping one level of pointer-reference nodes.
+func wrapParens(s textNode) textNode {
+	var refNode *textWrap
+	if s2, ok := s.(*textWrap); ok {
+		// Unwrap a single pointer reference node.
+		switch s2.Metadata.(type) {
+		case leafReference, trunkReference, trunkReferences:
+			refNode = s2
+			if s3, ok := refNode.Value.(*textWrap); ok {
+				s2 = s3
+			}
+		}
+
+		// Already has delimiters that make parenthesis unnecessary.
+		hasParens := strings.HasPrefix(s2.Prefix, "(") && strings.HasSuffix(s2.Suffix, ")")
+		hasBraces := strings.HasPrefix(s2.Prefix, "{") && strings.HasSuffix(s2.Suffix, "}")
 		if hasParens || hasBraces {
-			return textWrap{typeName, s, ""}
+			return s
 		}
 	}
-	return textWrap{typeName + "(", s, ")"}
+	if refNode != nil {
+		refNode.Value = &textWrap{Prefix: "(", Value: refNode.Value, Suffix: ")"}
+		return s
+	}
+	return &textWrap{Prefix: "(", Value: s, Suffix: ")"}
 }
 
 // FormatValue prints the reflect.Value, taking extra care to avoid descending
-// into pointers already in m. As pointers are visited, m is also updated.
-func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out textNode) {
+// into pointers already in ptrs. As pointers are visited, ptrs is also updated.
+func (opts formatOptions) FormatValue(v reflect.Value, parentKind reflect.Kind, ptrs *pointerReferences) (out textNode) {
 	if !v.IsValid() {
 		return nil
 	}
 	t := v.Type()
+
+	// Check slice element for cycles.
+	if parentKind == reflect.Slice {
+		ptrRef, visited := ptrs.Push(v.Addr())
+		if visited {
+			return makeLeafReference(ptrRef, false)
+		}
+		defer ptrs.Pop()
+		defer func() { out = wrapTrunkReference(ptrRef, false, out) }()
+	}
 
 	// Check whether there is an Error or String method to call.
 	if !opts.AvoidStringer && v.CanInterface() {
 		// Avoid calling Error or String methods on nil receivers since many
 		// implementations crash when doing so.
 		if (t.Kind() != reflect.Ptr && t.Kind() != reflect.Interface) || !v.IsNil() {
+			var prefix, strVal string
 			switch v := v.Interface().(type) {
 			case error:
-				return textLine("e" + formatString(v.Error()))
+				prefix, strVal = "e", v.Error()
 			case fmt.Stringer:
-				return textLine("s" + formatString(v.String()))
+				prefix, strVal = "s", v.String()
+			}
+			if prefix != "" {
+				maxLen := len(strVal)
+				if opts.LimitVerbosity {
+					maxLen = (1 << opts.verbosity()) << 5 // 32, 64, 128, 256, etc...
+				}
+				if len(strVal) > maxLen+len(textEllipsis) {
+					return textLine(prefix + formatString(strVal[:maxLen]) + string(textEllipsis))
+				}
+				return textLine(prefix + formatString(strVal))
 			}
 		}
 	}
@@ -102,94 +152,136 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 		}
 	}()
 
-	var ptr string
 	switch t.Kind() {
 	case reflect.Bool:
 		return textLine(fmt.Sprint(v.Bool()))
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return textLine(fmt.Sprint(v.Int()))
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		// Unnamed uints are usually bytes or words, so use hexadecimal.
-		if t.PkgPath() == "" || t.Kind() == reflect.Uintptr {
+	case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return textLine(fmt.Sprint(v.Uint()))
+	case reflect.Uint8:
+		if parentKind == reflect.Slice || parentKind == reflect.Array {
 			return textLine(formatHex(v.Uint()))
 		}
 		return textLine(fmt.Sprint(v.Uint()))
+	case reflect.Uintptr:
+		return textLine(formatHex(v.Uint()))
 	case reflect.Float32, reflect.Float64:
 		return textLine(fmt.Sprint(v.Float()))
 	case reflect.Complex64, reflect.Complex128:
 		return textLine(fmt.Sprint(v.Complex()))
 	case reflect.String:
+		maxLen := v.Len()
+		if opts.LimitVerbosity {
+			maxLen = (1 << opts.verbosity()) << 5 // 32, 64, 128, 256, etc...
+		}
+		if v.Len() > maxLen+len(textEllipsis) {
+			return textLine(formatString(v.String()[:maxLen]) + string(textEllipsis))
+		}
 		return textLine(formatString(v.String()))
 	case reflect.UnsafePointer, reflect.Chan, reflect.Func:
-		return textLine(formatPointer(v))
+		return textLine(formatPointer(value.PointerOf(v), true))
 	case reflect.Struct:
 		var list textList
+		v := makeAddressable(v) // needed for retrieveUnexportedField
+		maxLen := v.NumField()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		for i := 0; i < v.NumField(); i++ {
 			vv := v.Field(i)
 			if value.IsZero(vv) {
 				continue // Elide fields with zero values
 			}
-			s := opts.WithTypeMode(autoType).FormatValue(vv, m)
-			list = append(list, textRecord{Key: t.Field(i).Name, Value: s})
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
+			}
+			sf := t.Field(i)
+			if supportExporters && !isExported(sf.Name) {
+				vv = retrieveUnexportedField(v, sf, true)
+			}
+			s := opts.WithTypeMode(autoType).FormatValue(vv, t.Kind(), ptrs)
+			list = append(list, textRecord{Key: sf.Name, Value: s})
 		}
-		return textWrap{"{", list, "}"}
+		return &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 	case reflect.Slice:
 		if v.IsNil() {
 			return textNil
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
-		}
 		fallthrough
 	case reflect.Array:
+		maxLen := v.Len()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		var list textList
 		for i := 0; i < v.Len(); i++ {
-			vi := v.Index(i)
-			if vi.CanAddr() { // Check for cyclic elements
-				p := vi.Addr()
-				if m.Visit(p) {
-					var out textNode
-					out = textLine(formatPointer(p))
-					out = opts.WithTypeMode(emitType).FormatType(p.Type(), out)
-					out = textWrap{"*", out, ""}
-					list = append(list, textRecord{Value: out})
-					continue
-				}
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
 			}
-			s := opts.WithTypeMode(elideType).FormatValue(vi, m)
+			s := opts.WithTypeMode(elideType).FormatValue(v.Index(i), t.Kind(), ptrs)
 			list = append(list, textRecord{Value: s})
 		}
-		return textWrap{ptr + "{", list, "}"}
+
+		out = &textWrap{Prefix: "{", Value: list, Suffix: "}"}
+		if t.Kind() == reflect.Slice && opts.PrintAddresses {
+			header := fmt.Sprintf("ptr:%v, len:%d, cap:%d", formatPointer(value.PointerOf(v), false), v.Len(), v.Cap())
+			out = &textWrap{Prefix: pointerDelimPrefix + header + pointerDelimSuffix, Value: out}
+		}
+		return out
 	case reflect.Map:
 		if v.IsNil() {
 			return textNil
 		}
-		if m.Visit(v) {
-			return textLine(formatPointer(v))
-		}
 
+		// Check pointer for cycles.
+		ptrRef, visited := ptrs.Push(v)
+		if visited {
+			return makeLeafReference(ptrRef, opts.PrintAddresses)
+		}
+		defer ptrs.Pop()
+
+		maxLen := v.Len()
+		if opts.LimitVerbosity {
+			maxLen = ((1 << opts.verbosity()) >> 1) << 2 // 0, 4, 8, 16, 32, etc...
+			opts.VerbosityLevel--
+		}
 		var list textList
 		for _, k := range value.SortKeys(v.MapKeys()) {
-			sk := formatMapKey(k)
-			sv := opts.WithTypeMode(elideType).FormatValue(v.MapIndex(k), m)
+			if len(list) == maxLen {
+				list.AppendEllipsis(diffStats{})
+				break
+			}
+			sk := formatMapKey(k, false, ptrs)
+			sv := opts.WithTypeMode(elideType).FormatValue(v.MapIndex(k), t.Kind(), ptrs)
 			list = append(list, textRecord{Key: sk, Value: sv})
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
-		}
-		return textWrap{ptr + "{", list, "}"}
+
+		out = &textWrap{Prefix: "{", Value: list, Suffix: "}"}
+		out = wrapTrunkReference(ptrRef, opts.PrintAddresses, out)
+		return out
 	case reflect.Ptr:
 		if v.IsNil() {
 			return textNil
 		}
-		if m.Visit(v) || opts.ShallowPointers {
-			return textLine(formatPointer(v))
+
+		// Check pointer for cycles.
+		ptrRef, visited := ptrs.Push(v)
+		if visited {
+			out = makeLeafReference(ptrRef, opts.PrintAddresses)
+			return &textWrap{Prefix: "&", Value: out}
 		}
-		if opts.PrintAddresses {
-			ptr = formatPointer(v)
-		}
+		defer ptrs.Pop()
+
 		skipType = true // Let the underlying value print the type instead
-		return textWrap{"&" + ptr, opts.FormatValue(v.Elem(), m), ""}
+		out = opts.FormatValue(v.Elem(), t.Kind(), ptrs)
+		out = wrapTrunkReference(ptrRef, opts.PrintAddresses, out)
+		out = &textWrap{Prefix: "&", Value: out}
+		return out
 	case reflect.Interface:
 		if v.IsNil() {
 			return textNil
@@ -197,7 +289,7 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 		// Interfaces accept different concrete types,
 		// so configure the underlying value to explicitly print the type.
 		skipType = true // Print the concrete type instead
-		return opts.WithTypeMode(emitType).FormatValue(v.Elem(), m)
+		return opts.WithTypeMode(emitType).FormatValue(v.Elem(), t.Kind(), ptrs)
 	default:
 		panic(fmt.Sprintf("%v kind not handled", v.Kind()))
 	}
@@ -205,12 +297,14 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 
 // formatMapKey formats v as if it were a map key.
 // The result is guaranteed to be a single line.
-func formatMapKey(v reflect.Value) string {
+func formatMapKey(v reflect.Value, disambiguate bool, ptrs *pointerReferences) string {
 	var opts formatOptions
+	opts.DiffMode = diffIdentical
 	opts.TypeMode = elideType
-	opts.AvoidStringer = true
-	opts.ShallowPointers = true
-	s := opts.FormatValue(v, visitedPointers{}).String()
+	opts.PrintAddresses = disambiguate
+	opts.AvoidStringer = disambiguate
+	opts.QualifiedNames = disambiguate
+	s := opts.FormatValue(v, reflect.Map, ptrs).String()
 	return strings.TrimSpace(s)
 }
 
@@ -228,7 +322,7 @@ func formatString(s string) string {
 	rawInvalid := func(r rune) bool {
 		return r == '`' || r == '\n' || !(unicode.IsPrint(r) || r == '\t')
 	}
-	if strings.IndexFunc(s, rawInvalid) < 0 {
+	if utf8.ValidString(s) && strings.IndexFunc(s, rawInvalid) < 0 {
 		return "`" + s + "`"
 	}
 	return qs
@@ -256,24 +350,4 @@ func formatHex(u uint64) string {
 		f = "0x%016x"
 	}
 	return fmt.Sprintf(f, u)
-}
-
-// formatPointer prints the address of the pointer.
-func formatPointer(v reflect.Value) string {
-	p := v.Pointer()
-	if flags.Deterministic {
-		p = 0xdeadf00f // Only used for stable testing purposes
-	}
-	return fmt.Sprintf("⟪0x%x⟫", p)
-}
-
-type visitedPointers map[value.Pointer]struct{}
-
-// Visit inserts pointer v into the visited map and reports whether it had
-// already been visited before.
-func (m visitedPointers) Visit(v reflect.Value) bool {
-	p := value.PointerOf(v)
-	_, visited := m[p]
-	m[p] = struct{}{}
-	return visited
 }

--- a/vendor/github.com/google/go-cmp/cmp/report_slices.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_slices.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -23,11 +24,25 @@ func (opts formatOptions) CanFormatDiffSlice(v *valueNode) bool {
 		return false // Must be formatting in diff mode
 	case v.NumDiff == 0:
 		return false // No differences detected
-	case v.NumIgnored+v.NumCompared+v.NumTransformed > 0:
-		// TODO: Handle the case where someone uses bytes.Equal on a large slice.
-		return false // Some custom option was used to determined equality
 	case !v.ValueX.IsValid() || !v.ValueY.IsValid():
 		return false // Both values must be valid
+	case v.Type.Kind() == reflect.Slice && (v.ValueX.Len() == 0 || v.ValueY.Len() == 0):
+		return false // Both slice values have to be non-empty
+	case v.NumIgnored > 0:
+		return false // Some ignore option was used
+	case v.NumTransformed > 0:
+		return false // Some transform option was used
+	case v.NumCompared > 1:
+		return false // More than one comparison was used
+	case v.NumCompared == 1 && v.Type.Name() != "":
+		// The need for cmp to check applicability of options on every element
+		// in a slice is a significant performance detriment for large []byte.
+		// The workaround is to specify Comparer(bytes.Equal),
+		// which enables cmp to compare []byte more efficiently.
+		// If they differ, we still want to provide batched diffing.
+		// The logic disallows named types since they tend to have their own
+		// String method, with nicer formatting than what this provides.
+		return false
 	}
 
 	switch t := v.Type; t.Kind() {
@@ -82,7 +97,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 	}
 	if isText || isBinary {
 		var numLines, lastLineIdx, maxLineLen int
-		isBinary = false
+		isBinary = !utf8.ValidString(sx) || !utf8.ValidString(sy)
 		for i, r := range sx + sy {
 			if !(unicode.IsPrint(r) || unicode.IsSpace(r)) || r == utf8.RuneError {
 				isBinary = true
@@ -90,14 +105,14 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 			}
 			if r == '\n' {
 				if maxLineLen < i-lastLineIdx {
-					lastLineIdx = i - lastLineIdx
+					maxLineLen = i - lastLineIdx
 				}
 				lastLineIdx = i + 1
 				numLines++
 			}
 		}
 		isText = !isBinary
-		isLinedText = isText && numLines >= 4 && maxLineLen <= 256
+		isLinedText = isText && numLines >= 4 && maxLineLen <= 1024
 	}
 
 	// Format the string into printable records.
@@ -117,6 +132,83 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 			},
 		)
 		delim = "\n"
+
+		// If possible, use a custom triple-quote (""") syntax for printing
+		// differences in a string literal. This format is more readable,
+		// but has edge-cases where differences are visually indistinguishable.
+		// This format is avoided under the following conditions:
+		//	• A line starts with `"""`
+		//	• A line starts with "..."
+		//	• A line contains non-printable characters
+		//	• Adjacent different lines differ only by whitespace
+		//
+		// For example:
+		//		"""
+		//		... // 3 identical lines
+		//		foo
+		//		bar
+		//	-	baz
+		//	+	BAZ
+		//		"""
+		isTripleQuoted := true
+		prevRemoveLines := map[string]bool{}
+		prevInsertLines := map[string]bool{}
+		var list2 textList
+		list2 = append(list2, textRecord{Value: textLine(`"""`), ElideComma: true})
+		for _, r := range list {
+			if !r.Value.Equal(textEllipsis) {
+				line, _ := strconv.Unquote(string(r.Value.(textLine)))
+				line = strings.TrimPrefix(strings.TrimSuffix(line, "\r"), "\r") // trim leading/trailing carriage returns for legacy Windows endline support
+				normLine := strings.Map(func(r rune) rune {
+					if unicode.IsSpace(r) {
+						return -1 // drop whitespace to avoid visually indistinguishable output
+					}
+					return r
+				}, line)
+				isPrintable := func(r rune) bool {
+					return unicode.IsPrint(r) || r == '\t' // specially treat tab as printable
+				}
+				isTripleQuoted = !strings.HasPrefix(line, `"""`) && !strings.HasPrefix(line, "...") && strings.TrimFunc(line, isPrintable) == ""
+				switch r.Diff {
+				case diffRemoved:
+					isTripleQuoted = isTripleQuoted && !prevInsertLines[normLine]
+					prevRemoveLines[normLine] = true
+				case diffInserted:
+					isTripleQuoted = isTripleQuoted && !prevRemoveLines[normLine]
+					prevInsertLines[normLine] = true
+				}
+				if !isTripleQuoted {
+					break
+				}
+				r.Value = textLine(line)
+				r.ElideComma = true
+			}
+			if !(r.Diff == diffRemoved || r.Diff == diffInserted) { // start a new non-adjacent difference group
+				prevRemoveLines = map[string]bool{}
+				prevInsertLines = map[string]bool{}
+			}
+			list2 = append(list2, r)
+		}
+		if r := list2[len(list2)-1]; r.Diff == diffIdentical && len(r.Value.(textLine)) == 0 {
+			list2 = list2[:len(list2)-1] // elide single empty line at the end
+		}
+		list2 = append(list2, textRecord{Value: textLine(`"""`), ElideComma: true})
+		if isTripleQuoted {
+			var out textNode = &textWrap{Prefix: "(", Value: list2, Suffix: ")"}
+			switch t.Kind() {
+			case reflect.String:
+				if t != reflect.TypeOf(string("")) {
+					out = opts.FormatType(t, out)
+				}
+			case reflect.Slice:
+				// Always emit type for slices since the triple-quote syntax
+				// looks like a string (not a slice).
+				opts = opts.WithTypeMode(emitType)
+				out = opts.FormatType(t, out)
+			}
+			return out
+		}
+
 	// If the text appears to be single-lined text,
 	// then perform differencing in approximately fixed-sized chunks.
 	// The output is printed as quoted strings.
@@ -129,6 +221,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 			},
 		)
 		delim = ""
+
 	// If the text appears to be binary data,
 	// then perform differencing in approximately fixed-sized chunks.
 	// The output is inspired by hexdump.
@@ -145,6 +238,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 				return textRecord{Diff: d, Value: textLine(s), Comment: comment}
 			},
 		)
+
 	// For all other slices of primitive types,
 	// then perform differencing in approximately fixed-sized chunks.
 	// The size of each chunk depends on the width of the element kind.
@@ -172,7 +266,9 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 					switch t.Elem().Kind() {
 					case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 						ss = append(ss, fmt.Sprint(v.Index(i).Int()))
-					case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+					case reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+						ss = append(ss, fmt.Sprint(v.Index(i).Uint()))
+					case reflect.Uint8, reflect.Uintptr:
 						ss = append(ss, formatHex(v.Index(i).Uint()))
 					case reflect.Bool, reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128:
 						ss = append(ss, fmt.Sprint(v.Index(i).Interface()))
@@ -185,7 +281,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 	}
 
 	// Wrap the output with appropriate type information.
-	var out textNode = textWrap{"{", list, "}"}
+	var out textNode = &textWrap{Prefix: "{", Value: list, Suffix: "}"}
 	if !isText {
 		// The "{...}" byte-sequence literal is not valid Go syntax for strings.
 		// Emit the type for extra clarity (e.g. "string{...}").
@@ -196,12 +292,12 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 	}
 	switch t.Kind() {
 	case reflect.String:
-		out = textWrap{"strings.Join(", out, fmt.Sprintf(", %q)", delim)}
+		out = &textWrap{Prefix: "strings.Join(", Value: out, Suffix: fmt.Sprintf(", %q)", delim)}
 		if t != reflect.TypeOf(string("")) {
 			out = opts.FormatType(t, out)
 		}
 	case reflect.Slice:
-		out = textWrap{"bytes.Join(", out, fmt.Sprintf(", %q)", delim)}
+		out = &textWrap{Prefix: "bytes.Join(", Value: out, Suffix: fmt.Sprintf(", %q)", delim)}
 		if t != reflect.TypeOf([]byte(nil)) {
 			out = opts.FormatType(t, out)
 		}
@@ -242,9 +338,22 @@ func (opts formatOptions) formatDiffSlice(
 		return n0 - v.Len()
 	}
 
+	var numDiffs int
+	maxLen := -1
+	if opts.LimitVerbosity {
+		maxLen = (1 << opts.verbosity()) << 2 // 4, 8, 16, 32, 64, etc...
+		opts.VerbosityLevel--
+	}
+
 	groups := coalesceAdjacentEdits(name, es)
 	groups = coalesceInterveningIdentical(groups, chunkSize/4)
+	maxGroup := diffStats{Name: name}
 	for i, ds := range groups {
+		if maxLen >= 0 && numDiffs >= maxLen {
+			maxGroup = maxGroup.Append(ds)
+			continue
+		}
+
 		// Print equal.
 		if ds.NumDiff() == 0 {
 			// Compute the number of leading and trailing equal bytes to print.
@@ -273,12 +382,18 @@ func (opts formatOptions) formatDiffSlice(
 		}
 
 		// Print unequal.
+		len0 := len(list)
 		nx := appendChunks(vx.Slice(0, ds.NumIdentical+ds.NumRemoved+ds.NumModified), diffRemoved)
 		vx = vx.Slice(nx, vx.Len())
 		ny := appendChunks(vy.Slice(0, ds.NumIdentical+ds.NumInserted+ds.NumModified), diffInserted)
 		vy = vy.Slice(ny, vy.Len())
+		numDiffs += len(list) - len0
 	}
-	assert(vx.Len() == 0 && vy.Len() == 0)
+	if maxGroup.IsZero() {
+		assert(vx.Len() == 0 && vy.Len() == 0)
+	} else {
+		list.AppendEllipsis(maxGroup)
+	}
 	return list
 }
 
@@ -322,7 +437,7 @@ func coalesceInterveningIdentical(groups []diffStats, windowSize int) []diffStat
 			hadX, hadY := prev.NumRemoved > 0, prev.NumInserted > 0
 			hasX, hasY := next.NumRemoved > 0, next.NumInserted > 0
 			if ((hadX || hasX) && (hadY || hasY)) && curr.NumIdentical <= windowSize {
-				*prev = (*prev).Append(*curr).Append(*next)
+				*prev = prev.Append(*curr).Append(*next)
 				groups = groups[:len(groups)-1] // Truncate off equal group
 				continue
 			}

--- a/vendor/github.com/google/go-cmp/cmp/report_text.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_text.go
@@ -10,15 +10,23 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/go-cmp/cmp/internal/flags"
 )
 
 var randBool = rand.New(rand.NewSource(time.Now().Unix())).Intn(2) == 0
 
+const maxColumnLength = 80
+
 type indentMode int
 
 func (n indentMode) appendIndent(b []byte, d diffMode) []byte {
+	// The output of Diff is documented as being unstable to provide future
+	// flexibility in changing the output for more humanly readable reports.
+	// This logic intentionally introduces instability to the exact output
+	// so that users can detect accidental reliance on stability early on,
+	// rather than much later when an actual change to the format occurs.
 	if flags.Deterministic || randBool {
 		// Use regular spaces (U+0020).
 		switch d {
@@ -86,21 +94,22 @@ type textNode interface {
 // textWrap is a wrapper that concatenates a prefix and/or a suffix
 // to the underlying node.
 type textWrap struct {
-	Prefix string   // e.g., "bytes.Buffer{"
-	Value  textNode // textWrap | textList | textLine
-	Suffix string   // e.g., "}"
+	Prefix   string      // e.g., "bytes.Buffer{"
+	Value    textNode    // textWrap | textList | textLine
+	Suffix   string      // e.g., "}"
+	Metadata interface{} // arbitrary metadata; has no effect on formatting
 }
 
-func (s textWrap) Len() int {
+func (s *textWrap) Len() int {
 	return len(s.Prefix) + s.Value.Len() + len(s.Suffix)
 }
-func (s1 textWrap) Equal(s2 textNode) bool {
-	if s2, ok := s2.(textWrap); ok {
+func (s1 *textWrap) Equal(s2 textNode) bool {
+	if s2, ok := s2.(*textWrap); ok {
 		return s1.Prefix == s2.Prefix && s1.Value.Equal(s2.Value) && s1.Suffix == s2.Suffix
 	}
 	return false
 }
-func (s textWrap) String() string {
+func (s *textWrap) String() string {
 	var d diffMode
 	var n indentMode
 	_, s2 := s.formatCompactTo(nil, d)
@@ -109,7 +118,7 @@ func (s textWrap) String() string {
 	b = append(b, '\n')              // Trailing newline
 	return string(b)
 }
-func (s textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
+func (s *textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	n0 := len(b) // Original buffer length
 	b = append(b, s.Prefix...)
 	b, s.Value = s.Value.formatCompactTo(b, d)
@@ -119,7 +128,7 @@ func (s textWrap) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	}
 	return b, s
 }
-func (s textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
+func (s *textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 	b = append(b, s.Prefix...)
 	b = s.Value.formatExpandedTo(b, d, n)
 	b = append(b, s.Suffix...)
@@ -131,22 +140,23 @@ func (s textWrap) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 // of the textList.formatCompactTo method.
 type textList []textRecord
 type textRecord struct {
-	Diff    diffMode     // e.g., 0 or '-' or '+'
-	Key     string       // e.g., "MyField"
-	Value   textNode     // textWrap | textLine
-	Comment fmt.Stringer // e.g., "6 identical fields"
+	Diff       diffMode     // e.g., 0 or '-' or '+'
+	Key        string       // e.g., "MyField"
+	Value      textNode     // textWrap | textLine
+	ElideComma bool         // avoid trailing comma
+	Comment    fmt.Stringer // e.g., "6 identical fields"
 }
 
 // AppendEllipsis appends a new ellipsis node to the list if none already
 // exists at the end. If cs is non-zero it coalesces the statistics with the
 // previous diffStats.
 func (s *textList) AppendEllipsis(ds diffStats) {
-	hasStats := ds != diffStats{}
+	hasStats := !ds.IsZero()
 	if len(*s) == 0 || !(*s)[len(*s)-1].Value.Equal(textEllipsis) {
 		if hasStats {
-			*s = append(*s, textRecord{Value: textEllipsis, Comment: ds})
+			*s = append(*s, textRecord{Value: textEllipsis, ElideComma: true, Comment: ds})
 		} else {
-			*s = append(*s, textRecord{Value: textEllipsis})
+			*s = append(*s, textRecord{Value: textEllipsis, ElideComma: true})
 		}
 		return
 	}
@@ -186,7 +196,7 @@ func (s1 textList) Equal(s2 textNode) bool {
 }
 
 func (s textList) String() string {
-	return textWrap{"{", s, "}"}.String()
+	return (&textWrap{Prefix: "{", Value: s, Suffix: "}"}).String()
 }
 
 func (s textList) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
@@ -216,7 +226,7 @@ func (s textList) formatCompactTo(b []byte, d diffMode) ([]byte, textNode) {
 	}
 	// Force multi-lined output when printing a removed/inserted node that
 	// is sufficiently long.
-	if (d == diffInserted || d == diffRemoved) && len(b[n0:]) > 80 {
+	if (d == diffInserted || d == diffRemoved) && len(b[n0:]) > maxColumnLength {
 		multiLine = true
 	}
 	if !multiLine {
@@ -231,15 +241,49 @@ func (s textList) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 			_, isLine := r.Value.(textLine)
 			return r.Key == "" || !isLine
 		},
-		func(r textRecord) int { return len(r.Key) },
+		func(r textRecord) int { return utf8.RuneCountInString(r.Key) },
 	)
 	alignValueLens := s.alignLens(
 		func(r textRecord) bool {
 			_, isLine := r.Value.(textLine)
 			return !isLine || r.Value.Equal(textEllipsis) || r.Comment == nil
 		},
-		func(r textRecord) int { return len(r.Value.(textLine)) },
+		func(r textRecord) int { return utf8.RuneCount(r.Value.(textLine)) },
 	)
+
+	// Format lists of simple lists in a batched form.
+	// If the list is sequence of only textLine values,
+	// then batch multiple values on a single line.
+	var isSimple bool
+	for _, r := range s {
+		_, isLine := r.Value.(textLine)
+		isSimple = r.Diff == 0 && r.Key == "" && isLine && r.Comment == nil
+		if !isSimple {
+			break
+		}
+	}
+	if isSimple {
+		n++
+		var batch []byte
+		emitBatch := func() {
+			if len(batch) > 0 {
+				b = n.appendIndent(append(b, '\n'), d)
+				b = append(b, bytes.TrimRight(batch, " ")...)
+				batch = batch[:0]
+			}
+		}
+		for _, r := range s {
+			line := r.Value.(textLine)
+			if len(batch)+len(line)+len(", ") > maxColumnLength {
+				emitBatch()
+			}
+			batch = append(batch, line...)
+			batch = append(batch, ", "...)
+		}
+		emitBatch()
+		n--
+		return n.appendIndent(append(b, '\n'), d)
+	}
 
 	// Format the list as a multi-lined output.
 	n++
@@ -251,7 +295,7 @@ func (s textList) formatExpandedTo(b []byte, d diffMode, n indentMode) []byte {
 		b = alignKeyLens[i].appendChar(b, ' ')
 
 		b = r.Value.formatExpandedTo(b, d|r.Diff, n)
-		if !r.Value.Equal(textEllipsis) {
+		if !r.ElideComma {
 			b = append(b, ',')
 		}
 		b = alignValueLens[i].appendChar(b, ' ')
@@ -327,6 +371,11 @@ type diffStats struct {
 	NumModified  int
 }
 
+func (s diffStats) IsZero() bool {
+	s.Name = ""
+	return s == diffStats{}
+}
+
 func (s diffStats) NumDiff() int {
 	return s.NumRemoved + s.NumInserted + s.NumModified
 }
@@ -360,7 +409,7 @@ func (s diffStats) String() string {
 	// Pluralize the name (adjusting for some obscure English grammar rules).
 	name := s.Name
 	if sum > 1 {
-		name = name + "s"
+		name += "s"
 		if strings.HasSuffix(name, "ys") {
 			name = name[:len(name)-2] + "ies" // e.g., "entrys" => "entries"
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,8 @@ github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
-# github.com/google/go-cmp v0.3.0
+# github.com/google/go-cmp v0.5.0
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
This PR extends CCM as follows:

- Introduced a new environment variable to accept the name of the CCM worker firewall. If the flag is missing or empty, we're not going to take any of the following steps.

- Using client-go, created a controller that watches for Service changes. If a Service is created or changed and has type NodePort, we modify the specified CCM worker firewall to accept traffic for all protocols and sources on that NodePort. Conversely, if a Service changes its type to something else or gets deleted entirely, we undo the worker firewall change.

- Created a loop to periodically fetch the CCM worker firewall configuration from the API and check if there's a delta between it and the target configuration it should have based on the existing Services (which we can look up from our controller cache). If there's a delta, we overwrite it with the designated target state.

- Whenever possible we want to use the firewall ID to make quick (O(1)) lookups into our API. If we do not know the firewall ID (which is the case when CCM starts up), we enumerate through all firewalls in the account and find the firewall by name. We keep the ID in-memory for future API calls.

- If at any point we find that the CCM worker firewall does not exist, we (re-)create it on-the-fly. A firewall may be missing if this is a brand new cluster we're running on or if the firewall had been deleted out-of-band (e.g., directly through the cloud control panel).

Fixes #86