### PR TITLE
reduce the number of LBs per page when listing all LBs

### DIFF
--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -26,7 +26,7 @@ import (
 )
 
 // apiResultsPerPage is the maximum page size that DigitalOcean's api supports.
-const apiResultsPerPage = 200
+const apiResultsPerPage = 50
 
 func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
 	list := []godo.Droplet{}


### PR DESCRIPTION
while 200 LB per page is supported, it doesn't work in cases with many-node clusters, since every LB also includes the backing droplets, and if there are, say 100 droplets, that's already 200 * 100 = 20000 droplets in the response

Context: https://digitalocean.slack.com/archives/C024HPA08/p1736551003363399