### PR TITLE
Document label to exclude specific nodes from the LB target set

### DIFF
--- a/docs/controllers/services/examples/README.md
+++ b/docs/controllers/services/examples/README.md
@@ -253,7 +253,7 @@ You're done!
 
 ## Excluding specific nodes as targets
 
-To exclude a particular node from the load balancer target set, add the `node.kubernetes.io/exclude-from-external-load-balancers` label to the node. This requires the `ServiceNodeExclusion` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) to be enabled, which is the default since Kubernetes 1.19.
+To exclude a particular node from the load balancer target set, add the `node.kubernetes.io/exclude-from-external-load-balancers=` label to the node. (The value is not relevant.) This requires the `ServiceNodeExclusion` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) to be enabled, which is the default since Kubernetes 1.19.
 
 **Note:** For services that use `externalTrafficPolicy=Local`, this may mean that any pods on excluded nodes are not reachable by those external load-balancers.
 

--- a/docs/controllers/services/examples/README.md
+++ b/docs/controllers/services/examples/README.md
@@ -251,6 +251,12 @@ At this point, the load-balancer should be owned by the new Service, meaning tha
 
 You're done!
 
+## Excluding specific nodes as targets
+
+To exclude a particular node from the load balancer target set, add the `node.kubernetes.io/exclude-from-external-load-balancers` label to the node. This requires the `ServiceNodeExclusion` [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) to be enabled, which is the default since Kubernetes 1.19.
+
+**Note:** For services that use `externalTrafficPolicy=Local`, this may mean that any pods on excluded nodes are not reachable by those external load-balancers.
+
 ## Surfacing errors related to provisioning a load balancer
 
 Cloud Controller Manager is using DigitalOcean API internally to provision a


### PR DESCRIPTION
This is an upstream label implemented in the CCM core part, so we automatically support it.

Fixes #375

/cc @braghettos