### PR TITLE
firewall_controller: honor firewall-managed annotation and loadBalancerSourceRanges for LoadBalancer services

### DIFF
--- a/cloud-controller-manager/do/firewall_controller.go
+++ b/cloud-controller-manager/do/firewall_controller.go
@@ -321,6 +321,14 @@ func (fm *firewallManager) createReconciledFirewallRequest(serviceList []*v1.Ser
 				)
 			}
 		} else if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+			managed, err := isManaged(svc)
+			if err != nil {
+				klog.Warningf("managing service %s/%s for which no correct management flag setting could be detected: %s", svc.Namespace, svc.Name, err)
+				managed = true
+			}
+			if !managed {
+				continue
+			}
 			lbType, err := getType(svc, fm.defaultLBType)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get load balancer type for service %s/%s: %v", svc.Namespace, svc.Name, err)
@@ -350,6 +358,12 @@ func (fm *firewallManager) createReconciledFirewallRequest(serviceList []*v1.Ser
 
 				loadBalancerPorts[pp] = struct{}{}
 				// Add the services (port, protocol)
+				var svcPortSources *godo.Sources
+				if len(svc.Spec.LoadBalancerSourceRanges) > 0 {
+					svcPortSources = &godo.Sources{
+						Addresses: svc.Spec.LoadBalancerSourceRanges,
+					}
+				}
 				var protocol string
 				for _, servicePort := range svc.Spec.Ports {
 					switch servicePort.Protocol {
@@ -361,7 +375,7 @@ func (fm *firewallManager) createReconciledFirewallRequest(serviceList []*v1.Ser
 						klog.Warningf("unsupported service protocol %v, skipping service port %v", servicePort.Protocol, servicePort.Name)
 						continue
 					}
-					loadBalancerPorts[portProtocol{protocol: protocol, port: int(servicePort.Port)}] = struct{}{}
+					loadBalancerPorts[portProtocol{protocol: protocol, port: int(servicePort.Port), sources: svcPortSources}] = struct{}{}
 				}
 			}
 		}

--- a/cloud-controller-manager/do/firewall_controller_test.go
+++ b/cloud-controller-manager/do/firewall_controller_test.go
@@ -749,6 +749,100 @@ func TestFirewallController_createReconciledFirewallRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "skip REGIONAL_NETWORK LB service when firewall-managed annotation is false",
+			firewallRequest: &godo.FirewallRequest{
+				Name:          testWorkerFWName,
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "managementDisabledLB",
+						UID:  "uid-lb-1",
+						Annotations: map[string]string{
+							annDOType:                   godo.LoadBalancerTypeRegionalNetwork,
+							annDOLoadBalancerID:         "lb-uid-1",
+							annotationDOFirewallManaged: "false",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+						HealthCheckNodePort:   15000,
+						Ports: []v1.ServicePort{
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     80,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "use loadBalancerSourceRanges as inbound rule sources for REGIONAL_NETWORK LB",
+			firewallRequest: &godo.FirewallRequest{
+				Name: testWorkerFWName,
+				InboundRules: []godo.InboundRule{
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(15000),
+						Sources: &godo.Sources{
+							LoadBalancerUIDs: []string{"lb-uid-2"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(443),
+						Sources: &godo.Sources{
+							Addresses: []string{"1.2.3.0/24", "5.6.7.8/32"},
+						},
+					},
+					{
+						Protocol:  "tcp",
+						PortRange: strconv.Itoa(80),
+						Sources: &godo.Sources{
+							Addresses: []string{"1.2.3.0/24", "5.6.7.8/32"},
+						},
+					},
+				},
+				OutboundRules: testOutboundRules,
+				Tags:          testWorkerFWTags,
+			},
+			serviceList: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "lbWithSourceRanges",
+						UID:  "uid-lb-2",
+						Annotations: map[string]string{
+							annDOType:           godo.LoadBalancerTypeRegionalNetwork,
+							annDOLoadBalancerID: "lb-uid-2",
+						},
+					},
+					Spec: v1.ServiceSpec{
+						Type:                  v1.ServiceTypeLoadBalancer,
+						ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyLocal,
+						HealthCheckNodePort:   15000,
+						LoadBalancerSourceRanges: []string{
+							"1.2.3.0/24",
+							"5.6.7.8/32",
+						},
+						Ports: []v1.ServicePort{
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     80,
+							},
+							{
+								Protocol: v1.ProtocolTCP,
+								Port:     443,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range testcases {


### PR DESCRIPTION
Fixes #911

## Changes

### 1. Extend `isManaged()` check to LoadBalancer services

The `kubernetes.digitalocean.com/firewall-managed: "false"` annotation was silently ignored for `LoadBalancer` services - `isManaged()` was only called in the `NodePort` branch. This change adds the same check to the `LoadBalancer` branch so the annotation works consistently across both service types.

### 2. Use `spec.loadBalancerSourceRanges` as inbound rule sources

For `REGIONAL_NETWORK` + external `LoadBalancer` services, service port inbound rules were always created with hardcoded `0.0.0.0/0` / `::/0` sources. This change reads `spec.loadBalancerSourceRanges` (already parsed elsewhere for LB-level firewall rules) and uses those CIDRs as the source addresses in the worker firewall inbound rules when set.

Health check port rules are unaffected - they continue to use `LoadBalancerUIDs` as source.

Internal (`network: internal`) LBs are unaffected - they are excluded by the existing `lbNetwork == External` guard and no worker firewall rules are added for them.

## Tests

Two new test cases added to `TestFirewallController_createReconciledFirewallRequest`:
- `skip REGIONAL_NETWORK LB service when firewall-managed annotation is false`
- `use loadBalancerSourceRanges as inbound rule sources for REGIONAL_NETWORK LB`