### PR TITLE
cloud-controller-manager/do/load-balancers: add new annotation for disabling automatic DNS record creation for let's encrypt cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/digitalocean/godo v1.67.0
+	github.com/digitalocean/godo v1.69.0
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-ini/ini v1.39.0 // indirect
 	github.com/google/go-cmp v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/digitalocean/godo v1.67.0 h1:MksZlZl7i3nzrczgNXhzky8FODerHKL76JmpencjEyM=
-github.com/digitalocean/godo v1.67.0/go.mod h1:epPuOzTOOJujNo0nduDj2D5O1zu8cSpp9R+DdN0W9I0=
+github.com/digitalocean/godo v1.69.0 h1:d+CXI7s3g7zAbCYqscRrq46XPMrlv+A5doOdPYn7Pss=
+github.com/digitalocean/godo v1.69.0/go.mod h1:epPuOzTOOJujNo0nduDj2D5O1zu8cSpp9R+DdN0W9I0=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/vendor/github.com/digitalocean/godo/CHANGELOG.md
+++ b/vendor/github.com/digitalocean/godo/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v1.69.0] - 2021-10-04
+
+- #482 - @dikshant - godo/load-balancers: add DisableLetsEncryptDNSRecords field for LBaaS
+
+## [v1.68.0] - 2021-09-29
+
+- #480 - @sunny-b - kubernetes: add support for HA control plane
+
 ## [v1.67.0] - 2021-09-22
 
 - #478 - @sunny-b - kubernetes: add supported_features field to the kubernetes/options response

--- a/vendor/github.com/digitalocean/godo/godo.go
+++ b/vendor/github.com/digitalocean/godo/godo.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	libraryVersion = "1.67.0"
+	libraryVersion = "1.69.0"
 	defaultBaseURL = "https://api.digitalocean.com/"
 	userAgent      = "godo/" + libraryVersion
 	mediaType      = "application/json"

