### PR TITLE
loadbalancers: support http3 in do-loadbalancer-protocol annotation

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1022,7 +1022,7 @@ func getProtocol(service *v1.Service) (string, error) {
 	}
 
 	switch protocol {
-	case protocolTCP, protocolHTTP, protocolHTTPS, protocolHTTP2:
+	case protocolTCP, protocolHTTP, protocolHTTPS, protocolHTTP2, protocolHTTP3:
 	default:
 		return "", fmt.Errorf("invalid protocol %q specified in annotation %q", protocol, annDOProtocol)
 	}

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -873,6 +873,20 @@ func Test_getProtocol(t *testing.T) {
 			nil,
 		},
 		{
+			"http3 protocol specified",
+			&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDOProtocol: "http3",
+					},
+				},
+			},
+			"http3",
+			nil,
+		},
+		{
 			"invalid protocol",
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This seems to have been left out of https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/543