### PR TITLE
Allow specifying certificate by name

### DIFF
--- a/cloud-controller-manager/do/certificates.go
+++ b/cloud-controller-manager/do/certificates.go
@@ -16,8 +16,29 @@ limitations under the License.
 
 package do
 
+import (
+	"context"
+
+	"github.com/digitalocean/godo"
+)
+
 const (
 	// DO Certificate types
 	certTypeLetsEncrypt = "lets_encrypt"
 	certTypeCustom      = "custom"
 )
+
+func findCertificateByName(ctx context.Context, client *godo.Client, name string) (*godo.Certificate, error) {
+	certs, err := allCertificatesList(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cert := range certs {
+		if cert.Name == string(name) {
+			return &cert, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -143,3 +143,35 @@ func nodeAddresses(droplet *godo.Droplet) ([]v1.NodeAddress, error) {
 
 	return addresses, nil
 }
+
+func allCertificatesList(ctx context.Context, client *godo.Client) ([]godo.Certificate, error) {
+	list := []godo.Certificate{}
+
+	opt := &godo.ListOptions{Page: 1, PerPage: apiResultsPerPage}
+	for {
+		certs, resp, err := client.Certificates.List(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp == nil {
+			return nil, errors.New("certificates list request returned no response")
+		}
+
+		list = append(list, certs...)
+
+		// if we are at the last page, break out the for loop
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, err
+		}
+
+		opt.Page = page + 1
+	}
+
+	return list, nil
+}

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -93,9 +93,16 @@ const (
 	annDOTLSPassThrough = annDOLoadBalancerBase + "tls-passthrough"
 
 	// annDOCertificateID is the annotation specifying the certificate ID
-	// used for https protocol. This annotation is required if annDOTLSPorts
-	// is passed.
+	// used for https protocol. This annotation (or annDOCertificateName) is required
+	// if annDOTLSPorts is passed.
 	annDOCertificateID = annDOLoadBalancerBase + "certificate-id"
+
+	// annDOCertificateName is the annotation specifying the name of the certificate
+	// used for https protocol. The name is used to initially derive the certificate
+	// ID at time of loadbalancer creation. From then on, the ID is used and possibly
+	// updated when the certificate is renewed. This annotation (or annDOCertificateID)
+	// is required if annDOTLSPorts is passed.
+	annDOCertificateName = annDOLoadBalancerBase + "certificate-name"
 
 	// annDOHostname is the annotation specifying the hostname to use for the LB.
 	annDOHostname = annDOLoadBalancerBase + "hostname"


### PR DESCRIPTION
Using the 'service.beta.kubernetes.io/do-loadbalancer-certificate-name' service annotation, the certificate for an HTTPS load balancer can bow be specified by name. The corresponding certificate ID is then retrieved using the DO API at load balancer creation/update time and is used from then on.

So far, the certificate had to be specified using the '.../do-loadbalancer-certificate-id' annotation and this was automatically updated to reflect an ID change resulting from a certificate renewal. However if, after such a renewal, the service was re-created without re-fecthing the latest certificate ID, the service remained stuck waiting for its external IP.

This is for example very useful when deploying with a CD system such as Flux, where the deployment specification comes from a source repository. In that case, one would not expect having to update the source repository as a result of an automatic certificate renewal.

With this change, the source repository can specify the certificate by name so it won't have to be updated after the certificate is renewed. And a redeployment of the service will automatically fetch the current ID of the referenced certificate.