### PR TITLE
Remove beta note from LB size annotation

### DIFF
--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -105,8 +105,6 @@ Specifies which algorithm the Load Balancer should use. Options are `round_robin
 
 Specifies which size the Load Balancer should be created with. Options are `lb-small`, `lb-medium`, and `lb-large`. Defaults to `lb-small`.
 
-IMPORTANT NOTE: This feature is currently in closed beta.
-
 ## service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type
 
 Specifies which stick session type the loadbalancer should use. Options are `none` or `cookies`.


### PR DESCRIPTION
As announced today: https://www.digitalocean.com/blog/introducing-new-digitalocean-load-balancers-plans/