### PR TITLE
Fix Load Balancer Health Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## unreleased
 
 ## v0.1.50 (beta) - May  7, 2024
+* Adjusts load balancer health check behaviour to probe Kubernetes components. 
+When `ExternalTrafficPolicy=Cluster`, the health check will be configured to check `kube-proxy`. This ensures that each node is ready to serve LoadBalancer traffic.
+When `ExternalTrafficPolicy=Local`, the configured health check node port will be used which indicates whether the node has active pods.
+In both scenarios, the change will have a positive effect on load balancing behaviour. This will ensure that during life cycle changes within the cluster such as
+node autoscaling, node taints, pods going up and down will have the proper behaviour to ensure we don't send traffic to components that are not in a state to serve traffic.
+* A new annotation was added `service.beta.kubernetes.io/do-loadbalancer-revert-to-old-health-check` has been added to
+allow LBs to revert to the old health check behaviour. The annotation and old health check behaviour will be removed in a future version.
 
 ## v0.1.50 (beta) - May 7, 2024
 * Updates kubernetes dependencies: (@ihwang)

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -32,6 +32,22 @@ const (
 	// is overwritten to https. Options are tcp, http and https. Defaults to tcp.
 	annDOProtocol = annDOLoadBalancerBase + "protocol"
 
+	// annDOHealthCheckPath is the annotation used to specify the health check path
+	// for DO load balancers. Defaults to '/'.
+	annDOHealthCheckPath = annDOLoadBalancerBase + "healthcheck-path"
+
+	// annDOHealthCheckPort is the annotation used to specify the health check port
+	// for DO load balancers. Defaults to the first Service Port
+	annDOHealthCheckPort = annDOLoadBalancerBase + "healthcheck-port"
+
+	// annDOHealthCheckProtocol is the annotation used to specify the health check protocol
+	// for DO load balancers. Defaults to the protocol used in annDOProtocol.
+	annDOHealthCheckProtocol = annDOLoadBalancerBase + "healthcheck-protocol"
+
+	// annDORevertToOldHealthCheck is the annotation used to control reverting to the old health check behavior. This
+	// annotation is temporary and will be removed after the deprecation period is over.
+	annDORevertToOldHealthCheck = annDOLoadBalancerBase + "revert-to-old-health-check"
+
 	// annDOHealthCheckIntervalSeconds is the annotation used to specify the
 	// number of seconds between between two consecutive health checks. The
 	// value must be between 3 and 300. Defaults to 3.

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -32,18 +32,6 @@ const (
 	// is overwritten to https. Options are tcp, http and https. Defaults to tcp.
 	annDOProtocol = annDOLoadBalancerBase + "protocol"
 
-	// annDOHealthCheckPath is the annotation used to specify the health check path
-	// for DO load balancers. Defaults to '/'.
-	annDOHealthCheckPath = annDOLoadBalancerBase + "healthcheck-path"
-
-	// annDOHealthCheckPort is the annotation used to specify the health check port
-	// for DO load balancers. Defaults to the first Service Port
-	annDOHealthCheckPort = annDOLoadBalancerBase + "healthcheck-port"
-
-	// annDOHealthCheckProtocol is the annotation used to specify the health check protocol
-	// for DO load balancers. Defaults to the protocol used in annDOProtocol.
-	annDOHealthCheckProtocol = annDOLoadBalancerBase + "healthcheck-protocol"
-
 	// annDOHealthCheckIntervalSeconds is the annotation used to specify the
 	// number of seconds between between two consecutive health checks. The
 	// value must be between 3 and 300. Defaults to 3.

--- a/cloud-controller-manager/do/lb_service_admission_handler_test.go
+++ b/cloud-controller-manager/do/lb_service_admission_handler_test.go
@@ -87,12 +87,17 @@ func TestHandle(t *testing.T) {
 		{
 			name: "error create when building godo request fails",
 			req: fakeAdmissionRequest(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annDOHealthCheckIntervalSeconds: "abc",
+					},
+				},
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeLoadBalancer,
 				},
 			}, nil),
 			expectedAllowed: false,
-			expectedMessage: "failed to build DO API request: failed to build base load balancer request: no health check port of protocol TCP found",
+			expectedMessage: "failed to build DO API request: failed to build base load balancer request: failed to parse health check interval annotation \"service.beta.kubernetes.io/do-loadbalancer-healthcheck-check-interval-seconds\": strconv.Atoi: parsing \"abc\": invalid syntax",
 		},
 		{
 			name: "error create when godo answers has no resp and error",

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -57,6 +57,13 @@ The number of times a health check must fail for a backend Droplet to be marked 
 
 The number of times a health check must pass for a backend Droplet to be marked "healthy" for the given service and be re-added to the pool. The vaule must be between 2 and 10. If not specified, the default value is 5.
 
+## service.beta.kubernetes.io/do-loadbalancer-revert-to-old-health-check
+
+Reverts the load balancer health check to the previous logic, which health checks the application itself. This is a temporary mitigation to rollback
+to the previous logic in case the updated implementation has an unintended side effect on your application. We don't expect any customers to need to use
+this but has been added in case of emergency. The updated implementation will health check the Kubernetes components that are responsible for routing
+traffic, this will account for pod and node lifecycle such as taints, autoscaling, etc...
+
 ## service.beta.kubernetes.io/do-loadbalancer-http-ports
 
 Specify which ports of the loadbalancer should use the HTTP protocol. This is a comma separated list of ports (e.g. 80,8080).


### PR DESCRIPTION
Our current health check implementation is flawed. The external load balancer should not be responsible for health checking the pods since Kubernetes is already doing that. It instead should be health checking the worker nodes themselves. This is also dependent on the externalTrafficPolicy set on the Service itself.

If the `externalTrafficPolicy=Local` then a health check node port is created to serve health checks for the node. If there are 1 or more active pods on the node, then the health check will return 200 and it will indicate how many healthy pods are running. If there is no active pods, then it will return a 503 and will fail the health checks. It is necessary for the LB to health check this dedicated endpoint to ensure we respect the lifecycle of the worker node and the pods running on it.

If the `externalTrafficPolicy=Cluster` then we should health check kube-proxy running on the node. This is controlled by `--healthz-bind-address` which defaults to `0.0.0.0:10256`. Health checking kube-proxy allows us to follow the lifecycle of the node such as whether it is up and ready to serve traffic, or whether we should stop routing traffic because it is tainted, is being removed due to scaling down, or being removed due to maintenance. In this case, kube proxy is responsible for understanding the health of each individual pod and managing which pods should receive traffic. In our current behaviour, if a pod goes unhealthy, it can incorrectly mark entire worker nodes as unhealthy which isn't the case. If/when we make the switch to full cilium, we will need to make sure we set `--kube-proxy-replacement-healthz-bind-address`.

This change will delegate pod healthiness to Kubernetes, which it should have always done. It will instead start health checking the Kubernetes components themselves to ensure they are up and ready to process traffic, and we can stop sending traffic to them when they are no longer healthy or are being drained for any number of reasons. Pod unhealthiness will no longer mark nodes as unhealthy. This should also fix a number of edge cases customers are experiencing when using cluster autoscaling or pod autoscalers.