### PR TITLE
Support HTTPS as health check protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Support HTTPS as health check protocol (@timoreimann)
+
 ## v0.1.26 (beta) - June 16th 2020
 
 * Update Kubernetes dependences to 1.18.3 (@waynr)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -887,7 +887,9 @@ func getProtocol(service *v1.Service) (string, error) {
 		return protocolTCP, nil
 	}
 
-	if protocol != protocolTCP && protocol != protocolHTTP && protocol != protocolHTTPS && protocol != protocolHTTP2 {
+	switch protocol {
+	case protocolTCP, protocolHTTP, protocolHTTPS, protocolHTTP2:
+	default:
 		return "", fmt.Errorf("invalid protocol %q specified in annotation %q", protocol, annDOProtocol)
 	}
 
@@ -936,7 +938,9 @@ func healthCheckProtocol(service *v1.Service) (string, error) {
 		return protocolTCP, nil
 	}
 
-	if protocol != protocolTCP && protocol != protocolHTTP {
+	switch protocol {
+	case protocolTCP, protocolHTTP, protocolHTTPS:
+	default:
 		return "", fmt.Errorf("invalid protocol %q specified in annotation %q", protocol, annDOHealthCheckProtocol)
 	}
 

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -1984,7 +1984,7 @@ func Test_buildHealthCheck(t *testing.T) {
 			healthcheck: defaultHealthCheck("tcp", 30000, ""),
 		},
 		{
-			name: "http health check using protocol override",
+			name: "explicit http health check protocol and tcp payload protocol",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -2008,7 +2008,7 @@ func Test_buildHealthCheck(t *testing.T) {
 			healthcheck: defaultHealthCheck("http", 30000, ""),
 		},
 		{
-			name: "https health check using protocol override",
+			name: "explicit http health check protocol and https payload protocol",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -2033,7 +2033,7 @@ func Test_buildHealthCheck(t *testing.T) {
 			healthcheck: defaultHealthCheck("http", 30000, ""),
 		},
 		{
-			name: "http2 health check using protocol override",
+			name: "explicit http health check protocol and http2 payload protocol",
 			service: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
@@ -2056,6 +2056,30 @@ func Test_buildHealthCheck(t *testing.T) {
 				},
 			},
 			healthcheck: defaultHealthCheck("http", 30000, ""),
+		},
+		{
+			name: "explicit https health check protocol and tcp payload protocol",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOProtocol:            "tcp",
+						annDOHealthCheckProtocol: "https",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			healthcheck: defaultHealthCheck("https", 30000, ""),
 		},
 		{
 			name: "http health check with https and certificate",


### PR DESCRIPTION
HTTPS was previously not supported as health check protocol [but is as of 8 July, 2020](https://www.digitalocean.com/docs/networking/load-balancers/#8-july-2020).

Fixes #335