### PR TITLE
Run tests before image build in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Verify docker image builds
-        run: make build
-
-      - name: Run test command
+      - name: Run tests
         run: make ci
+
+      - name: Verify container image build
+        run: make build
 
   release-dev-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tests are cheaper to execute, so do them first before starting to build a container image that can take more time.