### PR TITLE
set -buildvcs=false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ compile:
 	@docker run -v $(PWD):/go/src/github.com/digitalocean/digitalocean-cloud-controller-manager \
 	  -w /go/src/github.com/digitalocean/digitalocean-cloud-controller-manager \
 	  -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 -e GOFLAGS=-mod=vendor golang:$(GO_VERSION) \
-	  go build -ldflags "$(LDFLAGS)" ${PKG}
+	  go build -buildvcs=false -ldflags "$(LDFLAGS)" ${PKG}
 	@echo "==> built the project"
 
 .PHONY: build


### PR DESCRIPTION
CI builds fail with the following error: 

```
Status: Downloaded newer image for golang:1.19
error obtaining VCS status: exit status 1[28](https://github.com/digitalocean/digitalocean-cloud-controller-manager/actions/runs/4136491568/jobs/7150424330#step:4:29)
	Use -buildvcs=false to disable VCS stamping.
make: *** [Makefile:69: compile] Error 1
```

This PR adds the -buildvcs=false flag to the CCM binary build step 