### PR TITLE
Have dependabot ignore Kubernetes dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+  # We always update Kubernetes dependencies manually and atomically.
+  - dependency-name: k8s.io/*
   open-pull-requests-limit: 10
 
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
We always update all Kubernetes dependencies atomically and manually when we work on supporting the next minor version.