### PR TITLE
CON-12382 backfill lb type annotation in k8s LB service object

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -226,6 +226,7 @@ func (l *loadBalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 		logLBInfo("CREATE", lbRequest, 2)
 
 		updateServiceAnnotation(service, annDOLoadBalancerID, lb.ID)
+		updateServiceAnnotation(service, annDOType, lb.Type)
 
 	default:
 		// unrecoverable LB retrieval error
@@ -428,6 +429,7 @@ func (l *loadBalancers) retrieveAndAnnotateLoadBalancer(ctx context.Context, ser
 	}
 
 	updateServiceAnnotation(service, annDOLoadBalancerID, lb.ID)
+	updateServiceAnnotation(service, annDOType, lb.Type)
 
 	return lb, nil
 }

--- a/cloud-controller-manager/do/loadbalancers_test.go
+++ b/cloud-controller-manager/do/loadbalancers_test.go
@@ -130,6 +130,7 @@ func newFakeLBClient(fakeLB *fakeLBService) *godo.Client {
 func createLB() *godo.LoadBalancer {
 	return &godo.LoadBalancer{
 		ID:     "load-balancer-id",
+		Type:   godo.LoadBalancerTypeRegional,
 		Name:   "afoobar123",
 		IP:     "10.0.0.1",
 		IPv6:   "fd53::b001",
@@ -5258,17 +5259,18 @@ func Test_GetLoadBalancer(t *testing.T) {
 
 func Test_EnsureLoadBalancer(t *testing.T) {
 	testcases := []struct {
-		name              string
-		droplets          []godo.Droplet
-		getFn             func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error)
-		listFn            func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
-		createFn          func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
-		updateFn          func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
-		service           *v1.Service
-		newLoadBalancerID *string
-		nodes             []*v1.Node
-		lbStatus          *v1.LoadBalancerStatus
-		err               error
+		name                string
+		droplets            []godo.Droplet
+		getFn               func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error)
+		listFn              func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
+		createFn            func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
+		updateFn            func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
+		service             *v1.Service
+		newLoadBalancerID   *string
+		newLoadBalancerType *string
+		nodes               []*v1.Node
+		lbStatus            *v1.LoadBalancerStatus
+		err                 error
 	}{
 		{
 			name: "successfully ensured loadbalancer by name, already exists",
@@ -5580,6 +5582,88 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "successfully ensured loadbalancer by Type that didn't exist",
+			droplets: []godo.Droplet{
+				{
+					ID:   100,
+					Name: "node-1",
+				},
+				{
+					ID:   101,
+					Name: "node-2",
+				},
+				{
+					ID:   102,
+					Name: "node-3",
+				},
+			},
+			getFn: func(context.Context, string) (*godo.LoadBalancer, *godo.Response, error) {
+				return nil, newFakeResponse(http.StatusNotFound), errors.New("LB not found")
+			},
+			listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("list should not have been invoked")
+			},
+			createFn: func(context.Context, *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
+				lb := createLB()
+				lb.ID = "load-balancer-id"
+				lb.Type = godo.LoadBalancerTypeRegionalNetwork
+				return lb, newFakeOKResponse(), nil
+			},
+			updateFn: func(ctx context.Context, lbID string, lbr *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
+				return nil, newFakeNotOKResponse(), errors.New("update should not have been invoked")
+			},
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					UID:  "foobar123",
+					Annotations: map[string]string{
+						annDOProtocol:       "http",
+						annDOLoadBalancerID: "load-balancer-id",
+						annDOType:           godo.LoadBalancerTypeRegional,
+					},
+				},
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:     "test",
+							Protocol: "TCP",
+							Port:     int32(80),
+							NodePort: int32(30000),
+						},
+					},
+				},
+			},
+			newLoadBalancerType: stringP(godo.LoadBalancerTypeRegionalNetwork),
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-2",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-3",
+					},
+				},
+			},
+			lbStatus: &v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{
+					{
+						IP: "10.0.0.1",
+					},
+					{
+						IP: "fd53::b001",
+					},
+				},
+			},
+			err: nil,
+		},
+		{
 			name:     "failed to ensure existing load-balancer, state is non-active",
 			droplets: []godo.Droplet{},
 			listFn: func(context.Context, *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
@@ -5669,7 +5753,8 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					},
 				},
 			},
-			newLoadBalancerID: stringP(""),
+			newLoadBalancerID:   stringP(""),
+			newLoadBalancerType: stringP(""),
 			lbStatus: &v1.LoadBalancerStatus{
 				Ingress: []v1.LoadBalancerIngress{
 					{
@@ -5733,13 +5818,20 @@ func Test_EnsureLoadBalancer(t *testing.T) {
 					t.Fatalf("failed to get service from kube client: %s", err)
 				}
 
-				gotLoadBalancerID := svc.Annotations[annDOLoadBalancerID]
-				wantLoadBalancerID := "load-balancer-id"
+				gotLoadBalancerID, gotLoadBalancerType := svc.Annotations[annDOLoadBalancerID], svc.Annotations[annDOType]
+				wantLoadBalancerID, wantLoadBalancerType := "load-balancer-id", godo.LoadBalancerTypeRegional
 				if test.newLoadBalancerID != nil {
 					wantLoadBalancerID = *test.newLoadBalancerID
 				}
 				if gotLoadBalancerID != wantLoadBalancerID {
 					t.Errorf("got load-balancer ID %q, want %q", gotLoadBalancerID, wantLoadBalancerID)
+				}
+
+				if test.newLoadBalancerType != nil {
+					wantLoadBalancerType = *test.newLoadBalancerType
+				}
+				if gotLoadBalancerType != wantLoadBalancerType {
+					t.Errorf("got load-balancer Type %q, want %q", gotLoadBalancerType, wantLoadBalancerType)
 				}
 			}
 		})


### PR DESCRIPTION
Backfill the LB type annotation in k8s LB services object. 

Existing and new LBs will always have the two following annotations: 

```yaml
  metadata:
    annotations:
      kubernetes.digitalocean.com/load-balancer-id: <cluster-uuid>
      service.beta.kubernetes.io/do-loadbalancer-type: <type>
``` 