### PR TITLE
Add support for internal load balancers

### DIFF
--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -181,4 +181,8 @@ const (
 	// annDOType is the annotation used to specify the type of the load balancer. Either REGIONAL or REGIONAL_NETWORK (currently in closed alpha)
 	// are permitted. If no type is provided, then it will default REGIONAL.
 	annDOType = annDOLoadBalancerBase + "type"
+
+	// annDONetwork is the annotation used to specify the network type of the load balancer. Either EXTERNAL or INTERNAL (currently in closed alpha)
+	// are permitted. If no network is provided, then it will default EXTERNAL.
+	annDONetwork = annDOLoadBalancerBase + "network"
 )

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1394,8 +1394,8 @@ func getType(service *v1.Service) (string, error) {
 }
 
 func getNetwork(service *v1.Service) (string, error) {
-	network, ok := service.Annotations[annDONetwork]
-	if !ok || network == "" {
+	network := service.Annotations[annDONetwork]
+	if network == "" {
 		return godo.LoadBalancerNetworkTypeExternal, nil
 	}
 	if !(network == godo.LoadBalancerNetworkTypeExternal || network == godo.LoadBalancerNetworkTypeInternal) {

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -3680,6 +3680,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -3757,6 +3758,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -3846,6 +3848,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -3979,6 +3982,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4056,6 +4060,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4134,6 +4139,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4212,6 +4218,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4350,6 +4357,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					CookieTtlSeconds: 300,
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4432,6 +4440,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					CookieTtlSeconds: 300,
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4524,6 +4533,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(false),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -4617,6 +4627,7 @@ func Test_buildLoadBalancerRequest(t *testing.T) {
 					Type: "none",
 				},
 				DisableLetsEncryptDNSRecords: godo.PtrTo(true),
+				Network:                      godo.LoadBalancerNetworkTypeExternal,
 			},
 			nil,
 		},
@@ -6222,13 +6233,13 @@ func Test_getNetwork(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			lbType, err := getType(test.service)
+			lbType, err := getNetwork(test.service)
 			if test.wantErr != (err != nil) {
 				t.Errorf("got error %q, want error: %t", err, test.wantErr)
 			}
 
 			if test.expected != nil && lbType != *test.expected {
-				t.Fatalf("got http idle timeout seconds %v, want %v", lbType, test.expected)
+				t.Fatalf("got lb network %v, want %v", lbType, *test.expected)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.2
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/digitalocean/godo v1.116.0
+	github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/digitalocean/godo v1.116.0 h1:SuF/Imd1/dE/nYrUFVkJ2itesQNnJQE1a/vmtHknxeE=
 github.com/digitalocean/godo v1.116.0/go.mod h1:Vk0vpCot2HOAJwc5WE8wljZGtJ3ZtWIc8MQ8rF38sdo=
+github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a h1:4px/JtHLirGz3uNMO2dZ2Nuk/XFFpjU7aJ3TI0z/W/Q=
+github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a/go.mod h1:Vk0vpCot2HOAJwc5WE8wljZGtJ3ZtWIc8MQ8rF38sdo=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.12.0 h1:y2DdzBAURM29NFF94q6RaY4vjIH1rtwDapwQtU84iWk=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/digitalocean/godo v1.116.0 h1:SuF/Imd1/dE/nYrUFVkJ2itesQNnJQE1a/vmtHknxeE=
-github.com/digitalocean/godo v1.116.0/go.mod h1:Vk0vpCot2HOAJwc5WE8wljZGtJ3ZtWIc8MQ8rF38sdo=
 github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a h1:4px/JtHLirGz3uNMO2dZ2Nuk/XFFpjU7aJ3TI0z/W/Q=
 github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a/go.mod h1:Vk0vpCot2HOAJwc5WE8wljZGtJ3ZtWIc8MQ8rF38sdo=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/vendor/github.com/digitalocean/godo/apps.gen.go
+++ b/vendor/github.com/digitalocean/godo/apps.gen.go
@@ -221,6 +221,7 @@ const (
 	AppDatabaseSpecEngine_PG      AppDatabaseSpecEngine = "PG"
 	AppDatabaseSpecEngine_Redis   AppDatabaseSpecEngine = "REDIS"
 	AppDatabaseSpecEngine_MongoDB AppDatabaseSpecEngine = "MONGODB"
+	AppDatabaseSpecEngine_Kafka   AppDatabaseSpecEngine = "KAFKA"
 )
 
 // AppDedicatedIp Represents a dedicated egress ip.
@@ -415,6 +416,7 @@ type AppLogDestinationSpec struct {
 	Papertrail  *AppLogDestinationSpecPapertrail `json:"papertrail,omitempty"`
 	Datadog     *AppLogDestinationSpecDataDog    `json:"datadog,omitempty"`
 	Logtail     *AppLogDestinationSpecLogtail    `json:"logtail,omitempty"`
+	OpenSearch  *AppLogDestinationSpecOpenSearch `json:"open_search,omitempty"`
 	Endpoint    string                           `json:"endpoint,omitempty"`
 	TLSInsecure bool                             `json:"tls_insecure,omitempty"`
 	Headers     []*AppLogDestinationSpecHeader   `json:"headers,omitempty"`
@@ -440,6 +442,15 @@ type AppLogDestinationSpecHeader struct {
 type AppLogDestinationSpecLogtail struct {
 	// Logtail token.
 	Token string `json:"token"`
+}
+
+// AppLogDestinationSpecOpenSearch OpenSearch configuration.
+type AppLogDestinationSpecOpenSearch struct {
+	// OpenSearch API Endpoint. Only HTTPS is supported. Format: https://<host>:<port>.
+	Endpoint  string               `json:"endpoint"`
+	BasicAuth *OpenSearchBasicAuth `json:"basic_auth,omitempty"`
+	// The index name to use for the logs. If not set, the default index name is \"logs\".
+	IndexName string `json:"index_name,omitempty"`
 }
 
 // AppLogDestinationSpecPapertrail Papertrail configuration.
@@ -1169,6 +1180,14 @@ const (
 type ListBuildpacksResponse struct {
 	// List of the available buildpacks on App Platform.
 	Buildpacks []*Buildpack `json:"buildpacks,omitempty"`
+}
+
+// OpenSearchBasicAuth Configure Username and/or Password for Basic authentication.
+type OpenSearchBasicAuth struct {
+	// Username to authenticate with.
+	User string `json:"user"`
+	// Password for user defined in User.
+	Password string `json:"password"`
 }
 
 // AppProposeRequest struct for AppProposeRequest

--- a/vendor/github.com/digitalocean/godo/apps_accessors.go
+++ b/vendor/github.com/digitalocean/godo/apps_accessors.go
@@ -1317,6 +1317,14 @@ func (a *AppLogDestinationSpec) GetName() string {
 	return a.Name
 }
 
+// GetOpenSearch returns the OpenSearch field.
+func (a *AppLogDestinationSpec) GetOpenSearch() *AppLogDestinationSpecOpenSearch {
+	if a == nil {
+		return nil
+	}
+	return a.OpenSearch
+}
+
 // GetPapertrail returns the Papertrail field.
 func (a *AppLogDestinationSpec) GetPapertrail() *AppLogDestinationSpecPapertrail {
 	if a == nil {
@@ -1371,6 +1379,30 @@ func (a *AppLogDestinationSpecLogtail) GetToken() string {
 		return ""
 	}
 	return a.Token
+}
+
+// GetBasicAuth returns the BasicAuth field.
+func (a *AppLogDestinationSpecOpenSearch) GetBasicAuth() *OpenSearchBasicAuth {
+	if a == nil {
+		return nil
+	}
+	return a.BasicAuth
+}
+
+// GetEndpoint returns the Endpoint field.
+func (a *AppLogDestinationSpecOpenSearch) GetEndpoint() string {
+	if a == nil {
+		return ""
+	}
+	return a.Endpoint
+}
+
+// GetIndexName returns the IndexName field.
+func (a *AppLogDestinationSpecOpenSearch) GetIndexName() string {
+	if a == nil {
+		return ""
+	}
+	return a.IndexName
 }
 
 // GetEndpoint returns the Endpoint field.
@@ -3531,6 +3563,22 @@ func (l *ListBuildpacksResponse) GetBuildpacks() []*Buildpack {
 		return nil
 	}
 	return l.Buildpacks
+}
+
+// GetPassword returns the Password field.
+func (o *OpenSearchBasicAuth) GetPassword() string {
+	if o == nil {
+		return ""
+	}
+	return o.Password
+}
+
+// GetUser returns the User field.
+func (o *OpenSearchBasicAuth) GetUser() string {
+	if o == nil {
+		return ""
+	}
+	return o.User
 }
 
 // GetAppID returns the AppID field.

--- a/vendor/github.com/digitalocean/godo/load_balancers.go
+++ b/vendor/github.com/digitalocean/godo/load_balancers.go
@@ -13,11 +13,15 @@ const (
 	loadBalancersBasePath = "/v2/load_balancers"
 )
 
-// Load Balancer types.
 const (
+	// Load Balancer types
 	LoadBalancerTypeGlobal          = "GLOBAL"
 	LoadBalancerTypeRegional        = "REGIONAL"
 	LoadBalancerTypeRegionalNetwork = "REGIONAL_NETWORK"
+
+	// Load Balancer network types
+	LoadBalancerNetworkTypeExternal = "EXTERNAL"
+	LoadBalancerNetworkTypeInternal = "INTERNAL"
 )
 
 // LoadBalancersService is an interface for managing load balancers with the DigitalOcean API.
@@ -68,6 +72,7 @@ type LoadBalancer struct {
 	Domains                      []*LBDomain      `json:"domains,omitempty"`
 	GLBSettings                  *GLBSettings     `json:"glb_settings,omitempty"`
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
+	Network                      string           `json:"network,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancer.
@@ -101,6 +106,7 @@ func (l LoadBalancer) AsRequest() *LoadBalancerRequest {
 		ProjectID:                    l.ProjectID,
 		HTTPIdleTimeoutSeconds:       l.HTTPIdleTimeoutSeconds,
 		TargetLoadBalancerIDs:        append([]string(nil), l.TargetLoadBalancerIDs...),
+		Network:                      l.Network,
 	}
 
 	if l.DisableLetsEncryptDNSRecords != nil {
@@ -238,6 +244,7 @@ type LoadBalancerRequest struct {
 	Domains                      []*LBDomain      `json:"domains,omitempty"`
 	GLBSettings                  *GLBSettings     `json:"glb_settings,omitempty"`
 	TargetLoadBalancerIDs        []string         `json:"target_load_balancer_ids,omitempty"`
+	Network                      string           `json:"network,omitempty"`
 }
 
 // String creates a human-readable description of a LoadBalancerRequest.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,7 +33,7 @@ github.com/coreos/go-systemd/v22/journal
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/digitalocean/godo v1.116.0
+# github.com/digitalocean/godo v1.116.1-0.20240604202737-333fbb54616a
 ## explicit; go 1.20
 github.com/digitalocean/godo
 github.com/digitalocean/godo/metrics


### PR DESCRIPTION
- Currently closed alpha and will document annotations when we open it up to beta
- When network=INTERNAL, the IP of the load balancer will be from the underlying VPC. This IP will only be accessible from within the VPC.