### PR TITLE
Support marking Services as firewall-unmanaged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* Support marking Services as firewall-unmanaged (@timoreimann)
 * Update Kubernetes dependencies to 1.19.3 (@timoreimann)
 
 ## v0.1.28 (beta) - October 15th 2020

--- a/README.md
+++ b/README.md
@@ -120,9 +120,19 @@ associated with the droplets that the firewall should apply to. Usually, this
 is a tag attached to the worker node droplets. Multiple tags are applied in
 a logical OR fashion.
 
-No firewall is managed if the environment variables are missing or left
-empty. Once the firewall is created, no public access other than to the NodePorts
-is allowed. Users should create additional firewalls to further extend access.
+In some cases, firewall management for a particular Service may not be
+desirable. One example is that a NodePort is supposed to be accessible over the
+VPC only. In such cases, the Service annotation
+`kubernetes.digitalocean.com/firewall-managed` can be used to selectively
+exclude a given Service from firewall management. If set to `"false"`, no
+inbound rules will be created for the Service, effectively disabling public
+access to the NodePort. (Note the quotes that must be included with "boolean"
+annotation values.) The default behavior applies if the annotation is omitted,
+is set to `"true`", or contains an invalid value.
+
+No firewall is managed if the environment variables are missing or left empty.
+Once the firewall is created, no public access other than to the NodePorts is
+allowed. Users should create additional firewalls to further extend access.
 
 #### Expose Prometheus Metrics
 

--- a/cloud-controller-manager/do/annotations.go
+++ b/cloud-controller-manager/do/annotations.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package do
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func getBool(annotations map[string]string, key string) (managed bool, found bool, err error) {
+	value, ok := annotations[key]
+	if !ok {
+		return false, false, nil
+	}
+
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, false, fmt.Errorf("cannot convert value %q for annotation %q to bool: %s", value, key, err)
+	}
+
+	return parsed, true, nil
+}

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -524,6 +524,112 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "reconcile firewall with management flag",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: "30000",
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: "31000",
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: "32000",
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "noManagementFlag",
+						UID:  "uid1",
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(30000),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managementEnabled",
+						UID:  "uid2",
+						Annotations: map[string]string{
+							annotationDOFirewallManaged: "true",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(31000),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managementFlagInvalid",
+						UID:  "uid4",
+						Annotations: map[string]string{
+							annotationDOFirewallManaged: "undecided",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(32000),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managementDisabled",
+						UID:  "uid3",
+						Annotations: map[string]string{
+							annotationDOFirewallManaged: "false",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type: v1.ServiceTypeNodePort,
+						Ports: []v1.ServicePort{
+							{
+								Name:     "port",
+								Protocol: v1.ProtocolTCP,
+								NodePort: int32(33000),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testcases {

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1067,17 +1067,8 @@ func getCertificateID(service *v1.Service) string {
 // getTLSPassThrough returns true if there should be TLS pass through to
 // backend nodes.
 func getTLSPassThrough(service *v1.Service) bool {
-	passThrough, ok := service.Annotations[annDOTLSPassThrough]
-	if !ok {
-		return false
-	}
-
-	passThroughBool, err := strconv.ParseBool(passThrough)
-	if err != nil {
-		return false
-	}
-
-	return passThroughBool
+	passThrough, _, err := getBool(service.Annotations, annDOTLSPassThrough)
+	return err == nil && passThrough
 }
 
 // getAlgorithm returns the load balancing algorithm to use for service.
@@ -1131,48 +1122,30 @@ func getStickySessionsCookieTTL(service *v1.Service) (int, error) {
 // getRedirectHTTPToHTTPS returns whether or not Http traffic should be redirected
 // to Https traffic for the loadbalancer. false is returned if not specified.
 func getRedirectHTTPToHTTPS(service *v1.Service) (bool, error) {
-	redirectHTTPToHTTPS, ok := service.Annotations[annDORedirectHTTPToHTTPS]
-	if !ok {
-		return false, nil
-	}
-
-	redirectHTTPToHTTPSBool, err := strconv.ParseBool(redirectHTTPToHTTPS)
+	redirectHTTPToHTTPS, _, err := getBool(service.Annotations, annDORedirectHTTPToHTTPS)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse redirect HTTP-to-HTTPS flag %q from annotation %q: %s", redirectHTTPToHTTPS, annDORedirectHTTPToHTTPS, err)
+		return false, fmt.Errorf("failed to get HTTP-to-HTTPS configuration setting: %s", err)
 	}
-
-	return redirectHTTPToHTTPSBool, nil
+	return redirectHTTPToHTTPS, nil
 }
 
 // getEnableProxyProtocol returns whether PROXY protocol should be enabled.
 // False is returned if not specified.
 func getEnableProxyProtocol(service *v1.Service) (bool, error) {
-	enableProxyProtocolStr, ok := service.Annotations[annDOEnableProxyProtocol]
-	if !ok {
-		return false, nil
-	}
-
-	enableProxyProtocol, err := strconv.ParseBool(enableProxyProtocolStr)
+	enableProxyProtocol, _, err := getBool(service.Annotations, annDOEnableProxyProtocol)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse proxy protocol flag %q from annotation %q: %s", enableProxyProtocolStr, annDOEnableProxyProtocol, err)
+		return false, fmt.Errorf("failed to get proxy protocol configuration setting: %s", err)
 	}
-
 	return enableProxyProtocol, nil
 }
 
 // getEnableBackendKeepalive returns whether HTTP keepalive to target droplets should be enabled.
 // False is returned if not specified.
 func getEnableBackendKeepalive(service *v1.Service) (bool, error) {
-	enableBackendKeepaliveStr, ok := service.Annotations[annDOEnableBackendKeepalive]
-	if !ok {
-		return false, nil
-	}
-
-	enableBackendKeepalive, err := strconv.ParseBool(enableBackendKeepaliveStr)
+	enableBackendKeepalive, _, err := getBool(service.Annotations, annDOEnableBackendKeepalive)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse backend keepalive flag %q from annotation %q: %s", enableBackendKeepaliveStr, annDOEnableBackendKeepalive, err)
+		return false, fmt.Errorf("failed to get backend keepalive configuration setting: %s", err)
 	}
-
 	return enableBackendKeepalive, nil
 }
 
@@ -1183,16 +1156,10 @@ func getLoadBalancerID(service *v1.Service) string {
 // getDisownLB returns whether the load-balancer should be disowned.
 // False is returned if not specified.
 func getDisownLB(service *v1.Service) (bool, error) {
-	disownLBStr, ok := service.Annotations[annDODisownLB]
-	if !ok {
-		return false, nil
-	}
-
-	disownLB, err := strconv.ParseBool(disownLBStr)
+	disownLB, _, err := getBool(service.Annotations, annDODisownLB)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse disown LB flag %q from annotation %q: %s", disownLBStr, annDODisownLB, err)
+		return false, fmt.Errorf("failed to get disown LB configuration setting: %s", err)
 	}
-
 	return disownLB, nil
 }
 


### PR DESCRIPTION
This change enables more direct control over how `NodePort` Services should be accessible through a new configuration annotation. One use case is when a `NodePort` is to be used for VPC-internal connectivity only, in which case no public access is desirable at all.

We also extract boolean annotation value parsing into a dedicated helper function and refactoring existing usages accordingly.