### PR TITLE
fix: don't delete attached load balancers

### DIFF
--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -5194,6 +5194,25 @@ func Test_EnsureLoadBalancerDeleted(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			name: "LB is protected",
+			listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("list should not have been invoked")
+			},
+			deleteFn: func(context.Context, string) (*godo.Response, error) {
+				return newFakeNotOKResponse(), errors.New("delete should not have been invoked")
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "foobar123",
+					Annotations: map[string]string{
+						annDOProtectLB: "true",
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -167,3 +167,11 @@ See also the [elaborate example](/docs/controllers/services/examples/README.md#c
 **Note**
 
 You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).
+
+## service.kubernetes.io/do-loadbalancer-protect
+
+Indicates whether the managed load-balancer should be protected. Protected load-balancers get all features, but won't be deleted when the LoadBalancer service is removed from your cluster. This is useful for cases where you provision the LoadBalancer through other automation. Options are `"true"` or `"false"`. Defaults to `"false"`.
+
+**Note**
+
+You have to supply the value as string (ex. `"true"`, not `true`), otherwise you might run into a [k8s bug that throws away all annotations on your `Service` resource](https://github.com/kubernetes/kubernetes/issues/59113).


### PR DESCRIPTION
When a Load Balancer is attached via the load-balancer-id annotation,
 thee CCM should not be responsible for deleting it as it was likely
 provisioned by another means.

Signed-off-by: David Flanagan <david@rawkode.dev>

Closes #454 