### PR TITLE
Disable automatic health check configuration on Proxy Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+* Disable automatic health check configuration when Proxy Protocol is enabled. This is required because the default health check endpoints do not expect a Proxy Protocol header.
+
 ## v0.1.53 (beta) - June  7, 2024
 
 * Adding support for internal load balancers (NOTE: this is a closed beta feature, contact DigitalOcean 

--- a/docs/controllers/services/annotations.md
+++ b/docs/controllers/services/annotations.md
@@ -27,17 +27,23 @@ If `https`, `http2`, or `http3` is specified, then either `service.beta.kubernet
 
 **Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check port. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set explicitly.
 
+An exception to the above is when Proxy Protocol is also enabled via the `service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol` annotation: in that case, a custom health check port _must_ be specified. (This limitation will be dropped in the future.)
+
 The service port used to check if a backend droplet is healthy. Defaults to the first port in a service. A NodePort must not be defined.
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-path
 
 **Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check path. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set additionally.
 
+An exception to the above is when Proxy Protocol is also enabled via the `service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol` annotation: in that case, a custom health check path _must_ be specified. (This limitation will be dropped in the future.)
+
 The path used to check if a backend droplet is healthy. Defaults to "/".
 
 ## service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol
 
 **Note:** digitalocean-cloud-controller-manager automatically chooses a proper health check protocol. In general, the parameter does not need to be specified. For a specified value to become effective, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set additionally.
+
+An exception to the above is when Proxy Protocol is also enabled via the `service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol` annotation: in that case, a custom health check protocol _must_ be specified. (This limitation will be dropped in the future.)
 
 The health check protocol to use to check if a backend droplet is healthy. Defaults to `tcp` if not specified. Options are `tcp`, `http`, and `https`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -119,6 +119,8 @@ See also [this blog post](https://kubernetes.io/blog/2022/12/30/advancements-in-
 
 In general, health check parameters for port, path, and protocol should not have to be set explicitly. For rare cases where it may be required, the annotation `service.beta.kubernetes.io/do-loadbalancer-override-health-check` must be set in addition to the corresponding health check parameter annotations. See the annotation documentation for details.
 
+**IMPORTANT:** the LB health check configuration is not automatically set when Proxy Protocol is enabled. In that case, all relevant health check parameters must be specified due to incompatibility between Proxy Protocol and the default health check endpoints.  
+
 ## Deployment
 
 ### Token


### PR DESCRIPTION
The default health check endpoints do not expect a Proxy Protocol header.