### PR TITLE
Add support for loadBalancerSourceRanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Adding support for specifiying `loadBalancerSourceRanges` in the service spec. Source ranges take precedence over annotation based allow rules (`service.beta.kubernetes.io/do-loadbalancer-allow-rules`).
+
 ## v0.1.51 (beta) - May 28, 2024
 
 * Adjusts load balancer health check behaviour to probe Kubernetes components correctly, ensuring that LB traffic stops

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -899,7 +899,7 @@ func getSourceRangeRules(service *v1.Service) ([]string, error) {
 	specs := service.Spec.LoadBalancerSourceRanges
 	ipnets, err := utilnet.ParseIPNets(specs...)
 	if err != nil {
-		return nil, fmt.Errorf("service.Spec.LoadBalancerSourceRanges: %v is not valid. Expecting a list of IP ranges. For example, 10.0.0.0/24. Error msg: %v", specs, err)
+		return nil, fmt.Errorf("failed to parse spec.loadBalancerSourceRanges %q: %s (expected format for an IP address is 10.0.0.0/24)", specs, err)
 	}
 
 	var sourceAllows []string

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -211,7 +211,7 @@ Specifies the HTTP idle timeout configuration in seconds. If not specified, the 
 
 ## service.beta.kubernetes.io/do-loadbalancer-deny-rules
 
-Specifies the comma seperated DENY firewall rules for the load-balancer
+Specifies the comma separated DENY firewall rules for the load-balancer
 
 **Note**
 
@@ -219,10 +219,10 @@ Rules must be in the format `{type}:{source}` (ex. `ip:1.2.3.4,cidr:2.3.0.0/16`)
 
 ## service.beta.kubernetes.io/do-loadbalancer-allow-rules
 
-Specifies the comma seperated ALLOW firewall rules for the load-balancer
+Specifies the comma separated ALLOW firewall rules for the load-balancer
 
 **Note**
 
 Rules must be in the format `{type}:{source}` (ex. `ip:1.2.3.4,cidr:2.3.0.0/16`).
 
-These rules will be ignored if `LoadBalancerSourceRanges` is set, which is the prefered way to enter allow rules.
+These rules will be ignored if `LoadBalancerSourceRanges` is set, which is the preferred way to enter allow rules.

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -223,4 +223,6 @@ Specifies the comma seperated ALLOW firewall rules for the load-balancer
 
 **Note**
 
-Rules must be in the format `{type}:{source}` (ex. `ip:1.2.3.4,cidr:2.3.0.0/16`)
+Rules must be in the format `{type}:{source}` (ex. `ip:1.2.3.4,cidr:2.3.0.0/16`).
+
+These rules will be ignored if `LoadBalancerSourceRanges` is set, which is the prefered way to enter allow rules.


### PR DESCRIPTION
This change introduces support for loadBalancerSourceRanges which is the preferred and recommended way to add firewall allow rules and therefore takes presedence over annotation based allow rules.

Thanks to @J0sh0nat0r for submitting the original pull request #584.