### PR TITLE
Fetch providerID from DigitalOcean API as a fallback if not specified on the node object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Add optional `DEFAULT_LB_TYPE` environment variable to configure the default load balancer type between `REGIONAL` and `REGIONAL_NETWORK` (@olove)
 * Restrict the kube-proxy health port to be accessible by the load balancer only instead of allowing all IPv4 and IPv6 addresses (@olove)
+* Fixes an issue with nodes that don't have their providerID set from the kubelet configuration. From now on, 
+  if the node object `node.Spec.ProviderID` property is empty, we will retrieve the information using the DO API by 
+  listing the droplets with that name.
 
 ## v0.1.61 (beta) - May 29, 2025
 * Ensure Network LoadBalancer (NLB) is the default loadbalancer type (@olove)

--- a/cloud-controller-manager/do/common.go
+++ b/cloud-controller-manager/do/common.go
@@ -29,12 +29,13 @@ import (
 // are very large and the response gets too big with 200 objects
 const apiResultsPerPage = 50
 
-func allDropletList(ctx context.Context, client *godo.Client) ([]godo.Droplet, error) {
-	list := []godo.Droplet{}
+func allDropletList(ctx context.Context, listFunc func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)) ([]godo.Droplet, error) {
+	var list []godo.Droplet
 
 	opt := &godo.ListOptions{Page: 1, PerPage: apiResultsPerPage}
 	for {
-		droplets, resp, err := client.Droplets.List(ctx, opt)
+		droplets, resp, err := listFunc(ctx, opt)
+
 		if err != nil {
 			return nil, err
 		}

--- a/cloud-controller-manager/do/common_test.go
+++ b/cloud-controller-manager/do/common_test.go
@@ -122,7 +122,9 @@ func TestAllDropletList(t *testing.T) {
 		},
 	)
 
-	droplets, err := allDropletList(context.Background(), client)
+	droplets, err := allDropletList(context.Background(), func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+		return client.Droplets.List(ctx, opt)
+	})
 	if err != nil {
 		t.Fatalf("unexpected err: %s", err)
 	}

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -148,7 +148,7 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		return nil, fmt.Errorf("getting node addresses of droplet %d for node %s: %s", dropletID, node.Name, err.Error())
 	}
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    node.Spec.ProviderID, // the providerID may or may not be present according to the interface doc. However, we set this from kubelet.
+		ProviderID:    strconv.Itoa(dropletID),
 		InstanceType:  droplet.SizeSlug,
 		Region:        droplet.Region.Slug,
 		NodeAddresses: nodeAddrs,

--- a/cloud-controller-manager/do/droplets.go
+++ b/cloud-controller-manager/do/droplets.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/digitalocean/godo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 )
 
@@ -92,10 +93,47 @@ func (i *instances) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, 
 	return droplet.Status == dropletShutdownStatus, nil
 }
 
-func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
-	dropletID, err := dropletIDFromProviderID(node.Spec.ProviderID)
+// dropletByName returns a *godo.Droplet for the droplet identified by nodeName.
+//
+// When nodeName identifies more than one droplet, only the first will be
+// considered.
+func dropletByName(ctx context.Context, client *godo.Client, nodeName types.NodeName) (*godo.Droplet, error) {
+	droplets, err := allDropletList(ctx, func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+		return client.Droplets.ListByName(ctx, string(nodeName), opt)
+	})
 	if err != nil {
-		return nil, fmt.Errorf("determining droplet ID from providerID: %s", err.Error())
+		return nil, err
+	}
+
+	for _, droplet := range droplets {
+		if droplet.Name == string(nodeName) {
+			return &droplet, nil
+		}
+		addresses, _ := nodeAddresses(&droplet)
+		for _, address := range addresses {
+			if address.Address == string(nodeName) {
+				return &droplet, nil
+			}
+		}
+	}
+
+	return nil, cloudprovider.InstanceNotFound
+}
+
+func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	var dropletID int
+	var err error
+	if node.Spec.ProviderID == "" {
+		droplet, err := dropletByName(ctx, i.resources.gclient, types.NodeName(node.GetName()))
+		if err != nil {
+			return nil, fmt.Errorf("getting droplet by name: %s", err.Error())
+		}
+		dropletID = droplet.ID
+	} else {
+		dropletID, err = dropletIDFromProviderID(node.Spec.ProviderID)
+		if err != nil {
+			return nil, fmt.Errorf("determining droplet ID from providerID: %s", err.Error())
+		}
 	}
 
 	droplet, err := dropletByID(ctx, i.resources.gclient, dropletID)

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -533,7 +533,9 @@ func (l *loadBalancers) nodesToDropletIDs(ctx context.Context, nodes []*v1.Node)
 
 	if len(missingDroplets) > 0 {
 		// Discover missing droplets by matching names.
-		droplets, err := allDropletList(ctx, l.resources.gclient)
+		droplets, err := allDropletList(ctx, func(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+			return l.resources.gclient.Droplets.List(ctx, opt)
+		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list all droplets: %s", err)
 		}


### PR DESCRIPTION
With the upgrade from instance to instancev2 done in this [PR](https://github.com/digitalocean/digitalocean-cloud-controller-manager/pull/776), we assumed that the node is pre propulated with a `node.spec.providerID` that is not empty. This is because in DOKS, we leverage the kubeletconfiguration and specify the droplet id in it which in turns sets it on the node object when it joins the clusters. This is an issue because not all solutions using DO CCM will use this configuration. One example is Rancher and currently if you specify the External cloud provider and install the latest version of CCM from our main repository branch (https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/master/releases/digitalocean-cloud-controller-manager/v0.1.61.yml), the cluster never reconciles completely. If you dig into the logs, you will find this error:

```text
I0616 18:26:53.237250       1 node_controller.go:233] error syncing 'stuff-6-pool1-vcm95-jzlxh': failed to get instance metadata for node stuff-6-pool1-vcm95-jzlxh: determining droplet ID from providerID: provider ID cannot be empty, requeuing
E0616 18:26:53.239168       1 node_controller.go:244] "Unhandled Error" err="error syncing 'stuff-6-pool1-vcm95-jzlxh': failed to get instance metadata for node stuff-6-pool1-vcm95-jzlxh: determining droplet ID from providerID: provider ID cannot be empty, requeuing" logger="UnhandledError"
``` 

Rancher does not set the providerID from the kubeletconfiguration which stalls the CCM indefinitely during the bootstrapping process. Rancher is working fine if you use the DO CCM up until `v0.1.56` and breaks afterward. This is because before we were relying on the DO API to fetch the provider ID but now we only rely on the node spec information. To fix this, this PR introduce a fallback and does the same thing as we did in the past but only if we have an empty providerID on the node object. Also, as an optimization we can now filter by name when fetching the list of droplets. Thus, I've reused the previous function and extended it with a new listFunc so that we can parametrized the way we retrieve the list from DO.  