### PR TITLE
Add new annotation for using certificate name when configuring load balancer TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-## v0.1.50 (beta) - May  7, 2024
+## v0.1.51 (beta) - May  21, 2024
 * Adjusts load balancer health check behaviour to probe Kubernetes components. 
 When `ExternalTrafficPolicy=Cluster`, the health check will be configured to check `kube-proxy`. This ensures that each node is ready to serve LoadBalancer traffic.
 When `ExternalTrafficPolicy=Local`, the configured health check node port will be used which indicates whether the node has active pods.
@@ -8,6 +8,11 @@ In both scenarios, the change will have a positive effect on load balancing beha
 node autoscaling, node taints, pods going up and down will have the proper behaviour to ensure we don't send traffic to components that are not in a state to serve traffic.
 * A new annotation was added `service.beta.kubernetes.io/do-loadbalancer-revert-to-old-health-check` has been added to
 allow LBs to revert to the old health check behaviour. The annotation and old health check behaviour will be removed in a future version.
+* Adding new annotation `service.beta.kubernetes.io/do-loadbalancer-certificate-name` to configure which TLS certificate
+  to use for HTTPs forwarding rules. This can be used instead of `service.beta.kubernetes.io/do-loadbalancer-certificate-id` which
+  needs to be manually updated when using Let's Encrypt certificates. This is due to the certificate ID updating each time the
+  certificate is rotated. If both annotations are provided, then `service.beta.kubernetes.io/do-loadbalancer-certificate-id` takes
+  precedence.
 
 ## v0.1.50 (beta) - May 7, 2024
 * Updates kubernetes dependencies: (@ihwang)

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -96,10 +96,15 @@ const (
 	// This is optional and defaults to false.
 	annDOTLSPassThrough = annDOLoadBalancerBase + "tls-passthrough"
 
-	// annDOCertificateID is the annotation specifying the certificate ID
-	// used for https protocol. This annotation is required if annDOTLSPorts
+	// annDOCertificateID is the annotation specifying the certificate ID.
+	// used for https protocol. Either this annotation OR annDOCertificateName is required if annDOTLSPorts
 	// is passed.
 	annDOCertificateID = annDOLoadBalancerBase + "certificate-id"
+
+	// annDOCertificateName is the annotation specifying the certificate name.
+	// used for https protocol. Either this annotation OR annDOCertificateID is required if annDOTLSPorts
+	// is passed.
+	annDOCertificateName = annDOLoadBalancerBase + "certificate-name"
 
 	// annDOHostname is the annotation specifying the hostname to use for the LB.
 	annDOHostname = annDOLoadBalancerBase + "hostname"

--- a/cloud-controller-manager/do/lb_service_admission_handler.go
+++ b/cloud-controller-manager/do/lb_service_admission_handler.go
@@ -80,7 +80,7 @@ func (h *LBServiceAdmissionHandler) handle(ctx context.Context, req admission.Re
 
 	lbID := svc.Annotations[annDOLoadBalancerID]
 
-	lbReq, err := h.buildLoadBalancerRequest(&svc)
+	lbReq, err := h.buildLoadBalancerRequest(ctx, &svc)
 	if err != nil {
 		return admission.Denied(fmt.Sprintf("failed to build DO API request: %s", err))
 	}
@@ -105,7 +105,7 @@ func (h *LBServiceAdmissionHandler) validateUpdate(ctx context.Context, req admi
 	// We ignore errors when building the old service's godo request because
 	// it is allowed to be wrong. In cases where it errors, it can potentially
 	// get fixed after the update.
-	oldReq, _ := h.buildLoadBalancerRequest(&oldSvc)
+	oldReq, _ := h.buildLoadBalancerRequest(ctx, &oldSvc)
 	if cmp.Equal(oldReq, lbReq) {
 		return admission.Allowed("new service has irrelevant changes")
 	}
@@ -130,8 +130,8 @@ func (h *LBServiceAdmissionHandler) validateCreate(ctx context.Context, lbReq *g
 	return h.mapGodoRespToAdmissionResp(resp, err)
 }
 
-func (h *LBServiceAdmissionHandler) buildLoadBalancerRequest(svc *corev1.Service) (*godo.LoadBalancerRequest, error) {
-	lbReq, err := buildLoadBalancerRequest(svc)
+func (h *LBServiceAdmissionHandler) buildLoadBalancerRequest(ctx context.Context, svc *corev1.Service) (*godo.LoadBalancerRequest, error) {
+	lbReq, err := buildLoadBalancerRequest(ctx, svc, h.godoClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build base load balancer request: %s", err)
 	}

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -547,7 +547,7 @@ func buildLoadBalancerRequest(ctx context.Context, service *v1.Service, godoClie
 			return nil, err
 		}
 	} else {
-		forwardingRules, err = buildForwardingRules(service, godoClient)
+		forwardingRules, err = buildForwardingRules(ctx, service, godoClient)
 		if err != nil {
 			return nil, err
 		}

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1173,10 +1173,10 @@ func findCertificateID(ctx context.Context, service *v1.Service, godoClient *god
 	}
 	lbCert, _, err := godoClient.Certificates.ListByName(ctx, certificateName, &godo.ListOptions{Page: 1, PerPage: 1})
 	if err != nil {
-		return "", fmt.Errorf("failed to get certificate by name: %s error: %w", certificateName, err)
+		return "", fmt.Errorf("failed to get certificate by name: %q error: %s", certificateName, err)
 	}
 	if len(lbCert) == 0 {
-		return "", fmt.Errorf("certificate with name: %s not found", certificateName)
+		return "", fmt.Errorf("certificate with name: %q not found", certificateName)
 	}
 	return lbCert[0].ID, nil
 }

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -294,7 +294,11 @@ func (l *loadBalancers) updateLoadBalancer(ctx context.Context, lb *godo.LoadBal
 	}
 
 	lbCertID := getCertificateIDFromLB(lb)
-	serviceCertID := getCertificateID(service)
+	serviceCertID, err := findCertificateID(ctx, service, l.resources.gclient)
+	if err != nil {
+		return nil, err
+	}
+
 	err = l.recordUpdatedLetsEncryptCert(ctx, service, lbCertID, serviceCertID)
 	if err != nil {
 		return nil, err
@@ -529,7 +533,7 @@ func (l *loadBalancers) nodesToDropletIDs(ctx context.Context, nodes []*v1.Node)
 	return dropletIDs, nil
 }
 
-func buildLoadBalancerRequest(service *v1.Service) (*godo.LoadBalancerRequest, error) {
+func buildLoadBalancerRequest(ctx context.Context, service *v1.Service, godoClient *godo.Client) (*godo.LoadBalancerRequest, error) {
 	lbName := getLoadBalancerName(service)
 
 	lbType, err := getType(service)
@@ -543,7 +547,7 @@ func buildLoadBalancerRequest(service *v1.Service) (*godo.LoadBalancerRequest, e
 			return nil, err
 		}
 	} else {
-		forwardingRules, err = buildForwardingRules(service)
+		forwardingRules, err = buildForwardingRules(service, godoClient)
 		if err != nil {
 			return nil, err
 		}
@@ -621,7 +625,7 @@ func buildLoadBalancerRequest(service *v1.Service) (*godo.LoadBalancerRequest, e
 // buildLoadBalancerRequest returns a *godo.LoadBalancerRequest to balance
 // requests for service across nodes.
 func (l *loadBalancers) buildLoadBalancerRequest(ctx context.Context, service *v1.Service, nodes []*v1.Node) (*godo.LoadBalancerRequest, error) {
-	req, err := buildLoadBalancerRequest(service)
+	req, err := buildLoadBalancerRequest(ctx, service, l.resources.gclient)
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +696,7 @@ func buildHealthCheck(service *v1.Service) (*godo.HealthCheck, error) {
 	}, nil
 }
 
-func buildHTTP3ForwardingRule(service *v1.Service) (*godo.ForwardingRule, error) {
+func buildHTTP3ForwardingRule(ctx context.Context, service *v1.Service, godoClient *godo.Client) (*godo.ForwardingRule, error) {
 	http3Port, err := getHTTP3Port(service)
 	if err != nil {
 		return nil, err
@@ -701,7 +705,10 @@ func buildHTTP3ForwardingRule(service *v1.Service) (*godo.ForwardingRule, error)
 		return nil, nil
 	}
 
-	certificateID := getCertificateID(service)
+	certificateID, err := findCertificateID(ctx, service, godoClient)
+	if err != nil {
+		return nil, err
+	}
 	if getTLSPassThrough(service) {
 		return nil, errors.New("TLS passthrough is not allowed to be used in conjunction with HTTP3")
 	}
@@ -726,7 +733,7 @@ func buildHTTP3ForwardingRule(service *v1.Service) (*godo.ForwardingRule, error)
 
 // buildForwardingRules returns the forwarding rules of the Load Balancer of
 // service.
-func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
+func buildForwardingRules(ctx context.Context, service *v1.Service, godoClient *godo.Client) ([]godo.ForwardingRule, error) {
 	var forwardingRules []godo.ForwardingRule
 
 	defaultProtocol, err := getProtocol(service)
@@ -755,7 +762,10 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 		return nil, fmt.Errorf("ports from annotations \"%s*-ports\" cannot be shared but found: %s", annDOLoadBalancerBase, strings.Join(portDups, ", "))
 	}
 
-	certificateID := getCertificateID(service)
+	certificateID, err := findCertificateID(ctx, service, godoClient)
+	if err != nil {
+		return nil, err
+	}
 	tlsPassThrough := getTLSPassThrough(service)
 	needSecureProto := certificateID != "" || tlsPassThrough
 
@@ -799,7 +809,7 @@ func buildForwardingRules(service *v1.Service) ([]godo.ForwardingRule, error) {
 		forwardingRules = append(forwardingRules, *forwardingRule)
 	}
 
-	if h3, err := buildHTTP3ForwardingRule(service); err != nil {
+	if h3, err := buildHTTP3ForwardingRule(ctx, service, godoClient); err != nil {
 		return nil, fmt.Errorf("failed to construct http3 forwarding rule: %w", err)
 	} else if h3 != nil {
 		forwardingRules = append(forwardingRules, *h3)
@@ -1140,10 +1150,35 @@ func getStrings(service *v1.Service, anno string) []string {
 	return pieces
 }
 
-// getCertificateID returns the certificate ID of service to use for fowarding
+// getCertificateID returns the certificate ID of service to use for forwarding
 // rules.
 func getCertificateID(service *v1.Service) string {
 	return service.Annotations[annDOCertificateID]
+}
+
+// getCertificateName returns the certificate name of service to use for forwarding
+// rules.
+func getCertificateName(service *v1.Service) string {
+	return service.Annotations[annDOCertificateName]
+}
+
+func findCertificateID(ctx context.Context, service *v1.Service, godoClient *godo.Client) (string, error) {
+	certificateID := getCertificateID(service)
+	if certificateID != "" {
+		return certificateID, nil
+	}
+	certificateName := getCertificateName(service)
+	if certificateName == "" {
+		return "", nil
+	}
+	lbCert, _, err := godoClient.Certificates.ListByName(ctx, certificateName, &godo.ListOptions{Page: 1, PerPage: 1})
+	if err != nil {
+		return "", fmt.Errorf("failed to get certificate by name: %s error: %w", certificateName, err)
+	}
+	if len(lbCert) == 0 {
+		return "", fmt.Errorf("certificate with name: %s not found", certificateName)
+	}
+	return lbCert[0].ID, nil
 }
 
 // getTLSPassThrough returns true if there should be TLS pass through to

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -722,7 +722,7 @@ func Test_getHTTP3Ports(t *testing.T) {
 
 func Test_buildHTTP3ForwardingRule(t *testing.T) {
 	t.Run("with tls passthrough returns error", func(t *testing.T) {
-		got, err := buildHTTP3ForwardingRule(&v1.Service{
+		got, err := buildHTTP3ForwardingRule(context.Background(), &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 				UID:  "abc123",
@@ -741,7 +741,7 @@ func Test_buildHTTP3ForwardingRule(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, nil)
 
 		if err.Error() != "TLS passthrough is not allowed to be used in conjunction with HTTP3" {
 			t.Fatalf("expected error, got: %v", err)
@@ -753,7 +753,7 @@ func Test_buildHTTP3ForwardingRule(t *testing.T) {
 	})
 
 	t.Run("without cert id returns error", func(t *testing.T) {
-		got, err := buildHTTP3ForwardingRule(&v1.Service{
+		got, err := buildHTTP3ForwardingRule(context.Background(), &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 				UID:  "abc123",
@@ -771,7 +771,7 @@ func Test_buildHTTP3ForwardingRule(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, nil)
 
 		if err.Error() != "certificate ID is required for HTTP3" {
 			t.Fatalf("expected error, got: %v", err)
@@ -783,7 +783,7 @@ func Test_buildHTTP3ForwardingRule(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		got, err := buildHTTP3ForwardingRule(&v1.Service{
+		got, err := buildHTTP3ForwardingRule(context.Background(), &v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 				UID:  "abc123",
@@ -802,7 +802,7 @@ func Test_buildHTTP3ForwardingRule(t *testing.T) {
 					},
 				},
 			},
-		})
+		}, nil)
 
 		if err != nil {
 			t.Fatalf("expected nil err, got: %v", err)
@@ -2164,7 +2164,7 @@ func Test_buildForwardingRules(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			forwardingRules, err := buildForwardingRules(test.service)
+			forwardingRules, err := buildForwardingRules(context.Background(), test.service, nil)
 			if !reflect.DeepEqual(forwardingRules, test.forwardingRules) {
 				t.Error("unexpected forwarding rules")
 				t.Logf("expected: %v", test.forwardingRules)

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -108,7 +108,18 @@ You have to supply the value as string (ex. `"true"`, not `true`), otherwise you
 
 ## service.beta.kubernetes.io/do-loadbalancer-certificate-id
 
-Specifies the certificate ID used for https. To list available certificates and their IDs, install [doctl](https://github.com/digitalocean/doctl) and run `doctl compute certificate list`.
+Specifies the certificate ID used for https. To list available certificates and their IDs, install [doctl](https://github.com/digitalocean/doctl) and run `doctl compute certificate list`. Either
+`service.beta.kubernetes.io/do-loadbalancer-certificate-id` OR `service.beta.kubernetes.io/do-loadbalancer-certificate-name` can be supplied, with the former
+taking precedence if both are provided.
+
+## service.beta.kubernetes.io/do-loadbalancer-certificate-name
+
+Specifies the certificate name used for https. To list available certificates and their IDs, install [doctl](https://github.com/digitalocean/doctl) and run `doctl compute certificate list`. Either
+`service.beta.kubernetes.io/do-loadbalancer-certificate-id` OR `service.beta.kubernetes.io/do-loadbalancer-certificate-name` can be supplied, with the former
+taking precedence if both are provided.
+
+If using Let's Encrypt certificate, we suggest using the name of the certificate since the ID of the certificate will update each time it is rotated. The name of the certificate is required
+to be unique within the scope of an account.
 
 ## service.beta.kubernetes.io/do-loadbalancer-hostname
 


### PR DESCRIPTION
This will improve the users experience when using a certificate. A name is easier to identify then a UUID. If they are using lets encrypt, the underlying UUID will change on each renewal which causes headaches for users. Certificate names are also now unique so we can identify a certificate by its name even if the underlying UUID has changed.

The existing certificate ID annotation will take precedence. If they specify a name, we will use the certificate API to look it up and get the certificate ID.