### PR TITLE
dockerfile: update alpine base image to the latest to fix any security issues

### DIFF
--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
using an old alpine version can contain several security issues and be very outdated
so bumping to the latest one available

also if use `trivy` we got

```
2022-02-12T16:28:10.982+0100    WARN    This OS version is no longer supported by the distribution: alpine 3.6.5
```

/assign @timoreimann 