### PR TITLE
update license headers to use the year 2020 instead of 2017

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 DigitalOcean
+   Copyright 2020 DigitalOcean
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/gofmt.sh
+++ b/ci/gofmt.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/headers-bash.sh
+++ b/ci/headers-bash.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 read -r -d '' LICENSE <<EOF
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/headers-docker.sh
+++ b/ci/headers-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 read -r -d '' LICENSE <<EOF
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ci/headers-go.sh
+++ b/ci/headers-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 read -r -d '' LICENSE <<EOF
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/main.go
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/certificates.go
+++ b/cloud-controller-manager/do/certificates.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/droplets_test.go
+++ b/cloud-controller-manager/do/droplets_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/faketagssvc_test.go
+++ b/cloud-controller-manager/do/faketagssvc_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/health.go
+++ b/cloud-controller-manager/do/health.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/health_test.go
+++ b/cloud-controller-manager/do/health_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/metadata.go
+++ b/cloud-controller-manager/do/metadata.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/patch.go
+++ b/cloud-controller-manager/do/patch.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/patch_test.go
+++ b/cloud-controller-manager/do/patch_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/zones.go
+++ b/cloud-controller-manager/do/zones.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cloud-controller-manager/do/zones_test.go
+++ b/cloud-controller-manager/do/zones_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/cluster_test.go
+++ b/e2e/cluster_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/docker.sh
+++ b/e2e/docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/scripts/cleanup-resources.sh
+++ b/e2e/scripts/cleanup-resources.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/scripts/destroy_cluster.sh
+++ b/e2e/scripts/destroy_cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/scripts/install_deps.sh
+++ b/e2e/scripts/install_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/scripts/setup_cluster.sh
+++ b/e2e/scripts/setup_cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/scripts/utils.sh
+++ b/e2e/scripts/utils.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/spaces_test.go
+++ b/e2e/spaces_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/e2e/util_test.go
+++ b/e2e/util_test.go
@@ -1,7 +1,7 @@
 // +build integration
 
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/generate-secret.sh
+++ b/scripts/generate-secret.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-k8s.sh
+++ b/scripts/update-k8s.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2017 DigitalOcean
+# Copyright 2020 DigitalOcean
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,7 @@
 // +build tools
 
 /*
-Copyright 2017 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
We need to use the year 2020 instead of 2017 in the license headers.

Here's the PR where this was suggested as an alternative to managing two different headers: https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/332#discussion_r448301487