### PR TITLE
Better document health check behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,9 @@
 
 ## v0.1.51 (beta) - May 28, 2024
 
-* Adjusts load balancer health check behaviour to probe Kubernetes components. 
-When `ExternalTrafficPolicy=Cluster`, the health check will be configured to check `kube-proxy`. This ensures that each node is ready to serve LoadBalancer traffic.
-When `ExternalTrafficPolicy=Local`, the configured health check node port will be used which indicates whether the node has active pods.
-In both scenarios, the change will have a positive effect on load balancing behaviour. This will ensure that during life cycle changes within the cluster such as
-node autoscaling, node taints, pods going up and down will have the proper behaviour to ensure we don't send traffic to components that are not in a state to serve traffic.
-* A new annotation was added `service.beta.kubernetes.io/do-loadbalancer-revert-to-old-health-check` has been added to
-allow LBs to revert to the old health check behaviour. The annotation and old health check behaviour will be removed in a future version.
+* Adjusts load balancer health check behaviour to probe Kubernetes components correctly, ensuring that LB traffic stops
+  in time in case of unavailability and pending node replacements. The concrete health check configuration depends on
+  the specified external traffic policy. See [the extended documentation](docs/getting-started.md#health-check-configuration) for details.
 * Adding new annotation `service.beta.kubernetes.io/do-loadbalancer-certificate-name` to configure which TLS certificate
   to use for HTTPs forwarding rules. This can be used instead of `service.beta.kubernetes.io/do-loadbalancer-certificate-id` which
   needs to be manually updated when using Let's Encrypt certificates. This is due to the certificate ID updating each time the

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -44,9 +44,13 @@ const (
 	// for DO load balancers. Defaults to the protocol used in annDOProtocol.
 	annDOHealthCheckProtocol = annDOLoadBalancerBase + "healthcheck-protocol"
 
-	// annDORevertToOldHealthCheck is the annotation used to control reverting to the old health check behavior. This
-	// annotation is temporary and will be removed after the deprecation period is over.
-	annDORevertToOldHealthCheck = annDOLoadBalancerBase + "revert-to-old-health-check"
+	// annDOOverrideHealthCheck is the annotation used to control overriding certain
+	// health check parameters.
+	//
+	// In most cases, it should not be used since
+	// digitalocean-cloud-controller-manager sets a proper health check configuration
+	// automatically.
+	annDOOverrideHealthCheck = annDOLoadBalancerBase + "override-health-check"
 
 	// annDOHealthCheckIntervalSeconds is the annotation used to specify the
 	// number of seconds between between two consecutive health checks. The

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -653,8 +653,9 @@ func buildHealthCheck(service *v1.Service) (*godo.HealthCheck, error) {
 	hcPath, hcPort := healthCheckPathAndPort(service)
 	hcProtocol := protocolHTTP
 
-	// If the old behavior was requested
-	_, ok := service.Annotations[annDORevertToOldHealthCheck]
+	// Permit changing the default health check behavior if the override annotation
+	// is set.
+	_, ok := service.Annotations[annDOOverrideHealthCheck]
 	if ok {
 		var err error
 		hcPath = healthCheckPath(service)

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -2327,7 +2327,7 @@ func Test_buildHealthCheck(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORevertToOldHealthCheck: "",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 
@@ -2361,10 +2361,10 @@ func Test_buildHealthCheck(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORevertToOldHealthCheck: "",
-						annDOHealthCheckProtocol:    "http",
-						annDOHealthCheckPort:        "81",
-						annDOHealthCheckPath:        "/test",
+						annDOOverrideHealthCheck: "",
+						annDOHealthCheckProtocol: "http",
+						annDOHealthCheckPort:     "81",
+						annDOHealthCheckPath:     "/test",
 					},
 				},
 
@@ -2582,7 +2582,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORevertToOldHealthCheck: "",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2605,8 +2605,8 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2629,9 +2629,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOCertificateID:          "test-certificate",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOCertificateID:       "test-certificate",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2654,9 +2654,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOTLSPassThrough:         "true",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOTLSPassThrough:      "true",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2679,9 +2679,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOCertificateID:          "test-certificate",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOCertificateID:       "test-certificate",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2704,9 +2704,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http2",
-						annDOCertificateID:          "test-certificate",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http2",
+						annDOCertificateID:       "test-certificate",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2729,9 +2729,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOTLSPassThrough:         "true",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOTLSPassThrough:      "true",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2754,9 +2754,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http2",
-						annDOTLSPassThrough:         "true",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http2",
+						annDOTLSPassThrough:      "true",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2779,9 +2779,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "tcp",
-						annDOHealthCheckProtocol:    "http",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "tcp",
+						annDOHealthCheckProtocol: "http",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2804,10 +2804,10 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOCertificateID:          "test-certificate",
-						annDOHealthCheckProtocol:    "http",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOCertificateID:       "test-certificate",
+						annDOHealthCheckProtocol: "http",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2830,10 +2830,10 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http2",
-						annDOCertificateID:          "test-certificate",
-						annDOHealthCheckProtocol:    "http",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http2",
+						annDOCertificateID:       "test-certificate",
+						annDOHealthCheckProtocol: "http",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2856,9 +2856,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "tcp",
-						annDOHealthCheckProtocol:    "https",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "tcp",
+						annDOHealthCheckProtocol: "https",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2881,10 +2881,10 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "https",
-						annDOCertificateID:          "test-certificate",
-						annDOHealthCheckProtocol:    "http",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "https",
+						annDOCertificateID:       "test-certificate",
+						annDOHealthCheckProtocol: "http",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2907,9 +2907,9 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http",
-						annDOHealthCheckPath:        "/health",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http",
+						annDOHealthCheckPath:     "/health",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2932,8 +2932,8 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOHealthCheckProtocol:    "invalid",
-						annDORevertToOldHealthCheck: "",
+						annDOHealthCheckProtocol: "invalid",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2956,10 +2956,10 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOProtocol:               "http",
-						annDOHealthCheckPath:        "/health",
-						annDOHealthCheckPort:        "636",
-						annDORevertToOldHealthCheck: "",
+						annDOProtocol:            "http",
+						annDOHealthCheckPath:     "/health",
+						annDOHealthCheckPort:     "636",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -2989,8 +2989,8 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Namespace: "default",
 					UID:       "abc123",
 					Annotations: map[string]string{
-						annDOHealthCheckPort:        "9999",
-						annDORevertToOldHealthCheck: "",
+						annDOHealthCheckPort:     "9999",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3019,8 +3019,8 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOHealthCheckPort:        "invalid",
-						annDORevertToOldHealthCheck: "",
+						annDOHealthCheckPort:     "invalid",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3049,8 +3049,8 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDOHealthCheckPort:        "636,332",
-						annDORevertToOldHealthCheck: "",
+						annDOHealthCheckPort:     "636,332",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3079,7 +3079,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					Name: "test",
 					UID:  "abc123",
 					Annotations: map[string]string{
-						annDORevertToOldHealthCheck: "",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3113,7 +3113,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 						annDOHealthCheckResponseTimeoutSeconds: "3",
 						annDOHealthCheckUnhealthyThreshold:     "1",
 						annDOHealthCheckHealthyThreshold:       "2",
-						annDORevertToOldHealthCheck:            "",
+						annDOOverrideHealthCheck:               "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3144,7 +3144,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					UID:  "abc123",
 					Annotations: map[string]string{
 						annDOHealthCheckIntervalSeconds: "invalid",
-						annDORevertToOldHealthCheck:     "",
+						annDOOverrideHealthCheck:        "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3168,7 +3168,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					UID:  "abc123",
 					Annotations: map[string]string{
 						annDOHealthCheckResponseTimeoutSeconds: "invalid",
-						annDORevertToOldHealthCheck:            "",
+						annDOOverrideHealthCheck:               "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3192,7 +3192,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					UID:  "abc123",
 					Annotations: map[string]string{
 						annDOHealthCheckUnhealthyThreshold: "invalid",
-						annDORevertToOldHealthCheck:        "",
+						annDOOverrideHealthCheck:           "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3216,7 +3216,7 @@ func Test_buildHealthCheckOld(t *testing.T) {
 					UID:  "abc123",
 					Annotations: map[string]string{
 						annDOHealthCheckHealthyThreshold: "invalid",
-						annDORevertToOldHealthCheck:      "",
+						annDOOverrideHealthCheck:         "",
 					},
 				},
 				Spec: v1.ServiceSpec{
@@ -3870,7 +3870,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Name: "test",
 					UID:  "foobar123",
 					Annotations: map[string]string{
-						annDORevertToOldHealthCheck: "",
+						annDOOverrideHealthCheck: "",
 					},
 				},
 				Spec: v1.ServiceSpec{

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -25,15 +25,19 @@ If `https`, `http2`, or `http3` is specified, then either `service.beta.kubernet
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-port
 
-The service port used to check if a backend droplet is healthy. Defaults to the first port in a service.
+**Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check port. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set explicitly.
 
-**Note:** Users must specify a port exposed by the Service, not the NodePort.
+The service port used to check if a backend droplet is healthy. Defaults to the first port in a service. A NodePort must not be defined.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-path
+
+**Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check path. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set additionally.
 
 The path used to check if a backend droplet is healthy. Defaults to "/".
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol
+
+**Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check protocol. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set additionally.
 
 The health check protocol to use to check if a backend droplet is healthy. Defaults to `tcp` if not specified. Options are `tcp`, `http`, and `https`.
 
@@ -57,12 +61,15 @@ The number of times a health check must fail for a backend Droplet to be marked 
 
 The number of times a health check must pass for a backend Droplet to be marked "healthy" for the given service and be re-added to the pool. The vaule must be between 2 and 10. If not specified, the default value is 5.
 
-## service.beta.kubernetes.io/do-loadbalancer-revert-to-old-health-check
+## service.beta.kubernetes.io/do-loadbalancer-override-health-check
 
-Reverts the load balancer health check to the previous logic, which health checks the application itself. This is a temporary mitigation to rollback
-to the previous logic in case the updated implementation has an unintended side effect on your application. We don't expect any customers to need to use
-this but has been added in case of emergency. The updated implementation will health check the Kubernetes components that are responsible for routing
-traffic, this will account for pod and node lifecycle such as taints, autoscaling, etc...
+digitalocean-cloud-controller-manager automatically chooses proper values for the health check port, path, and protocol. In order to set any of these explicitly, this annotation must be specified additionally and set to any value.
+
+If the annotation is set, then all of the following annotations (either any implicit or explicit values) will become effective as well:
+
+- `service.beta.kubernetes.io/do-loadbalancer-healthcheck-port`
+- `service.beta.kubernetes.io/do-loadbalancer-healthcheck-path`
+- `service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol`
 
 ## service.beta.kubernetes.io/do-loadbalancer-http-ports
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,17 @@ When a cluster is created in a non-default VPC for the region, the environment v
 
 You can have `digitalocean-cloud-controller-manager` manage an existing load-balancer by creating a `LoadBalancer` Service annotated with the UUID of the load-balancer. However, if it is already managed by another Service/cluster, you have to make sure [to disown it properly](/docs/controllers/services/examples/README.md#changing-ownership-of-a-load-balancer-for-migration-purposes) to prevent conflicting modifications to the load-balancer.
 
+### Health check configuration
+
+digitalocean-cloud-controller-manager automatically sets an LB health check configuration suitable for identifying pod/node availability and facilitating graceful rotation in the event of workload and node replacements. The concrete values depend on the configured external traffic policy:
+
+- `Cluster`: the kube-proxy /healthz endpoint available on each worker node indicating if the node is healthy
+- `Local`: the /healthz endpoint on the separate health check node port (created explicitly by Kubernetes) indicating if the node has active pods
+
+See also [this blog post](https://kubernetes.io/blog/2022/12/30/advancements-in-kubernetes-traffic-engineering/) for details.
+
+In general, health check parameters for port, path, and protocol should not have to be set explicitly. For rare cases where it may be required, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set in addition to the corresponding health check parameter annotations. See the annotation documentation for details.
+
 ## Deployment
 
 ### Token
@@ -178,4 +189,3 @@ To install it, run the following kubectl command:
 kubectl apply -f releases/digitalocean-cloud-controller-manager-admission-server/v0.1.47.yml
 deployment "digitalocean-cloud-controller-manager-admission-server" created
 ```
-


### PR DESCRIPTION
Additionally, do not immediately announce the overriding annotation to be removed in the future to allow for potential special cases in self-managed Kubernetes clusters.