### PR TITLE
firewalls: add exponential backoff to service informer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add controller to manage worker firewall for public access (@MorrisLaw)
 * Add prometheus metrics instrumentation to firewall controller (@MorrisLaw)
 * Update Kubernetes dependencies to 1.19.1 (@adamwg)
+* Add exponential retry to firewall controller (@MorrisLaw)
 
 ## v0.1.26 (beta) - June 16th 2020
 

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -195,7 +195,7 @@ func (c *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	}
 	ctx := context.Background()
 	fc := NewFirewallController(ctx, c.resources.kclient, c.client, sharedInformer.Core().V1().Services(), fm, fm.workerFirewallTags, fm.workerFirewallName, c.metrics)
-
+	go fc.runWorker()
 	go fc.Run(ctx, stop, firewallReconcileFrequency)
 }
 

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -491,7 +491,7 @@ func TestFirewallController_NoDataRace(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		fc.Run(context.TODO(), ctx.Done(), time.Duration(0))
+		fc.Run(ctx, ctx.Done(), time.Duration(0))
 	}()
 
 	wg.Wait()
@@ -560,7 +560,7 @@ func TestFirewallController_actualRun(t *testing.T) {
 			fwManager := newFakeFirewallManager(gclient, test.fwCache)
 			fc := NewFirewallController(ctx, kclient, gclient, inf.Core().V1().Services(), fwManager, testWorkerFWTags, testWorkerFWName, fwManager.metrics)
 
-			err := fc.actualRun(ctx.Done(), time.Duration(0))
+			err := fc.reconcileCloudFirewallChanges(ctx)
 			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
 				t.Errorf("error with firewall controller run\nwant: %#v\n got: %#v", test.expectedError, err)
 			}


### PR DESCRIPTION
This PR adds exponential backoff as the retry mechanism for the firewall controller. Specifically, the service informer when handling event notifications for:
- `Add` service
- `Update` service
- `Delete` service