### PR TITLE
Add support for loadbalancer services in managed-firewall

### DIFF
--- a/cloud-controller-manager/do/firewall_fixture_test.go
+++ b/cloud-controller-manager/do/firewall_fixture_test.go
@@ -287,3 +287,7 @@ func mustCopy(v interface{}) interface{} {
 	w, err := copystructure.Copy(v)
 	return copystructure.Must(w, err)
 }
+
+func boolPtr(value bool) *bool {
+	return &value
+}


### PR DESCRIPTION
This adds support for allowing `type: LoadBalancer` services to be added to the CCM-managed firewall.

If a load balancer has not been attached to the service or the service has [`allocateLoadBalancerNodePorts`](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation) is set to `false`, no firewall rule is added.