### PR TITLE
CON-11819 spread sync of load balancers

### DIFF
--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -95,7 +95,6 @@ func (s *tickerSyncer) Sync(name string, period time.Duration, stopCh <-chan str
 		case <-stopCh:
 			return
 		}
-		ticker.Reset(period + (time.Second * time.Duration(rand.Int31n(300))))
 	}
 }
 
@@ -128,7 +127,9 @@ func (r *ResourcesController) Run(stopCh <-chan struct{}) {
 		klog.Info("No cluster ID configured -- skipping cluster dependent syncers.")
 		return
 	}
-	go r.syncer.Sync("tags syncer", controllerSyncTagsPeriod, stopCh, r.syncTags)
+	syncPeriod := controllerSyncTagsPeriod + (time.Second * time.Duration(rand.Int31n(300)))
+	klog.Infof("sync tags period: %s", syncPeriod)
+	go r.syncer.Sync("tags syncer", syncPeriod, stopCh, r.syncTags)
 }
 
 // syncTags synchronizes tags. Currently, this is only needed to associate

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -19,6 +19,7 @@ package do
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"time"
 
@@ -94,6 +95,7 @@ func (s *tickerSyncer) Sync(name string, period time.Duration, stopCh <-chan str
 		case <-stopCh:
 			return
 		}
+		ticker.Reset(period + (time.Second * time.Duration(rand.Int31n(300))))
 	}
 }
 

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -135,7 +135,7 @@ func (r *ResourcesController) Run(stopCh <-chan struct{}) {
 		klog.Info("No cluster ID configured -- skipping cluster dependent syncers.")
 		return
 	}
-	go r.syncer.Sync("tags syncer", controllerSyncTagsPeriod, time.Second*time.Duration(rand.Int31n(300)), stopCh, r.syncTags)
+	go r.syncer.Sync("tags syncer", controllerSyncTagsPeriod, time.Second*time.Duration(rand.Int31n(600)), stopCh, r.syncTags)
 }
 
 // syncTags synchronizes tags. Currently, this is only needed to associate

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -86,10 +86,8 @@ func (s *tickerSyncer) Sync(name string, period time.Duration, initialDelay time
 		klog.Errorf("%s failed: %s", name, err)
 	}
 
-	initialDelayTicker := time.NewTicker(initialDelay)
-	defer initialDelayTicker.Stop()
 	select {
-	case <-initialDelayTicker.C:
+	case <-time.After(initialDelay):
 	case <-stopCh:
 		return
 	}

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -33,9 +33,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	controllerSyncTagsPeriod = (15 * time.Minute) + (time.Second * time.Duration(rand.Int31n(300)))
+)
+
 const (
-	controllerSyncTagsPeriod = 15 * time.Minute
-	syncTagsTimeout          = 1 * time.Minute
+	syncTagsTimeout = 1 * time.Minute
 )
 
 type tagMissingError struct {
@@ -127,9 +130,8 @@ func (r *ResourcesController) Run(stopCh <-chan struct{}) {
 		klog.Info("No cluster ID configured -- skipping cluster dependent syncers.")
 		return
 	}
-	syncPeriod := controllerSyncTagsPeriod + (time.Second * time.Duration(rand.Int31n(300)))
-	klog.Infof("sync tags period: %s", syncPeriod)
-	go r.syncer.Sync("tags syncer", syncPeriod, stopCh, r.syncTags)
+	klog.Infof("sync tags period: %s", controllerSyncTagsPeriod)
+	go r.syncer.Sync("tags syncer", controllerSyncTagsPeriod, stopCh, r.syncTags)
 }
 
 // syncTags synchronizes tags. Currently, this is only needed to associate

--- a/cloud-controller-manager/do/resources_test.go
+++ b/cloud-controller-manager/do/resources_test.go
@@ -125,7 +125,7 @@ func newRecordingSyncer(stopOn int, stopCh chan struct{}) *recordingSyncer {
 	}
 }
 
-func (s *recordingSyncer) Sync(name string, period time.Duration, stopCh <-chan struct{}, fn func() error) {
+func (s *recordingSyncer) Sync(name string, period time.Duration, initialDelay time.Duration, stopCh <-chan struct{}, fn func() error) {
 	recordingFn := func() error {
 		s.mutex.Lock()
 		defer s.mutex.Unlock()
@@ -139,7 +139,7 @@ func (s *recordingSyncer) Sync(name string, period time.Duration, stopCh <-chan 
 		return fn()
 	}
 
-	s.tickerSyncer.Sync(name, period, stopCh, recordingFn)
+	s.tickerSyncer.Sync(name, period, initialDelay, stopCh, recordingFn)
 }
 
 var (


### PR DESCRIPTION
Spread the sync period of the loadbalancer unevenly to prevent a spike of loadbalancer API calls at the same time. We saw an issue when multiple clusters see their maintenance window happening at the same time and the CCM component is restarted at the same time. The sync tag period will match closely for all those CCM pods and all of those clusters will make a LIST api calls relatively close to each other resulting in spikes each 15minutes. This PR attempts to mitigate this issue by adding some randomness to the sync period (5minutes) as an initial delay. Thus, the new sync period will remain 15 minutes but the subsequent sync tag will be off between 0 to 300 seconds.   