### PR TITLE
Add a firewall rule to open the LB health check and service port(s) when using `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+* When using `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK` (under closed beta) a firewall rule
+  is now added to permit the LB layer to health check the appropriate port.
+
 ## v0.1.54 (beta) - June 12, 2024
 
 * Fixes an issue with load balancer health checks when the LB is using PROXY protocol. The new health check 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## unreleased
 
-* When using `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK` (under closed beta) a firewall rule
-  is now added to permit the LB layer to health check the appropriate port.
+* When using the LoadBalancer `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK` (under closed beta), firewall rules
+are added to open up the underlying health check port and all the defined (port, protocols) defined on the service. This is to
+permit traffic to arrive directly on the underlying worker nodes.
 
 ## v0.1.54 (beta) - June 12, 2024
 

--- a/cloud-controller-manager/do/firewall_controller.go
+++ b/cloud-controller-manager/do/firewall_controller.go
@@ -316,11 +316,11 @@ func (fm *firewallManager) createReconciledFirewallRequest(serviceList []*v1.Ser
 		} else if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 			lbType, err := getType(svc)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to get load balancer type for service %s/%s: %v", svc.Namespace, svc.Name, err)
 			}
 			lbNetwork, err := getNetwork(svc)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to get load balancer network for service %s/%s: %v", svc.Namespace, svc.Name, err)
 			}
 			if lbType == godo.LoadBalancerTypeRegionalNetwork && lbNetwork == godo.LoadBalancerNetworkTypeExternal {
 				_, port := healthCheckPathAndPort(svc)

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -296,6 +297,7 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 		firewallRequest    *godo.FirewallRequest
 		firewallController FirewallController
 		serviceList        []*v1.Service
+		expectedError      error
 	}{
 		{
 			name: "nothing to reconcile when there are no changes",
@@ -525,6 +527,71 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "reconcile firewall with REGIONAL_NETWORK LB w/ externalTrafficPolicy=Cluster",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(kubeProxyHealthPort),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "regional_network",
+						UID:  "abc123",
+						Annotations: map[string]string{
+							annDOType: godo.LoadBalancerTypeRegionalNetwork,
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
+					},
+				},
+			},
+		},
+		{
+			name: "reconcile firewall with REGIONAL_NETWORK LB w/ externalTrafficPolicy=Local",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(15000),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "regional_network",
+						UID:  "abc123",
+						Annotations: map[string]string{
+							annDOType: godo.LoadBalancerTypeRegionalNetwork,
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+						HealthCheckNodePort:   15000,
+					},
+				},
+			},
+		},
+		{
 			name: "reconcile firewall with management flag",
 			firewallRequest: &godo.FirewallRequest{
 				Name: testWorkerFWName,
@@ -638,7 +705,11 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 				workerFirewallTags: testWorkerFWTags,
 				workerFirewallName: testWorkerFWName,
 			}
-			fwReq := fm.createReconciledFirewallRequest(test.serviceList)
+			fwReq, err := fm.createReconciledFirewallRequest(test.serviceList)
+
+			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
+				t.Errorf("incorrect firewall config\nwant: %#v\n got: %#v", test.expectedError, err)
+			}
 			if diff := cmp.Diff(test.firewallRequest, fwReq); diff != "" {
 				t.Errorf("createReconciledFirewallRequest() mismatch (-want +got):\n%s", diff)
 			}
@@ -675,15 +746,18 @@ func TestFirewallController_ensureReconciledFirewall(t *testing.T) {
 		}
 	}
 
-	serviceToFirewall := func(fm *firewallManager, svc *v1.Service) *godo.Firewall {
-		fr := fm.createReconciledFirewallRequest([]*v1.Service{svc})
+	serviceToFirewall := func(fm *firewallManager, svc *v1.Service) (*godo.Firewall, error) {
+		fr, err := fm.createReconciledFirewallRequest([]*v1.Service{svc})
+		if err != nil {
+			return nil, err
+		}
 		return &godo.Firewall{
 			ID:            "id",
 			Name:          fr.Name,
 			InboundRules:  fr.InboundRules,
 			OutboundRules: fr.OutboundRules,
 			Tags:          fr.Tags,
-		}
+		}, nil
 	}
 
 	tests := []struct {
@@ -757,7 +831,10 @@ func TestFirewallController_ensureReconciledFirewall(t *testing.T) {
 
 			// Populate the firewall cache.
 			if test.nodePortForCachedFirewall != nil {
-				fw := serviceToFirewall(fwManager, nodePortToService(*test.nodePortForCachedFirewall))
+				fw, err := serviceToFirewall(fwManager, nodePortToService(*test.nodePortForCachedFirewall))
+				if err != nil {
+					t.Fatal(err)
+				}
 				fwManager.fwCache.updateCache(fw)
 			}
 

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -427,28 +427,14 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 				InboundRules: []godo.InboundRule{
 					{
 						Protocol:  "tcp",
-						PortRange: "31000",
-						Sources: &godo.Sources{
-							Addresses: []string{"0.0.0.0/0", "::/0"},
-						},
-					},
-					{
-						Protocol:  "udp",
-						PortRange: "31000",
+						PortRange: "30000",
 						Sources: &godo.Sources{
 							Addresses: []string{"0.0.0.0/0", "::/0"},
 						},
 					},
 					{
 						Protocol:  "tcp",
-						PortRange: "30000",
-						Sources: &godo.Sources{
-							Addresses: []string{"0.0.0.0/0", "::/0"},
-						},
-					},
-					{
-						Protocol:  "udp",
-						PortRange: "30000",
+						PortRange: "31000",
 						Sources: &godo.Sources{
 							Addresses: []string{"0.0.0.0/0", "::/0"},
 						},
@@ -456,6 +442,20 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 					{
 						Protocol:  "tcp",
 						PortRange: "32727",
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "30000",
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "udp",
+						PortRange: "31000",
 						Sources: &godo.Sources{
 							Addresses: []string{"0.0.0.0/0", "::/0"},
 						},
@@ -538,6 +538,20 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 							Addresses: []string{"0.0.0.0/0", "::/0"},
 						},
 					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(443),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(80),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
 				},
 				OutboundRules: testOutboundRules,
 				Tags:          testWorkerFWTags,
@@ -554,6 +568,16 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 					Spec: v1.ServiceSpec{
 						Type:                  v1.ServiceTypeLoadBalancer,
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyCluster,
+						Ports: []v1.ServicePort{
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     80,
+							},
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     443,
+							},
+						},
 					},
 				},
 			},
@@ -566,6 +590,20 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 					{
 						Protocol:  "tcp",
 						PortRange: strconv.Itoa(15000),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(443),
+						Sources: &godo.Sources{
+							Addresses: []string{"0.0.0.0/0", "::/0"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(80),
 						Sources: &godo.Sources{
 							Addresses: []string{"0.0.0.0/0", "::/0"},
 						},
@@ -587,6 +625,16 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 						Type:                  v1.ServiceTypeLoadBalancer,
 						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
 						HealthCheckNodePort:   15000,
+						Ports: []v1.ServicePort{
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     80,
+							},
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     443,
+							},
+						},
 					},
 				},
 			},

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -708,7 +708,7 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 			fwReq, err := fm.createReconciledFirewallRequest(test.serviceList)
 
 			if (err != nil && test.expectedError == nil) || (err == nil && test.expectedError != nil) {
-				t.Errorf("incorrect firewall config\nwant: %#v\n got: %#v", test.expectedError, err)
+				t.Fatalf("expected error %q, got %q", test.expectedError, err)
 			}
 			if diff := cmp.Diff(test.firewallRequest, fwReq); diff != "" {
 				t.Errorf("createReconciledFirewallRequest() mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Since NLB will route traffic over the public interface for both the LB data plane and health checks, we will need to open the appropriate health check port. This change only affects LBs who set the annotation `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK` and the network is `EXTERNAL` (default).