### PR TITLE
controllers/services/load-balancer/docs: update docs to remove the requirement for needing to contact support to enable UDP

### DIFF
--- a/docs/controllers/services/README.md
+++ b/docs/controllers/services/README.md
@@ -2,6 +2,6 @@
 
 ## UDP Support
 
-In order to use UDP protocol with a Load Balancer, please reach out to support with a ticket to enable it. If your load balancer has UDP service ports you must configure a TCP service as a health check for the load balancer to work properly.
+If your load balancer has UDP service ports you must configure a TCP service as a health check for the load balancer to work properly.
 
 Note: currently, a port cannot be shared between TCP and UDP due to a [bug in Kubernetes](https://github.com/kubernetes/kubernetes/issues/39188).


### PR DESCRIPTION
UDP is now available to all users of load balancers on DOKS versions 1.21.11-do.1 or 1.22.8-do.1 and higher.