### PR TITLE
update ccm for deprecations and tolerations for k8s 1.24+

### DIFF
--- a/releases/dev.yml
+++ b/releases/dev.yml
@@ -28,7 +28,11 @@ spec:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
         # cloud controller manages should be able to run on masters
+        # TODO: remove this when ccm is not supported on k8s <= 1.23
         - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        # k8s clusters 1.24+ uses control-plane name instead of master
+        - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
       containers:
       - image: digitalocean/digitalocean-cloud-controller-manager:v0.1.36

--- a/releases/dev.yml
+++ b/releases/dev.yml
@@ -14,12 +14,11 @@ spec:
     metadata:
       labels:
         app: digitalocean-cloud-controller-manager
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
       hostNetwork: true
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-cluster-critical
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`
         # so we should tolerate it to schedule the digitalocean ccm


### PR DESCRIPTION
- annotation for critical-pod is deprecated updating to priorityClassName
- add new toleration for k8s 1.24+


already tested this in https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/315

cc @timoreimann 