### PR TITLE
Improve firewall metrics design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* Improve firewall metrics design (@timoreimann)
 * Support marking Services as firewall-unmanaged (@timoreimann)
 * Update Kubernetes dependencies to 1.19.3 (@timoreimann)
 

--- a/cloud-controller-manager/do/cloud.go
+++ b/cloud-controller-manager/do/cloud.go
@@ -218,9 +218,12 @@ func (c *cloud) serveMetrics() {
 	http.Handle("/metrics", promhttp.Handler())
 
 	// register metrics
-	prometheus.MustRegister(apiRequestDuration)
-	prometheus.MustRegister(runLoopDuration)
+	prometheus.MustRegister(apiOperationDuration)
+	prometheus.MustRegister(apiOperationsTotal)
+	prometheus.MustRegister(resourceSyncDuration)
+	prometheus.MustRegister(resourceSyncsTotal)
 	prometheus.MustRegister(reconcileDuration)
+	prometheus.MustRegister(reconcilesTotal)
 
 	if err := http.ListenAndServe(c.metrics.host, nil); err != http.ErrServerClosed {
 		klog.Warningf("Metrics server has not been configured: %s", err)

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -21,9 +21,8 @@ import (
 	"errors"
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/digitalocean/godo"
+	v1 "k8s.io/api/core/v1"
 )
 
 // apiResultsPerPage is the maximum page size that DigitalOcean's api supports.
@@ -63,15 +62,17 @@ func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, e
 
 func filterFirewallList(ctx context.Context, client *godo.Client, matchExpectedFirewallName func(godo.Firewall) bool) (*godo.Firewall, *godo.Response, error) {
 	opt := &godo.ListOptions{Page: 1, PerPage: apiResultsPerPage}
+	var lastResp *godo.Response
 	for {
 		firewalls, resp, err := client.Firewalls.List(ctx, opt)
 		if err != nil {
 			return nil, resp, err
 		}
+		lastResp = resp
 
 		for _, fw := range firewalls {
 			if matchExpectedFirewallName(fw) {
-				return &fw, nil, nil
+				return &fw, resp, nil
 			}
 		}
 
@@ -88,7 +89,7 @@ func filterFirewallList(ctx context.Context, client *godo.Client, matchExpectedF
 		opt.Page = page + 1
 	}
 
-	return nil, nil, nil
+	return nil, lastResp, nil
 }
 
 func allLoadBalancerList(ctx context.Context, client *godo.Client) ([]godo.LoadBalancer, error) {

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -277,7 +277,7 @@ func TestFirewallController_ConcurrentUsage(t *testing.T) {
 	}))
 
 	eg.Go(loopCreator(func() error {
-		err := fc.observeRunLoopDuration(ctx)
+		err := fc.syncResource(ctx)
 		if err != nil {
 			return fmt.Errorf("run loop failed: %s", err)
 		}

--- a/cloud-controller-manager/do/firewall_fixture_test.go
+++ b/cloud-controller-manager/do/firewall_fixture_test.go
@@ -273,12 +273,7 @@ func newFakeFirewallManager(client *godo.Client, cache *firewallCache) *firewall
 		fwCache:            cache,
 		workerFirewallName: testWorkerFWName,
 		workerFirewallTags: testWorkerFWTags,
-		metrics: metrics{
-			host:               "localhost:8080",
-			apiRequestDuration: apiRequestDuration,
-			runLoopDuration:    runLoopDuration,
-			reconcileDuration:  reconcileDuration,
-		},
+		metrics:            newMetrics("localhost:8080"),
 	}
 }
 


### PR DESCRIPTION
This change updates our firewall-related metrics design in the following aspects:

- Rename `api_request_duration_seconds` to `api_operation_duration_seconds` and capture API operations (get by ID, get by list, create, update) instead of HTTP requests. This allows us to distinguish between requests using the same method (namely GETs by ID and by list) while also making it easier for the user to understand what these metrics are about (telling what a PUT or POST means is less clear than a "create" or "update").
- Rename `run_loop_duration_seconds` to `resource_sync_duration_seconds` to (presumably) ease understanding: the former name did not easily imply what kind of functionality happened during a run loop.
- Add a "result" label to be two before-mentioned metrics to easily parse for succeeded and failed operations in Prometheus since we may not always have an HTTP code available (e.g., when a network error occurred).
- Make metrics help descriptions more concise and align with Prometheus convention in terms of wording/phrasing.
- Add counter metrics for existing histograms to allow inexpensive, basic observability.

We also fix `filterFirewallList` by returning a response so that we can fill in the HTTP code Prometheus label.

Finally, we DRY out the existing observing functionality into a set of helper methods.