### PR TITLE
loadbalancers: support loadBalancerSourceRanges

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -796,7 +796,7 @@ func buildForwardingRule(service *v1.Service, port *v1.ServicePort, protocol, ce
 
 func buildFirewall(service *v1.Service) *godo.LBFirewall {
 	denyRules := getStrings(service, annDODenyRules)
-	allowRules := getStrings(service, annDOAllowRules)
+	allowRules := append(getStrings(service, annDOAllowRules), getSourceRangeRules(service)...)
 	if len(denyRules) == 0 && len(allowRules) == 0 {
 		return nil
 	}
@@ -854,6 +854,18 @@ func buildStickySessions(service *v1.Service) (*godo.StickySessions, error) {
 		CookieName:       name,
 		CookieTtlSeconds: ttl,
 	}, nil
+}
+
+// getSourceRangeRules returns loadBalancerSourceRanges
+// in the format `cidr:{source}`
+func getSourceRangeRules(service *v1.Service) []string {
+	sourceRanges := service.Spec.LoadBalancerSourceRanges
+
+	for i, sourceRange := range sourceRanges {
+		sourceRanges[i] = "cidr:" + sourceRange
+	}
+
+	return sourceRanges
 }
 
 // getProtocol returns the desired protocol of service.

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -5702,6 +5702,54 @@ func Test_buildFirewall(t *testing.T) {
 				Allow: []string{"ip:1.2.3.4", "ip:1.2.3.5"},
 			},
 		},
+		{
+			name: "source ranges not set",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerSourceRanges: []string{},
+				},
+			},
+			expectedFirewall: nil,
+		},
+		{
+			name: "source ranges set",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerSourceRanges: []string{"1.2.0.0/16"},
+				},
+			},
+			expectedFirewall: &godo.LBFirewall{
+				Allow: []string{"cidr:1.2.0.0/16"},
+			},
+		},
+		{
+			name: "source ranges and annotations set",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "abc123",
+					Annotations: map[string]string{
+						annDODenyRules:  "cidr:1.2.0.0/16",
+						annDOAllowRules: "ip:1.2.3.4,ip:1.2.3.5",
+					},
+				},
+				Spec: v1.ServiceSpec{
+					LoadBalancerSourceRanges: []string{"1.3.0.0/16"},
+				},
+			},
+			expectedFirewall: &godo.LBFirewall{
+				Deny:  []string{"cidr:1.2.0.0/16"},
+				Allow: []string{"ip:1.2.3.4", "ip:1.2.3.5", "cidr:1.3.0.0/16"},
+			},
+		},
 	}
 
 	for _, test := range testcases {

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -199,3 +199,5 @@ Specifies the comma seperated ALLOW firewall rules for the load-balancer
 **Note**
 
 Rules must be in the format `{type}:{source}` (ex. `ip:1.2.3.4,cidr:2.3.0.0/16`)
+
+Additionally, you may configure `cidr` ALLOW rules using `loadBalancerSourceRanges`

--- a/docs/controllers/services/examples/http-nginx-with-load-balancer-firewall.yml
+++ b/docs/controllers/services/examples/http-nginx-with-load-balancer-firewall.yml
@@ -15,6 +15,8 @@ spec:
       protocol: TCP
       port: 80
       targetPort: 80
+  loadBalancerSourceRanges:
+  - 1.3.0.0/16
 
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
This PR introduces support for `loadBalancerSourceRanges` as a configuration source for the recently added firewall support.

I understand this may be somewhat redundant given that it's actually _less_ powerful than the annotations, however, given that it's standardised and easy to support I think it's nice-to-have.

I wasn't quite sure where to document this so I left a note under the existing annotations documentation, but if there's somewhere better suited (the examples README perhaps?) let me know