### PR TITLE
Specify retry duration when DO LB is in a being created ("new" state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## unreleased
+* Update retry duration when DO LoadBalancer is being created (@olove) 
 * Updates kubernetes dependencies: (@olove)
   - k8s.io/api@v0.28.0
   - k8s.io/apimachinery@v0.28.0

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -221,7 +221,7 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 
 	if lb.Status != lbStatusActive {
 		if lb.Status == lbStatusNew {
-			return nil, api.NewRetryError(fmt.Sprintf("load-balancer is not yet active (current status: %s)", lb.Status), 15*time.Second)
+			return nil, api.NewRetryError("load-balancer is not in an active state", 15*time.Second)
 		}
 
 		return nil, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -25,11 +25,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider/api"
 	"k8s.io/klog/v2"
 
 	"github.com/digitalocean/godo"
@@ -218,6 +220,10 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	}
 
 	if lb.Status != lbStatusActive {
+		if lb.Status == lbStatusNew {
+			return nil, api.NewRetryError(fmt.Sprintf("load-balancer is not yet active (current status: %s)", lb.Status), 15*time.Second)
+		}
+
 		return nil, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)
 	}
 

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -221,7 +221,7 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 
 	if lb.Status != lbStatusActive {
 		if lb.Status == lbStatusNew {
-			return nil, api.NewRetryError("load-balancer is not in an active state", 15*time.Second)
+			return nil, api.NewRetryError("load-balancer is currently being created", 15*time.Second)
 		}
 
 		return nil, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -219,12 +219,12 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 		return nil, err
 	}
 
-	if lb.Status != lbStatusActive {
-		if lb.Status == lbStatusNew {
-			return nil, api.NewRetryError("load-balancer is currently being created", 15*time.Second)
-		}
+	if lb.Status == lbStatusNew {
+		return nil, api.NewRetryError("load-balancer is currently being created", 15*time.Second)
+	}
 
-		return nil, fmt.Errorf("load-balancer is not yet active (current status: %s)", lb.Status)
+	if lb.Status != lbStatusActive {
+		return nil, fmt.Errorf("load-balancer has unexpected status %q", lb.Status)
 	}
 
 	// If a LB hostname annotation is specified, return with it instead of the IP.

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -26,14 +26,15 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/digitalocean/godo"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/fake"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider/api"
 	"k8s.io/klog/v2"
 )
 
@@ -5148,7 +5149,7 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 				},
 			},
 			lbStatus: nil,
-			err:      utilerrors.NewAggregate([]error{fmt.Errorf("load-balancer is not yet active (current status: %s)", lbStatusNew)}),
+			err:      utilerrors.NewAggregate([]error{api.NewRetryError("load-balancer is currently being created", 15*time.Second)}),
 		},
 		{
 			name:     "LB is disowned",


### PR DESCRIPTION
[Context]
When an LB is being created by CCM, the controller waits for the operation to complete by retrying the create continuously. This leads to an error by the LB API as long as the LB is still being provisioned (with the error from the API saying something along the lines of "LB cannot be updated while create is pending"), which in turn causes CCM to back off at exponentially increasing waiting times. This has the effect that by the time the LB has actually finished provisioning, CCM is in such deep back-off that it takes an unreasonable long time for it to recognize the LB as ready. Anecdotal data indicates that we lose up to a few single-digit minutes until CCM can retrieve the LB IP address and allow the LB to be used in Kubernetes.

Kubernetes 1.28 [added support](https://github.com/kubernetes/kubernetes/pull/94021) for returning a `RetryError` type specifying a custom retry period for CCM to wait. This PR leverages the new error type in our CCM's `EnsureLoadBalancer` method implementation by identifying when an LB is `new` and returning such a type with a relatively short `15` seconds retry time between each reconciliation.