### PR TITLE
Expose health check failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add prometheus metrics instrumentation to firewall controller (@MorrisLaw)
 * Update Kubernetes dependencies to 1.19.1 (@adamwg)
 * Add exponential retry to firewall controller (@MorrisLaw)
+* Expose health check failures (@timoreimann)
 
 ## v0.1.26 (beta) - June 16th 2020
 

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -33,7 +33,6 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/informers"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog"
@@ -132,7 +131,7 @@ func newCloud() (cloudprovider.Interface, error) {
 	var httpServer *http.Server
 	if debugAddr := os.Getenv(debugAddrEnv); debugAddr != "" {
 		debugMux := http.NewServeMux()
-		healthz.InstallHandler(debugMux, &godoHealthChecker{client: doClient})
+		debugMux.Handle("/healthz", &godoHealthChecker{client: doClient})
 		httpServer = &http.Server{
 			Addr:    debugAddr,
 			Handler: debugMux,

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	k8s.io/api v0.19.1
 	k8s.io/apimachinery v0.19.1
-	k8s.io/apiserver v0.19.1
 	k8s.io/client-go v0.19.1
 	k8s.io/cloud-provider v0.19.1
 	k8s.io/component-base v0.19.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -421,7 +421,6 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.19.1 => k8s.io/apiserver v0.19.1
-## explicit
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
 k8s.io/apiserver/pkg/admission/initializer


### PR DESCRIPTION
We use the `healthz` package from `k8s.io/apiserver` to implement our health check. However, that check does not expose the failure reason in the logs. Example output:

```
I1002 08:05:39.882128       1 healthz.go:200] [-]godo failed: reason withheld
```

As described in [an upstream code comment](https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/f3ea5608898f253f7bfd85de35f166dde36a278a/vendor/k8s.io/apiserver/pkg/server/healthz/healthz.go#L226-L227), the rationale here is that the endpoint is public and not supposed to give away sensitive data. Instead, Kubernetes users are [expected to inspect failure details through separate, authenticated access](https://stackoverflow.com/a/53861547).

This makes the package a bad fit for our use case because (1) we do not have an alternative way to inspect errors and (2) we do not need to: users concerned about the information that is being returned from the health check implementation (currently the respone from the `/v2/account` endpoint of the DigitalOcean API) can configure CCM's debug endpoint to run on localhost.

Consequently, we re-implement the health check as a custom, plain net/http handler and log health check failures explicitly.