### PR TITLE
Replace alpine:3.15 with distroless static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 * Add handling for private IP only droplets (@gottwald)
+* Replace alpine:3.15 with distroless static-debian13 nonroot base image (@thearyanahmed)
 
 ## v0.1.67 (beta) - May  6, 2026
 

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager-admission-server/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager-admission-server/Dockerfile
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.15
+FROM gcr.io/distroless/static-debian12:nonroot
 
-RUN apk add --no-cache ca-certificates
+COPY digitalocean-cloud-controller-manager-admission-server /bin/
 
-ADD digitalocean-cloud-controller-manager-admission-server /bin/
-
-CMD ["/bin/digitalocean-cloud-controller-manager-admission-server"]
+ENTRYPOINT ["/bin/digitalocean-cloud-controller-manager-admission-server"]

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager-admission-server/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager-admission-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 
 COPY digitalocean-cloud-controller-manager-admission-server /bin/
 

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.15
+FROM gcr.io/distroless/static-debian12:nonroot
 
-RUN apk add --no-cache ca-certificates
+COPY digitalocean-cloud-controller-manager /bin/
 
-ADD digitalocean-cloud-controller-manager /bin/
-
-CMD ["/bin/digitalocean-cloud-controller-manager"]
+ENTRYPOINT ["/bin/digitalocean-cloud-controller-manager"]

--- a/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
+++ b/cloud-controller-manager/cmd/digitalocean-cloud-controller-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 
 COPY digitalocean-cloud-controller-manager /bin/
 


### PR DESCRIPTION
This PR Replaces `alpine:3.15` with `gcr.io/distroless/static-debian13:nonroot` for both images.

Also removes package installation (`apk add ca-certificates`) and simplify the image contents to just the compiled binaries.
