### PR TITLE
Handle removing Certificate Annotation

### DIFF
--- a/cloud-controller-manager/do/certificates_test.go
+++ b/cloud-controller-manager/do/certificates_test.go
@@ -239,6 +239,24 @@ func Test_LBaaSCertificateScenarios(t *testing.T) {
 			expectedLBCertID:      "lb-cert-id",
 			expectedLBCertName:    "meow1",
 		},
+		{
+			name: "[lets_encrypt] LB cert ID exists, service cert annotation nonexistant",
+			setupFn: func(lbService fakeLBService, certService kvCertService) *v1.Service {
+				lb, cert := createHTTPSLB("test-lb-id", "lb-cert-id", certTypeLetsEncrypt)
+				lbService.store[lb.ID] = lb
+				cert.Name = "meow1"
+				certService.store[cert.ID] = cert
+
+				svcert := createCertWithName("service-cert-id", "meow1", certTypeLetsEncrypt)
+
+				service := createService(lb.ID)
+				certService.store[svcert.ID] = svcert
+				return service
+			},
+			expectedServiceCertID: "",
+			expectedLBCertID:      "",
+			expectedLBCertName:    "",
+		},
 		// custom test cases
 		{
 			name: "[custom] LB cert ID and service cert ID match",

--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -284,7 +284,7 @@ func getCertificateIDFromLB(lb *godo.LoadBalancer) string {
 // annotation on the Service gets newly-updated certificate ID from the
 // Load Balancer.
 func (l *loadBalancers) recordUpdatedLetsEncryptCert(ctx context.Context, service *v1.Service, lbCertID, serviceCertID string) error {
-	if lbCertID != "" && lbCertID != serviceCertID {
+	if lbCertID != "" && serviceCertID != "" && lbCertID != serviceCertID {
 		lbCert, _, err := l.resources.gclient.Certificates.Get(ctx, lbCertID)
 		if err != nil {
 			respErr, ok := err.(*godo.ErrorResponse)


### PR DESCRIPTION
Fixes https://github.com/digitalocean/digitalocean-cloud-controller-manager/issues/844

When a customer removes a certificate ID from their annotations, it crashes. This adds logic in to check if the serviceCertID (derived from the annotation) even has anything populated before running further checks.

Our API erroneously returns a 200 OK when you pass `""` as an argument to `Certificates.Get` which is why this didn't get caught.