### PR TITLE
Add unreleased changelog entries for v0.1.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add subnet UUID and BYOIP support for load balancers (@rbhatia-code)
 * Updates dependencies: (@dependabot)
   - github.com/digitalocean/godo v1.204.0
+  - golang.org/x/sync v0.22.0
 
 ## v0.1.68 (beta) - July  6, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## unreleased
 
-## v0.1.68 (beta) - July  6, 2026
+* Retry LB sync while nodes are still cloud-provider initializing (@pyadagiri-do)
+* Add subnet UUID and BYOIP support for load balancers (@rbhatia-code)
+* Updates dependencies: (@dependabot)
+  - github.com/digitalocean/godo v1.204.0
 
 ## v0.1.68 (beta) - July  6, 2026
 


### PR DESCRIPTION
## Summary
- Fill `## unreleased` with changes since v0.1.68 ahead of the CCM release workflow
- Drop the duplicate `## v0.1.68` heading