### PR TITLE
Prevent cross-cluster LB hijack via duplicate do-loadbalancer-name

### DIFF
--- a/cloud-controller-manager/do/loadbalancers.go
+++ b/cloud-controller-manager/do/loadbalancers.go
@@ -457,7 +457,7 @@ func (l *loadBalancers) retrieveLoadBalancer(ctx context.Context, service *v1.Se
 		return nil, err
 	}
 
-	lb := findLoadBalancerByName(service, allLBs)
+	lb := findLoadBalancerByName(service, allLBs, l.resources.clusterID)
 	if lb == nil {
 		return nil, errLBNotFound
 	}
@@ -477,7 +477,7 @@ func (l *loadBalancers) findLoadBalancerByID(ctx context.Context, id string) (*g
 	return lb, nil
 }
 
-func findLoadBalancerByName(service *v1.Service, allLBs []godo.LoadBalancer) *godo.LoadBalancer {
+func findLoadBalancerByName(service *v1.Service, allLBs []godo.LoadBalancer, clusterID string) *godo.LoadBalancer {
 	customName := getLoadBalancerName(service)
 	legacyName := getLoadBalancerLegacyName(service)
 	candidates := []string{customName}
@@ -487,9 +487,18 @@ func findLoadBalancerByName(service *v1.Service, allLBs []godo.LoadBalancer) *go
 
 	klog.V(2).Infof("Looking up load-balancer for service %s/%s by name (candidates: %s)", service.Namespace, service.Name, strings.Join(candidates, ", "))
 
+	var clusterTag string
+	if clusterID != "" {
+		clusterTag = buildK8sTag(clusterID)
+	}
+
 	for _, lb := range allLBs {
 		for _, cand := range candidates {
 			if lb.Name == cand {
+				if clusterTag != "" && !lbHasTag(lb, clusterTag) {
+					klog.Warningf("Skipping load-balancer %q (%s): owned by a different cluster (missing tag %s)", lb.Name, lb.ID, clusterTag)
+					continue
+				}
 				return &lb
 			}
 		}
@@ -498,13 +507,23 @@ func findLoadBalancerByName(service *v1.Service, allLBs []godo.LoadBalancer) *go
 	return nil
 }
 
-func findLoadBalancerID(service *v1.Service, allLBs []godo.LoadBalancer) string {
+// lbHasTag reports whether lb carries the given tag.
+func lbHasTag(lb godo.LoadBalancer, tag string) bool {
+	for _, t := range lb.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+func findLoadBalancerID(service *v1.Service, allLBs []godo.LoadBalancer, clusterID string) string {
 	id := getLoadBalancerID(service)
 	if len(id) > 0 {
 		return id
 	}
 
-	lb := findLoadBalancerByName(service, allLBs)
+	lb := findLoadBalancerByName(service, allLBs, clusterID)
 	if lb == nil {
 		return ""
 	}

--- a/cloud-controller-manager/do/resources.go
+++ b/cloud-controller-manager/do/resources.go
@@ -169,7 +169,7 @@ func (r *ResourcesController) syncTags() error {
 	// a matching name).
 	var res []godo.Resource
 	for _, svc := range lbSvcs {
-		id := findLoadBalancerID(svc, lbs)
+		id := findLoadBalancerID(svc, lbs, r.resources.clusterID)
 
 		// Load-balancers that have no LB ID set yet and were renamed directly
 		// (e.g., via the cloud control panel) would still be missed, so check


### PR DESCRIPTION
## Summary

Fixes #916 | Related #556

When two DOKS clusters use the same `service.beta.kubernetes.io/do-loadbalancer-name` annotation, `findLoadBalancerByName()` matches any LB on the account with that name — regardless of which cluster owns it. The second cluster silently claims and overwrites the first cluster's LB. When the clusters are in different regions, this destroys the original LB and permanently loses its IP.

## Changes

- Add a `clusterID` parameter to `findLoadBalancerByName()` and `findLoadBalancerID()`
- Before returning a name match, verify the LB carries the current cluster's `k8s:<clusterID>` tag
- If the tag is missing, skip the LB and log a warning
- The CCM then falls through to create a new LB, which will fail with a proper name-conflict or quota error from the DO API

## Test plan

- All existing tests pass
- Verified with `go build ./...` and `go test ./cloud-controller-manager/do/...`