--- a/vendor/github.com/digitalocean/godo/kubernetes.go
+++ b/vendor/github.com/digitalocean/godo/kubernetes.go
@@ -71,6 +71,9 @@ type KubernetesClusterCreateRequest struct {
 	Tags        []string `json:"tags,omitempty"`
 	VPCUUID     string   `json:"vpc_uuid,omitempty"`
 
+	// Create cluster with highly available control plane
+	HA bool `json:"ha"`
+
 	NodePools []*KubernetesNodePoolCreateRequest `json:"node_pools,omitempty"`
 
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy"`
@@ -85,6 +88,9 @@ type KubernetesClusterUpdateRequest struct {
 	MaintenancePolicy *KubernetesMaintenancePolicy `json:"maintenance_policy,omitempty"`
 	AutoUpgrade       *bool                        `json:"auto_upgrade,omitempty"`
 	SurgeUpgrade      bool                         `json:"surge_upgrade,omitempty"`
+
+	// Convert cluster to run highly available control plane
+	HA bool `json:"ha,omitempty"`
 }
 
 // KubernetesClusterDeleteSelectiveRequest represents a delete selective request to delete a cluster and it's associated resources.
@@ -189,6 +195,9 @@ type KubernetesCluster struct {
 	Endpoint      string   `json:"endpoint,omitempty"`
 	Tags          []string `json:"tags,omitempty"`
 	VPCUUID       string   `json:"vpc_uuid,omitempty"`
+
+	// Cluster runs a highly available control plane
+	HA bool `json:"ha,omitempty"`
 
 	NodePools []*KubernetesNodePool `json:"node_pools,omitempty"`
 

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -34,21 +34,22 @@ type LoadBalancer struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	Algorithm              string           `json:"algorithm,omitempty"`
-	Status                 string           `json:"status,omitempty"`
-	Created                string           `json:"created_at,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	Region                 *Region          `json:"region,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	Algorithm                    string           `json:"algorithm,omitempty"`
+	Status                       string           `json:"status,omitempty"`
+	Created                      string           `json:"created_at,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	Region                       *Region          `json:"region,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -65,18 +66,23 @@ func (l LoadBalancer) URN() string {
 // Modifying the returned LoadBalancerRequest will not modify the original LoadBalancer.
 func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 	r := LoadBalancerRequest{
-		Name:                   l.Name,
-		Algorithm:              l.Algorithm,
-		SizeSlug:               l.SizeSlug,
-		SizeUnit:               l.SizeUnit,
-		ForwardingRules:        append([]ForwardingRule(nil), l.ForwardingRules...),
-		DropletIDs:             append([]int(nil), l.DropletIDs...),
-		Tag:                    l.Tag,
-		RedirectHttpToHttps:    l.RedirectHttpToHttps,
-		EnableProxyProtocol:    l.EnableProxyProtocol,
-		EnableBackendKeepalive: l.EnableBackendKeepalive,
-		HealthCheck:            l.HealthCheck,
-		VPCUUID:                l.VPCUUID,
+		Name:                         l.Name,
+		Algorithm:                    l.Algorithm,
+		SizeSlug:                     l.SizeSlug,
+		SizeUnit:                     l.SizeUnit,
+		ForwardingRules:              append([]ForwardingRule(nil), l.ForwardingRules...),
+		DropletIDs:                   append([]int(nil), l.DropletIDs...),
+		Tag:                          l.Tag,
+		RedirectHttpToHttps:          l.RedirectHttpToHttps,
+		EnableProxyProtocol:          l.EnableProxyProtocol,
+		EnableBackendKeepalive:       l.EnableBackendKeepalive,
+		HealthCheck:                  l.HealthCheck,
+		VPCUUID:                      l.VPCUUID,
+		DisableLetsEncryptDNSRecords: l.DisableLetsEncryptDNSRecords,
+	}
+
+	if l.DisableLetsEncryptDNSRecords != nil {
+		*r.DisableLetsEncryptDNSRecords = *l.DisableLetsEncryptDNSRecords
 	}
 
 	if l.HealthCheck != nil {
@@ -144,17 +150,18 @@ type LoadBalancerRequest struct {
 	// SizeSlug is mutually exclusive with SizeUnit. Only one should be specified
 	SizeSlug string `json:"size,omitempty"`
 	// SizeUnit is mutually exclusive with SizeSlug. Only one should be specified
-	SizeUnit               uint32           `json:"size_unit,omitempty"`
-	ForwardingRules        []ForwardingRule `json:"forwarding_rules,omitempty"`
-	HealthCheck            *HealthCheck     `json:"health_check,omitempty"`
-	StickySessions         *StickySessions  `json:"sticky_sessions,omitempty"`
-	DropletIDs             []int            `json:"droplet_ids,omitempty"`
-	Tag                    string           `json:"tag,omitempty"`
-	Tags                   []string         `json:"tags,omitempty"`
-	RedirectHttpToHttps    bool             `json:"redirect_http_to_https,omitempty"`
-	EnableProxyProtocol    bool             `json:"enable_proxy_protocol,omitempty"`
-	EnableBackendKeepalive bool             `json:"enable_backend_keepalive,omitempty"`
-	VPCUUID                string           `json:"vpc_uuid,omitempty"`
+	SizeUnit                     uint32           `json:"size_unit,omitempty"`
+	ForwardingRules              []ForwardingRule `json:"forwarding_rules,omitempty"`
+	HealthCheck                  *HealthCheck     `json:"health_check,omitempty"`
+	StickySessions               *StickySessions  `json:"sticky_sessions,omitempty"`
+	DropletIDs                   []int            `json:"droplet_ids,omitempty"`
+	Tag                          string           `json:"tag,omitempty"`
+	Tags                         []string         `json:"tags,omitempty"`
+	RedirectHttpToHttps          bool             `json:"redirect_http_to_https,omitempty"`
+	EnableProxyProtocol          bool             `json:"enable_proxy_protocol,omitempty"`
+	EnableBackendKeepalive       bool             `json:"enable_backend_keepalive,omitempty"`
+	VPCUUID                      string           `json:"vpc_uuid,omitempty"`
+	DisableLetsEncryptDNSRecords *bool            `json:"disable_lets_encrypt_dns_records,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/coreos/pkg/capnslog
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.67.0
+# github.com/digitalocean/godo v1.69.0
 ## explicit
 github.com/digitalocean/godo
 # github.com/emicklei/go-restful v2.9.5+incompatible


### PR DESCRIPTION
By default when adding a cert to a load balancer it automatically creates a A record pointing to the root domain in the cert. Setting this new annotation of `"service.beta.kubernetes.io/do-loadbalancer-disable-lets-encrypt-dns-records"` to `"true"` will disable this behavior and not automatically create the A record.