### PR TITLE
Makefile: fix binary compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,12 @@ jobs:
         uses: actions/setup-go@0caeaed6fd66a828038c2da3c0f662a42862658f
         with:
           go-version: ^1.17
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+      - name: Verify docker image builds
+        run: make build
+
       - name: Run test command
         run: make ci

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ COMMIT ?= $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 VERSION ?= $(shell cat VERSION)
 REGISTRY ?= digitalocean
-GO_VERSION ?= 1.15.2
+GO_VERSION ?= 1.17.6
 
 LDFLAGS ?= -X github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/do.version=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitVersion=$(VERSION) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitCommit=$(COMMIT) -X github.com/digitalocean/digitalocean-cloud-controller-manager/vendor/k8s.io/kubernetes/pkg/version.gitTreeState=$(GIT_TREE_STATE)
 PKG ?= github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ else
   GIT_TREE_STATE=dirty
 endif
 
+SHELL = bash
 COMMIT ?= $(shell git rev-parse HEAD)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 VERSION ?= $(shell cat VERSION)
@@ -69,6 +70,7 @@ compile:
 	  -w /go/src/github.com/digitalocean/digitalocean-cloud-controller-manager \
 	  -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 -e GOFLAGS=-mod=vendor golang:$(GO_VERSION) \
 	  go build -ldflags "$(LDFLAGS)" ${PKG}
+	@echo "==> built the project"
 
 .PHONY: build
 build: compile

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PKG ?= github.com/digitalocean/digitalocean-cloud-controller-manager/cloud-contr
 
 all: test
 
-publish: clean ci compile build push
+publish: clean ci build push
 
 ci: check-headers check-unused gofmt govet test
 
@@ -71,7 +71,7 @@ compile:
 	  go build -ldflags "$(LDFLAGS)" ${PKG}
 
 .PHONY: build
-build:
+build: compile
 	@echo "==> Building the docker image"
 	@docker build -t $(REGISTRY)/digitalocean-cloud-controller-manager:$(VERSION) -f cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile .
 


### PR DESCRIPTION
* Makefile: set SHELL to bash (default is `sh` which doesn't have the `[[` builtin)
* Makefile: add echo to compile task to confirm build succeeds
* Makefile: use go 1.17.6 to compile binary
* workflow: require image to build before merging PRs