### PR TITLE
CON-12387 Ensure NLB is the default loadbalancer in DO CCM

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -1425,7 +1425,7 @@ func getDisownLB(service *v1.Service) (bool, error) {
 func getType(service *v1.Service) (string, error) {
 	name, ok := service.Annotations[annDOType]
 	if !ok || name == "" {
-		return godo.LoadBalancerTypeRegional, nil
+		return godo.LoadBalancerTypeRegionalNetwork, nil
 	}
 	if !(name == godo.LoadBalancerTypeRegional || name == godo.LoadBalancerTypeRegionalNetwork) {
 		return "", fmt.Errorf("only LB types supported are (%s, %s)", godo.LoadBalancerTypeRegional, godo.LoadBalancerTypeRegionalNetwork)


### PR DESCRIPTION
Change the default LB type to be NLB instead of regional LB. 