### PR TITLE
Fix broken firewall counter metrics by incrementing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+* Fix broken firewall counter metrics by incrementing (@timoreimann)
+
 ## v0.1.30 (beta) - October 31th 2020
 
 * Support LB custom size slug (@anitgandhi)

--- a/cloud-controller-manager/do/firewall_controller.go
+++ b/cloud-controller-manager/do/firewall_controller.go
@@ -379,7 +379,7 @@ func (fm *firewallManager) executeInstrumentedFirewallOperation(ctx context.Cont
 	}))
 	defer func() {
 		timer.ObserveDuration()
-		fm.metrics.apiOperationsTotal.With(promLabels)
+		fm.metrics.apiOperationsTotal.With(promLabels).Inc()
 	}()
 
 	fw, resp, err := f(ctx)
@@ -439,7 +439,7 @@ func (fc *FirewallController) ensureReconciledFirewallInstrumented(ctx context.C
 	}))
 	defer func() {
 		t.ObserveDuration()
-		fc.fwManager.metrics.reconcilesTotal.With(labels)
+		fc.fwManager.metrics.reconcilesTotal.With(labels).Inc()
 	}()
 
 	skipped, err := fc.ensureReconciledFirewall(ctx)
@@ -466,7 +466,7 @@ func (fc *FirewallController) syncResource(ctx context.Context) error {
 	}))
 	defer func() {
 		t.ObserveDuration()
-		fc.fwManager.metrics.resourceSyncsTotal.With(labels)
+		fc.fwManager.metrics.resourceSyncsTotal.With(labels).Inc()
 	}()
 
 	// Ignore Get() result since we only care about the cache getting updated.


### PR DESCRIPTION
The counter metrics would never increase because we forgot to call the `Inc()` method.