### PR TITLE
Support explicit target protocol annotation for load balancers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## unreleased
 
+* When using the LoadBalancer `service.beta.kubernetes.io/do-loadbalancer-target-protocol` annotation with any of `http`, 
+  `https`, `http2` or `http3` specification, the forwarding target protocol is overridden from the implicit default `http`
+  protocol.
+
 ## v0.1.55 (beta) - July 29, 2024
 
 * When using the LoadBalancer `service.beta.kubernetes.io/do-loadbalancer-type=REGIONAL_NETWORK` (under closed beta), firewall rules
-are added to open up the underlying health check port and all the defined (port, protocols) defined on the service. This is to
-permit traffic to arrive directly on the underlying worker nodes.
+  are added to open up the underlying health check port and all the defined (port, protocols) defined on the service. This is to
+  permit traffic to arrive directly on the underlying worker nodes.
 
 ## v0.1.54 (beta) - June 12, 2024
 

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -32,6 +32,11 @@ const (
 	// is overwritten to https. Options are tcp, http and https. Defaults to tcp.
 	annDOProtocol = annDOLoadBalancerBase + "protocol"
 
+	// annDOTargetProtocol is the annotation used to specify the target protocol
+	// for DO load balancers. If unspecified, load balancers are configured with
+	// annDOProtocol specification. Options are http, https, http2 and  http3.
+	annDOTargetProtocol = annDOLoadBalancerBase + "target-protocol"
+
 	// annDOHealthCheckPath is the annotation used to specify the health check path
 	// for DO load balancers. Defaults to '/'.
 	annDOHealthCheckPath = annDOLoadBalancerBase + "healthcheck-path"

--- a/cloud-controller-manager/do/lb_annotations.go
+++ b/cloud-controller-manager/do/lb_annotations.go
@@ -34,7 +34,7 @@ const (
 
 	// annDOTargetProtocol is the annotation used to specify the target protocol
 	// for DO load balancers. If unspecified, load balancers are configured with
-	// annDOProtocol specification. Options are http, https, http2 and  http3.
+	// annDOProtocol specification. Options are http, https, http2, and  http3.
 	annDOTargetProtocol = annDOLoadBalancerBase + "target-protocol"
 
 	// annDOHealthCheckPath is the annotation used to specify the health check path

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -915,7 +915,7 @@ func Test_getProtocol(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			protocol, err := getProtocol(test.service, annDOProtocol)
+			protocol, err := getEntryProtocol(test.service)
 			if protocol != test.protocol {
 				t.Error("unexpected protocol")
 				t.Logf("expected: %q", test.protocol)
@@ -2185,7 +2185,7 @@ func Test_buildForwardingRules(t *testing.T) {
 				},
 			},
 			nil,
-			errors.New("failed to build TLS part(s) of forwarding rule: invalid protocol \"abcd\" specified in annotation \"service.beta.kubernetes.io/do-loadbalancer-protocol\""),
+			errors.New("failed to build TLS part(s) of forwarding rule: invalid protocol \"abcd\" specified in annotation \"service.beta.kubernetes.io/do-loadbalancer-target-protocol\""),
 		},
 		{
 			"unsupported target protocol annotation value returns error",
@@ -2211,7 +2211,7 @@ func Test_buildForwardingRules(t *testing.T) {
 				},
 			},
 			nil,
-			errors.New("failed to build TLS part(s) of forwarding rule: target protocol annotation is not supported for TCP or UDP"),
+			errors.New("failed to build TLS part(s) of forwarding rule: invalid protocol \"tcp\" specified in annotation \"service.beta.kubernetes.io/do-loadbalancer-target-protocol\""),
 		},
 		{
 			"support same SSL terminated forwarding protocols (http2 -> http2)",


### PR DESCRIPTION
- introduce `service.beta.kubernetes.io/do-loadbalancer-target-protocol` annotation that provides explicit specifier for forwarding rules target protocols, if set correctly overrides the implicit default of `http` target protocol
- default behavior in absence of this new annotation is unchanged

Fixes #367 #378