### PR TITLE
feat(CON-8768): add LB admission webhook manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ bump-version:
 	@echo $(NEW_VERSION) > VERSION
 	@cp releases/dev.yml releases/${NEW_VERSION}.yml
 	@sed -i.sedbak 's#image: digitalocean/digitalocean-cloud-controller-manager:dev#image: digitalocean/digitalocean-cloud-controller-manager:${NEW_VERSION}#g' releases/${NEW_VERSION}.yml
+	@sed -i.sedbak 's#image: digitalocean/digitalocean-cloud-controller-manager-admission-server:dev#image: digitalocean/digitalocean-cloud-controller-manager-admission-server:${NEW_VERSION}#g' releases/${NEW_VERSION}.yml
 	@git add --intent-to-add releases/${NEW_VERSION}.yml
 	$(eval NEW_DATE = $(shell  date '+%B %e, %Y'))
 	@sed -i.sedbak 's/## unreleased/## ${NEW_VERSION} (beta) - ${NEW_DATE}/g' CHANGELOG.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,10 @@ These are the recommended versions to run the cloud controller manager based on 
 * Use CCM versions >= v0.1.5 if you're running Kubernetes version >= v1.10
 * Use CCM versions >= v0.1.8 if you're running Kubernetes version >= v1.11
 
+### Cluster
+
+If you opt to install all of the components of the [releases](../releases), you'll have to install [cert-manager](https://cert-manager.io/docs/installation/) (if not already installed).
+
 ### Parameters
 
 This section outlines parameters that can be passed to the cloud controller manager binary.

--- a/releases/dev.yml
+++ b/releases/dev.yml
@@ -50,7 +50,33 @@ spec:
               secretKeyRef:
                 name: digitalocean
                 key: access-token
-
+      - image: digitalocean/digitalocean-cloud-controller-manager-admission-server:dev
+        name: digitalocean-cloud-controller-manager-admission-server
+        command:
+          - "/bin/digitalocean-cloud-controller-manager-admission-server"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 50Mi
+        env:
+          - name: DO_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: digitalocean
+                key: access-token
+        ports:
+        - containerPort: 9443
+          name: admission
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: digitalocean-cloud-controller-manager-serving-certs
+          readOnly: true
+      volumes:
+      - name: digitalocean-cloud-controller-manager-serving-certs
+        secret:
+          defaultMode: 420
+          secretName: digitalocean-cloud-controller-manager-serving-certs
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -152,3 +178,68 @@ subjects:
 - kind: ServiceAccount
   name: cloud-controller-manager
   namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: digitalocean-cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    app: digitalocean-cloud-controller-manager
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 9443
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: digitalocean-cloud-controller-manager-serving-certs
+  namespace: kube-system
+spec:
+  dnsNames:
+  - digitalocean-cloud-controller-manager
+  - digitalocean-cloud-controller-manager.kube-system.svc
+  - digitalocean-cloud-controller-manager.kube-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: digitalocean-cloud-controller-manager-selfsigned-issuer
+  secretName: digitalocean-cloud-controller-manager-serving-certs
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: digitalocean-cloud-controller-manager-selfsigned-issuer
+  namespace: kube-system
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/digitalocean-cloud-controller-manager-serving-certs
+  name: digitalocean-cloud-controller-manager-admission-webhook
+webhooks:
+- name: validation-webhook.loadbalancer.doks.io
+  admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      namespace: "kube-system"
+      name: "digitalocean-cloud-controller-manager"
+      path: "/lb-service"
+  failurePolicy: Fail
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+    scope: '*'
+  sideEffects: None

--- a/releases/dev.yml
+++ b/releases/dev.yml
@@ -230,7 +230,7 @@ webhooks:
       namespace: "kube-system"
       name: "digitalocean-cloud-controller-manager"
       path: "/lb-service"
-  failurePolicy: Fail
+  failurePolicy: Ignore
   rules:
   - apiGroups:
     - ""
@@ -241,5 +241,5 @@ webhooks:
     - UPDATE
     resources:
     - services
-    scope: '*'
+    scope: Namespaced
   sideEffects: None


### PR DESCRIPTION
This change introduces the k8s manifest changes required to deploy the LB admission webhook alongside the existing CCM deployment. Adds:

- Validation webhook definition
- Self signed issuer for signing the admission server certs
- Serving certs for the admission server
- Service fronting the CCM pod
- Additional container running the admission server within the CCM pod.